### PR TITLE
codegen.go: support seeding pager with initial nextLink

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -413,6 +413,8 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.Paramet
       // this is a synthesized parameter (e.g. ResumeToken)
       if (param.language.go!.isResumeToken) {
         adaptedParam = new go.ResumeTokenParameter();
+      } else if (param.language.go!.isNextLink) {
+        adaptedParam = new go.NextLinkParameter();
       } else {
         const type = adaptPossibleType(param.schema);
         const placement = adaptParameterKind(param);

--- a/packages/autorest.go/src/transform/transform.ts
+++ b/packages/autorest.go/src/transform/transform.ts
@@ -653,6 +653,17 @@ async function processOperationRequests(session: Session<m4.CodeModel>) {
         op.parameters?.push(tokenParam);
         tokenParam.language.go!.paramGroup = op.language.go!.optionalParamGroup;
         (<m4.GroupProperty>op.language.go!.optionalParamGroup).originalParameter.push(tokenParam);
+      } else if (helpers.isPageableOperation(op)) {
+        // add the NextLink to the optional params type
+        const nextLinkParam = newParameter('NextLink', '', newString('string', ''));
+        nextLinkParam.language.go!.byValue = true;
+        nextLinkParam.language.go!.isNextLink = true;
+        nextLinkParam.required = false;
+        op.parameters?.push(nextLinkParam);
+        nextLinkParam.language.go!.paramGroup = op.language.go!.optionalParamGroup;
+        if (<m4.GroupProperty>op.language.go!.optionalParamGroup) { // TODO: why is this sometimes unset?
+          (<m4.GroupProperty>op.language.go!.optionalParamGroup).originalParameter.push(nextLinkParam);
+        }
       }
       // recursively add the marshalling format to the body param if applicable
       const marshallingFormat = getMarshallingFormat(op.requests![0].protocol);

--- a/packages/autorest.go/test/acr/azacr/zz_containerregistry_client.go
+++ b/packages/autorest.go/test/acr/azacr/zz_containerregistry_client.go
@@ -430,8 +430,10 @@ func (client *ContainerRegistryClient) NewGetManifestsPager(name string, options
 		Fetcher: func(ctx context.Context, page *ContainerRegistryClientGetManifestsResponse) (ContainerRegistryClientGetManifestsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ContainerRegistryClient.NewGetManifestsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.Link != nil {
 				nextLink = *page.Link
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getManifestsCreateRequest(ctx, name, options)
@@ -553,8 +555,10 @@ func (client *ContainerRegistryClient) NewGetRepositoriesPager(options *Containe
 		Fetcher: func(ctx context.Context, page *ContainerRegistryClientGetRepositoriesResponse) (ContainerRegistryClientGetRepositoriesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ContainerRegistryClient.NewGetRepositoriesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.Link != nil {
 				nextLink = *page.Link
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getRepositoriesCreateRequest(ctx, options)
@@ -675,8 +679,10 @@ func (client *ContainerRegistryClient) NewGetTagsPager(name string, options *Con
 		Fetcher: func(ctx context.Context, page *ContainerRegistryClientGetTagsResponse) (ContainerRegistryClientGetTagsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ContainerRegistryClient.NewGetTagsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.Link != nil {
 				nextLink = *page.Link
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getTagsCreateRequest(ctx, name, options)

--- a/packages/autorest.go/test/acr/azacr/zz_options.go
+++ b/packages/autorest.go/test/acr/azacr/zz_options.go
@@ -148,6 +148,9 @@ type ContainerRegistryClientGetManifestsOptions struct {
 	// query parameter for max number of items
 	N *int32
 
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// orderby query parameter
 	Orderby *string
 }
@@ -166,6 +169,9 @@ type ContainerRegistryClientGetRepositoriesOptions struct {
 
 	// query parameter for max number of items
 	N *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ContainerRegistryClientGetTagPropertiesOptions contains the optional parameters for the ContainerRegistryClient.GetTagProperties
@@ -185,6 +191,9 @@ type ContainerRegistryClientGetTagsOptions struct {
 
 	// query parameter for max number of items
 	N *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 
 	// orderby query parameter
 	Orderby *string

--- a/packages/autorest.go/test/autorest/paginggroup/zz_options.go
+++ b/packages/autorest.go/test/autorest/paginggroup/zz_options.go
@@ -16,7 +16,8 @@ type CustomParameterGroup struct {
 
 // PagingClientAppendAPIVersionOptions contains the optional parameters for the PagingClient.NewAppendAPIVersionPager method.
 type PagingClientAppendAPIVersionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientBeginGetMultiplePagesLROOptions contains the optional parameters for the PagingClient.BeginGetMultiplePagesLRO
@@ -38,42 +39,51 @@ type PagingClientBeginGetMultiplePagesLROOptions struct {
 type PagingClientDuplicateParamsOptions struct {
 	// OData filter options. Pass in 'foo'
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientFirstResponseEmptyOptions contains the optional parameters for the PagingClient.NewFirstResponseEmptyPager
 // method.
 type PagingClientFirstResponseEmptyOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientGetEmptyNextLinkNamePagesOptions contains the optional parameters for the PagingClient.NewGetEmptyNextLinkNamePagesPager
 // method.
 type PagingClientGetEmptyNextLinkNamePagesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientGetMultiplePagesFailureOptions contains the optional parameters for the PagingClient.NewGetMultiplePagesFailurePager
 // method.
 type PagingClientGetMultiplePagesFailureOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientGetMultiplePagesFailureURIOptions contains the optional parameters for the PagingClient.NewGetMultiplePagesFailureURIPager
 // method.
 type PagingClientGetMultiplePagesFailureURIOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientGetMultiplePagesFragmentNextLinkOptions contains the optional parameters for the PagingClient.NewGetMultiplePagesFragmentNextLinkPager
 // method.
 type PagingClientGetMultiplePagesFragmentNextLinkOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientGetMultiplePagesFragmentWithGroupingNextLinkOptions contains the optional parameters for the PagingClient.NewGetMultiplePagesFragmentWithGroupingNextLinkPager
 // method.
 type PagingClientGetMultiplePagesFragmentWithGroupingNextLinkOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientGetMultiplePagesOptions contains the optional parameters for the PagingClient.NewGetMultiplePagesPager method.
@@ -83,6 +93,9 @@ type PagingClientGetMultiplePagesOptions struct {
 	// Sets the maximum number of items to return in the response.
 	Maxresults *int32
 
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.
 	Timeout *int32
 }
@@ -90,13 +103,15 @@ type PagingClientGetMultiplePagesOptions struct {
 // PagingClientGetMultiplePagesRetryFirstOptions contains the optional parameters for the PagingClient.NewGetMultiplePagesRetryFirstPager
 // method.
 type PagingClientGetMultiplePagesRetryFirstOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientGetMultiplePagesRetrySecondOptions contains the optional parameters for the PagingClient.NewGetMultiplePagesRetrySecondPager
 // method.
 type PagingClientGetMultiplePagesRetrySecondOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientGetMultiplePagesWithOffsetOptions contains the optional parameters for the PagingClient.NewGetMultiplePagesWithOffsetPager
@@ -106,6 +121,9 @@ type PagingClientGetMultiplePagesWithOffsetOptions struct {
 
 	// Sets the maximum number of items to return in the response.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 
 	// Offset of return value
 	Offset int32
@@ -117,13 +135,15 @@ type PagingClientGetMultiplePagesWithOffsetOptions struct {
 // PagingClientGetNoItemNamePagesOptions contains the optional parameters for the PagingClient.NewGetNoItemNamePagesPager
 // method.
 type PagingClientGetNoItemNamePagesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientGetNullNextLinkNamePagesOptions contains the optional parameters for the PagingClient.NewGetNullNextLinkNamePagesPager
 // method.
 type PagingClientGetNullNextLinkNamePagesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientGetODataMultiplePagesOptions contains the optional parameters for the PagingClient.NewGetODataMultiplePagesPager
@@ -134,6 +154,9 @@ type PagingClientGetODataMultiplePagesOptions struct {
 	// Sets the maximum number of items to return in the response.
 	Maxresults *int32
 
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.
 	Timeout *int32
 }
@@ -141,30 +164,35 @@ type PagingClientGetODataMultiplePagesOptions struct {
 // PagingClientGetPagingModelWithItemNameWithXMSClientNameOptions contains the optional parameters for the PagingClient.NewGetPagingModelWithItemNameWithXMSClientNamePager
 // method.
 type PagingClientGetPagingModelWithItemNameWithXMSClientNameOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientGetSinglePagesFailureOptions contains the optional parameters for the PagingClient.NewGetSinglePagesFailurePager
 // method.
 type PagingClientGetSinglePagesFailureOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientGetSinglePagesOptions contains the optional parameters for the PagingClient.NewGetSinglePagesPager method.
 type PagingClientGetSinglePagesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientGetSinglePagesWithBodyParamsOptions contains the optional parameters for the PagingClient.NewGetSinglePagesWithBodyParamsPager
 // method.
 type PagingClientGetSinglePagesWithBodyParamsOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientGetWithQueryParamsOptions contains the optional parameters for the PagingClient.NewGetWithQueryParamsPager
 // method.
 type PagingClientGetWithQueryParamsOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientPageWithMaxPageSizeOptions contains the optional parameters for the PagingClient.NewPageWithMaxPageSizePager
@@ -172,9 +200,13 @@ type PagingClientGetWithQueryParamsOptions struct {
 type PagingClientPageWithMaxPageSizeOptions struct {
 	// Max page size query param. Don't send. Specifying any value will set the value to 5.
 	Maxpagesize *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PagingClientReplaceAPIVersionOptions contains the optional parameters for the PagingClient.NewReplaceAPIVersionPager method.
 type PagingClientReplaceAPIVersionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/autorest.go/test/autorest/paginggroup/zz_paging_client.go
+++ b/packages/autorest.go/test/autorest/paginggroup/zz_paging_client.go
@@ -417,7 +417,7 @@ func (client *PagingClient) NewGetMultiplePagesFragmentNextLinkPager(apiVersion 
 				return client.getMultiplePagesFragmentNextLinkCreateRequest(ctx, apiVersion, tenant, options)
 			}, &runtime.FetcherForNextLinkOptions{
 				NextReq: func(ctx context.Context, encodedNextLink string) (*policy.Request, error) {
-					return client.nextFragmentCreateRequest(ctx, apiVersion, tenant, encodedNextLink)
+					return client.nextFragmentCreateRequest(ctx, apiVersion, tenant, encodedNextLink, nextLink)
 				},
 			})
 			if err != nil {
@@ -481,7 +481,7 @@ func (client *PagingClient) NewGetMultiplePagesFragmentWithGroupingNextLinkPager
 				return client.getMultiplePagesFragmentWithGroupingNextLinkCreateRequest(ctx, customParameterGroup, options)
 			}, &runtime.FetcherForNextLinkOptions{
 				NextReq: func(ctx context.Context, encodedNextLink string) (*policy.Request, error) {
-					return client.nextFragmentWithGroupingCreateRequest(ctx, encodedNextLink, customParameterGroup)
+					return client.nextFragmentWithGroupingCreateRequest(ctx, encodedNextLink, nextLink, customParameterGroup)
 				},
 			})
 			if err != nil {
@@ -1162,7 +1162,7 @@ func (client *PagingClient) NewGetWithQueryParamsPager(requiredQueryParameter in
 				return client.getWithQueryParamsCreateRequest(ctx, requiredQueryParameter, options)
 			}, &runtime.FetcherForNextLinkOptions{
 				NextReq: func(ctx context.Context, encodedNextLink string) (*policy.Request, error) {
-					return client.nextOperationWithQueryParamsCreateRequest(ctx)
+					return client.nextOperationWithQueryParamsCreateRequest(ctx, nextLink)
 				},
 			})
 			if err != nil {
@@ -1308,7 +1308,7 @@ func (client *PagingClient) replaceAPIVersionHandleResponse(resp *http.Response)
 }
 
 // nextFragmentCreateRequest creates the nextFragmentCreateRequest request.
-func (client *PagingClient) nextFragmentCreateRequest(ctx context.Context, apiVersion string, tenant string, nextLink string) (*policy.Request, error) {
+func (client *PagingClient) nextFragmentCreateRequest(ctx context.Context, apiVersion string, tenant string, nextLink string, nextLink *string) (*policy.Request, error) {
 	urlPath := "/paging/multiple/fragment/{tenant}/{nextLink}"
 	if tenant == "" {
 		return nil, errors.New("parameter tenant cannot be empty")
@@ -1327,7 +1327,7 @@ func (client *PagingClient) nextFragmentCreateRequest(ctx context.Context, apiVe
 }
 
 // nextFragmentWithGroupingCreateRequest creates the nextFragmentWithGroupingCreateRequest request.
-func (client *PagingClient) nextFragmentWithGroupingCreateRequest(ctx context.Context, nextLink string, customParameterGroup CustomParameterGroup) (*policy.Request, error) {
+func (client *PagingClient) nextFragmentWithGroupingCreateRequest(ctx context.Context, nextLink string, nextLink *string, customParameterGroup CustomParameterGroup) (*policy.Request, error) {
 	urlPath := "/paging/multiple/fragmentwithgrouping/{tenant}/{nextLink}"
 	if customParameterGroup.Tenant == "" {
 		return nil, errors.New("parameter customParameterGroup.Tenant cannot be empty")
@@ -1346,7 +1346,7 @@ func (client *PagingClient) nextFragmentWithGroupingCreateRequest(ctx context.Co
 }
 
 // nextOperationWithQueryParamsCreateRequest creates the nextOperationWithQueryParamsCreateRequest request.
-func (client *PagingClient) nextOperationWithQueryParamsCreateRequest(ctx context.Context) (*policy.Request, error) {
+func (client *PagingClient) nextOperationWithQueryParamsCreateRequest(ctx context.Context, nextLink *string) (*policy.Request, error) {
 	urlPath := "/paging/multiple/nextOperationWithQueryParams"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
 	if err != nil {

--- a/packages/autorest.go/test/autorest/paginggroup/zz_paging_client.go
+++ b/packages/autorest.go/test/autorest/paginggroup/zz_paging_client.go
@@ -37,8 +37,10 @@ func (client *PagingClient) NewAppendAPIVersionPager(options *PagingClientAppend
 		Fetcher: func(ctx context.Context, page *PagingClientAppendAPIVersionResponse) (PagingClientAppendAPIVersionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewAppendAPIVersionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.appendAPIVersionCreateRequest(ctx, options)
@@ -89,8 +91,10 @@ func (client *PagingClient) NewDuplicateParamsPager(options *PagingClientDuplica
 		Fetcher: func(ctx context.Context, page *PagingClientDuplicateParamsResponse) (PagingClientDuplicateParamsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewDuplicateParamsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.duplicateParamsCreateRequest(ctx, options)
@@ -143,8 +147,10 @@ func (client *PagingClient) NewFirstResponseEmptyPager(options *PagingClientFirs
 		Fetcher: func(ctx context.Context, page *PagingClientFirstResponseEmptyResponse) (PagingClientFirstResponseEmptyResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewFirstResponseEmptyPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.firstResponseEmptyCreateRequest(ctx, options)
@@ -191,8 +197,10 @@ func (client *PagingClient) NewGetEmptyNextLinkNamePagesPager(options *PagingCli
 		Fetcher: func(ctx context.Context, page *PagingClientGetEmptyNextLinkNamePagesResponse) (PagingClientGetEmptyNextLinkNamePagesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetEmptyNextLinkNamePagesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getEmptyNextLinkNamePagesCreateRequest(ctx, options)
@@ -239,8 +247,10 @@ func (client *PagingClient) NewGetMultiplePagesPager(options *PagingClientGetMul
 		Fetcher: func(ctx context.Context, page *PagingClientGetMultiplePagesResponse) (PagingClientGetMultiplePagesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetMultiplePagesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getMultiplePagesCreateRequest(ctx, options)
@@ -296,8 +306,10 @@ func (client *PagingClient) NewGetMultiplePagesFailurePager(options *PagingClien
 		Fetcher: func(ctx context.Context, page *PagingClientGetMultiplePagesFailureResponse) (PagingClientGetMultiplePagesFailureResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetMultiplePagesFailurePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getMultiplePagesFailureCreateRequest(ctx, options)
@@ -344,8 +356,10 @@ func (client *PagingClient) NewGetMultiplePagesFailureURIPager(options *PagingCl
 		Fetcher: func(ctx context.Context, page *PagingClientGetMultiplePagesFailureURIResponse) (PagingClientGetMultiplePagesFailureURIResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetMultiplePagesFailureURIPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getMultiplePagesFailureURICreateRequest(ctx, options)
@@ -394,8 +408,10 @@ func (client *PagingClient) NewGetMultiplePagesFragmentNextLinkPager(apiVersion 
 		Fetcher: func(ctx context.Context, page *PagingClientGetMultiplePagesFragmentNextLinkResponse) (PagingClientGetMultiplePagesFragmentNextLinkResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetMultiplePagesFragmentNextLinkPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.ODataNextLink != nil {
 				nextLink = *page.ODataNextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getMultiplePagesFragmentNextLinkCreateRequest(ctx, apiVersion, tenant, options)
@@ -456,8 +472,10 @@ func (client *PagingClient) NewGetMultiplePagesFragmentWithGroupingNextLinkPager
 		Fetcher: func(ctx context.Context, page *PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse) (PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetMultiplePagesFragmentWithGroupingNextLinkPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.ODataNextLink != nil {
 				nextLink = *page.ODataNextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getMultiplePagesFragmentWithGroupingNextLinkCreateRequest(ctx, customParameterGroup, options)
@@ -609,8 +627,10 @@ func (client *PagingClient) NewGetMultiplePagesRetryFirstPager(options *PagingCl
 		Fetcher: func(ctx context.Context, page *PagingClientGetMultiplePagesRetryFirstResponse) (PagingClientGetMultiplePagesRetryFirstResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetMultiplePagesRetryFirstPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getMultiplePagesRetryFirstCreateRequest(ctx, options)
@@ -658,8 +678,10 @@ func (client *PagingClient) NewGetMultiplePagesRetrySecondPager(options *PagingC
 		Fetcher: func(ctx context.Context, page *PagingClientGetMultiplePagesRetrySecondResponse) (PagingClientGetMultiplePagesRetrySecondResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetMultiplePagesRetrySecondPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getMultiplePagesRetrySecondCreateRequest(ctx, options)
@@ -706,8 +728,10 @@ func (client *PagingClient) NewGetMultiplePagesWithOffsetPager(options PagingCli
 		Fetcher: func(ctx context.Context, page *PagingClientGetMultiplePagesWithOffsetResponse) (PagingClientGetMultiplePagesWithOffsetResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetMultiplePagesWithOffsetPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getMultiplePagesWithOffsetCreateRequest(ctx, options)
@@ -764,8 +788,10 @@ func (client *PagingClient) NewGetNoItemNamePagesPager(options *PagingClientGetN
 		Fetcher: func(ctx context.Context, page *PagingClientGetNoItemNamePagesResponse) (PagingClientGetNoItemNamePagesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetNoItemNamePagesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getNoItemNamePagesCreateRequest(ctx, options)
@@ -861,8 +887,10 @@ func (client *PagingClient) NewGetODataMultiplePagesPager(options *PagingClientG
 		Fetcher: func(ctx context.Context, page *PagingClientGetODataMultiplePagesResponse) (PagingClientGetODataMultiplePagesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetODataMultiplePagesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.ODataNextLink != nil {
 				nextLink = *page.ODataNextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getODataMultiplePagesCreateRequest(ctx, options)
@@ -919,8 +947,10 @@ func (client *PagingClient) NewGetPagingModelWithItemNameWithXMSClientNamePager(
 		Fetcher: func(ctx context.Context, page *PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse) (PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetPagingModelWithItemNameWithXMSClientNamePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getPagingModelWithItemNameWithXMSClientNameCreateRequest(ctx, options)
@@ -967,8 +997,10 @@ func (client *PagingClient) NewGetSinglePagesPager(options *PagingClientGetSingl
 		Fetcher: func(ctx context.Context, page *PagingClientGetSinglePagesResponse) (PagingClientGetSinglePagesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetSinglePagesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getSinglePagesCreateRequest(ctx, options)
@@ -1015,8 +1047,10 @@ func (client *PagingClient) NewGetSinglePagesFailurePager(options *PagingClientG
 		Fetcher: func(ctx context.Context, page *PagingClientGetSinglePagesFailureResponse) (PagingClientGetSinglePagesFailureResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetSinglePagesFailurePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getSinglePagesFailureCreateRequest(ctx, options)
@@ -1064,8 +1098,10 @@ func (client *PagingClient) NewGetSinglePagesWithBodyParamsPager(parameters Body
 		Fetcher: func(ctx context.Context, page *PagingClientGetSinglePagesWithBodyParamsResponse) (PagingClientGetSinglePagesWithBodyParamsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetSinglePagesWithBodyParamsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getSinglePagesWithBodyParamsCreateRequest(ctx, parameters, options)
@@ -1117,8 +1153,10 @@ func (client *PagingClient) NewGetWithQueryParamsPager(requiredQueryParameter in
 		Fetcher: func(ctx context.Context, page *PagingClientGetWithQueryParamsResponse) (PagingClientGetWithQueryParamsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewGetWithQueryParamsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getWithQueryParamsCreateRequest(ctx, requiredQueryParameter, options)
@@ -1173,8 +1211,10 @@ func (client *PagingClient) NewPageWithMaxPageSizePager(options *PagingClientPag
 		Fetcher: func(ctx context.Context, page *PagingClientPageWithMaxPageSizeResponse) (PagingClientPageWithMaxPageSizeResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewPageWithMaxPageSizePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.pageWithMaxPageSizeCreateRequest(ctx, options)
@@ -1227,8 +1267,10 @@ func (client *PagingClient) NewReplaceAPIVersionPager(options *PagingClientRepla
 		Fetcher: func(ctx context.Context, page *PagingClientReplaceAPIVersionResponse) (PagingClientReplaceAPIVersionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PagingClient.NewReplaceAPIVersionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.replaceAPIVersionCreateRequest(ctx, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_availabilitysets_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_availabilitysets_client.go
@@ -242,8 +242,10 @@ func (client *AvailabilitySetsClient) NewListPager(resourceGroupName string, opt
 		Fetcher: func(ctx context.Context, page *AvailabilitySetsClientListResponse) (AvailabilitySetsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AvailabilitySetsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -368,8 +370,10 @@ func (client *AvailabilitySetsClient) NewListBySubscriptionPager(options *Availa
 		Fetcher: func(ctx context.Context, page *AvailabilitySetsClientListBySubscriptionResponse) (AvailabilitySetsClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AvailabilitySetsClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_capacityreservationgroups_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_capacityreservationgroups_client.go
@@ -252,8 +252,10 @@ func (client *CapacityReservationGroupsClient) NewListByResourceGroupPager(resou
 		Fetcher: func(ctx context.Context, page *CapacityReservationGroupsClientListByResourceGroupResponse) (CapacityReservationGroupsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "CapacityReservationGroupsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -315,8 +317,10 @@ func (client *CapacityReservationGroupsClient) NewListBySubscriptionPager(option
 		Fetcher: func(ctx context.Context, page *CapacityReservationGroupsClientListBySubscriptionResponse) (CapacityReservationGroupsClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "CapacityReservationGroupsClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_capacityreservations_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_capacityreservations_client.go
@@ -304,8 +304,10 @@ func (client *CapacityReservationsClient) NewListByCapacityReservationGroupPager
 		Fetcher: func(ctx context.Context, page *CapacityReservationsClientListByCapacityReservationGroupResponse) (CapacityReservationsClientListByCapacityReservationGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "CapacityReservationsClient.NewListByCapacityReservationGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByCapacityReservationGroupCreateRequest(ctx, resourceGroupName, capacityReservationGroupName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_cloudserviceoperatingsystems_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_cloudserviceoperatingsystems_client.go
@@ -189,8 +189,10 @@ func (client *CloudServiceOperatingSystemsClient) NewListOSFamiliesPager(locatio
 		Fetcher: func(ctx context.Context, page *CloudServiceOperatingSystemsClientListOSFamiliesResponse) (CloudServiceOperatingSystemsClientListOSFamiliesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "CloudServiceOperatingSystemsClient.NewListOSFamiliesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listOSFamiliesCreateRequest(ctx, location, options)
@@ -251,8 +253,10 @@ func (client *CloudServiceOperatingSystemsClient) NewListOSVersionsPager(locatio
 		Fetcher: func(ctx context.Context, page *CloudServiceOperatingSystemsClientListOSVersionsResponse) (CloudServiceOperatingSystemsClientListOSVersionsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "CloudServiceOperatingSystemsClient.NewListOSVersionsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listOSVersionsCreateRequest(ctx, location, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_cloudserviceroleinstances_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_cloudserviceroleinstances_client.go
@@ -332,8 +332,10 @@ func (client *CloudServiceRoleInstancesClient) NewListPager(resourceGroupName st
 		Fetcher: func(ctx context.Context, page *CloudServiceRoleInstancesClientListResponse) (CloudServiceRoleInstancesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "CloudServiceRoleInstancesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, cloudServiceName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_cloudserviceroles_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_cloudserviceroles_client.go
@@ -122,8 +122,10 @@ func (client *CloudServiceRolesClient) NewListPager(resourceGroupName string, cl
 		Fetcher: func(ctx context.Context, page *CloudServiceRolesClientListResponse) (CloudServiceRolesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "CloudServiceRolesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, cloudServiceName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_cloudservices_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_cloudservices_client.go
@@ -423,8 +423,10 @@ func (client *CloudServicesClient) NewListPager(resourceGroupName string, option
 		Fetcher: func(ctx context.Context, page *CloudServicesClientListResponse) (CloudServicesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "CloudServicesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -484,8 +486,10 @@ func (client *CloudServicesClient) NewListAllPager(options *CloudServicesClientL
 		Fetcher: func(ctx context.Context, page *CloudServicesClientListAllResponse) (CloudServicesClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "CloudServicesClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_cloudservicesupdatedomain_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_cloudservicesupdatedomain_client.go
@@ -126,8 +126,10 @@ func (client *CloudServicesUpdateDomainClient) NewListUpdateDomainsPager(resourc
 		Fetcher: func(ctx context.Context, page *CloudServicesUpdateDomainClientListUpdateDomainsResponse) (CloudServicesUpdateDomainClientListUpdateDomainsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "CloudServicesUpdateDomainClient.NewListUpdateDomainsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listUpdateDomainsCreateRequest(ctx, resourceGroupName, cloudServiceName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_dedicatedhostgroups_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_dedicatedhostgroups_client.go
@@ -248,8 +248,10 @@ func (client *DedicatedHostGroupsClient) NewListByResourceGroupPager(resourceGro
 		Fetcher: func(ctx context.Context, page *DedicatedHostGroupsClientListByResourceGroupResponse) (DedicatedHostGroupsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DedicatedHostGroupsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -308,8 +310,10 @@ func (client *DedicatedHostGroupsClient) NewListBySubscriptionPager(options *Ded
 		Fetcher: func(ctx context.Context, page *DedicatedHostGroupsClientListBySubscriptionResponse) (DedicatedHostGroupsClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DedicatedHostGroupsClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_dedicatedhosts_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_dedicatedhosts_client.go
@@ -295,8 +295,10 @@ func (client *DedicatedHostsClient) NewListByHostGroupPager(resourceGroupName st
 		Fetcher: func(ctx context.Context, page *DedicatedHostsClientListByHostGroupResponse) (DedicatedHostsClientListByHostGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DedicatedHostsClient.NewListByHostGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByHostGroupCreateRequest(ctx, resourceGroupName, hostGroupName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_diskaccesses_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_diskaccesses_client.go
@@ -501,8 +501,10 @@ func (client *DiskAccessesClient) NewListPager(options *DiskAccessesClientListOp
 		Fetcher: func(ctx context.Context, page *DiskAccessesClientListResponse) (DiskAccessesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DiskAccessesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -557,8 +559,10 @@ func (client *DiskAccessesClient) NewListByResourceGroupPager(resourceGroupName 
 		Fetcher: func(ctx context.Context, page *DiskAccessesClientListByResourceGroupResponse) (DiskAccessesClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DiskAccessesClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -620,8 +624,10 @@ func (client *DiskAccessesClient) NewListPrivateEndpointConnectionsPager(resourc
 		Fetcher: func(ctx context.Context, page *DiskAccessesClientListPrivateEndpointConnectionsResponse) (DiskAccessesClientListPrivateEndpointConnectionsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DiskAccessesClient.NewListPrivateEndpointConnectionsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listPrivateEndpointConnectionsCreateRequest(ctx, resourceGroupName, diskAccessName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_diskencryptionsets_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_diskencryptionsets_client.go
@@ -280,8 +280,10 @@ func (client *DiskEncryptionSetsClient) NewListPager(options *DiskEncryptionSets
 		Fetcher: func(ctx context.Context, page *DiskEncryptionSetsClientListResponse) (DiskEncryptionSetsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DiskEncryptionSetsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -339,8 +341,10 @@ func (client *DiskEncryptionSetsClient) NewListAssociatedResourcesPager(resource
 		Fetcher: func(ctx context.Context, page *DiskEncryptionSetsClientListAssociatedResourcesResponse) (DiskEncryptionSetsClientListAssociatedResourcesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DiskEncryptionSetsClient.NewListAssociatedResourcesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAssociatedResourcesCreateRequest(ctx, resourceGroupName, diskEncryptionSetName, options)
@@ -403,8 +407,10 @@ func (client *DiskEncryptionSetsClient) NewListByResourceGroupPager(resourceGrou
 		Fetcher: func(ctx context.Context, page *DiskEncryptionSetsClientListByResourceGroupResponse) (DiskEncryptionSetsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DiskEncryptionSetsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_diskrestorepoint_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_diskrestorepoint_client.go
@@ -222,8 +222,10 @@ func (client *DiskRestorePointClient) NewListByRestorePointPager(resourceGroupNa
 		Fetcher: func(ctx context.Context, page *DiskRestorePointClientListByRestorePointResponse) (DiskRestorePointClientListByRestorePointResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DiskRestorePointClient.NewListByRestorePointPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByRestorePointCreateRequest(ctx, resourceGroupName, restorePointCollectionName, vmRestorePointName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_disks_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_disks_client.go
@@ -359,8 +359,10 @@ func (client *DisksClient) NewListPager(options *DisksClientListOptions) *runtim
 		Fetcher: func(ctx context.Context, page *DisksClientListResponse) (DisksClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DisksClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -415,8 +417,10 @@ func (client *DisksClient) NewListByResourceGroupPager(resourceGroupName string,
 		Fetcher: func(ctx context.Context, page *DisksClientListByResourceGroupResponse) (DisksClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DisksClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_galleries_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_galleries_client.go
@@ -279,8 +279,10 @@ func (client *GalleriesClient) NewListPager(options *GalleriesClientListOptions)
 		Fetcher: func(ctx context.Context, page *GalleriesClientListResponse) (GalleriesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "GalleriesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -335,8 +337,10 @@ func (client *GalleriesClient) NewListByResourceGroupPager(resourceGroupName str
 		Fetcher: func(ctx context.Context, page *GalleriesClientListByResourceGroupResponse) (GalleriesClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "GalleriesClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_galleryapplications_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_galleryapplications_client.go
@@ -293,8 +293,10 @@ func (client *GalleryApplicationsClient) NewListByGalleryPager(resourceGroupName
 		Fetcher: func(ctx context.Context, page *GalleryApplicationsClientListByGalleryResponse) (GalleryApplicationsClientListByGalleryResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "GalleryApplicationsClient.NewListByGalleryPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByGalleryCreateRequest(ctx, resourceGroupName, galleryName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_galleryapplicationversions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_galleryapplicationversions_client.go
@@ -314,8 +314,10 @@ func (client *GalleryApplicationVersionsClient) NewListByGalleryApplicationPager
 		Fetcher: func(ctx context.Context, page *GalleryApplicationVersionsClientListByGalleryApplicationResponse) (GalleryApplicationVersionsClientListByGalleryApplicationResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "GalleryApplicationVersionsClient.NewListByGalleryApplicationPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByGalleryApplicationCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_galleryimages_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_galleryimages_client.go
@@ -293,8 +293,10 @@ func (client *GalleryImagesClient) NewListByGalleryPager(resourceGroupName strin
 		Fetcher: func(ctx context.Context, page *GalleryImagesClientListByGalleryResponse) (GalleryImagesClientListByGalleryResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "GalleryImagesClient.NewListByGalleryPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByGalleryCreateRequest(ctx, resourceGroupName, galleryName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_galleryimageversions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_galleryimageversions_client.go
@@ -313,8 +313,10 @@ func (client *GalleryImageVersionsClient) NewListByGalleryImagePager(resourceGro
 		Fetcher: func(ctx context.Context, page *GalleryImageVersionsClientListByGalleryImageResponse) (GalleryImageVersionsClientListByGalleryImageResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "GalleryImageVersionsClient.NewListByGalleryImagePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByGalleryImageCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_images_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_images_client.go
@@ -276,8 +276,10 @@ func (client *ImagesClient) NewListPager(options *ImagesClientListOptions) *runt
 		Fetcher: func(ctx context.Context, page *ImagesClientListResponse) (ImagesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ImagesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -332,8 +334,10 @@ func (client *ImagesClient) NewListByResourceGroupPager(resourceGroupName string
 		Fetcher: func(ctx context.Context, page *ImagesClientListByResourceGroupResponse) (ImagesClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ImagesClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_options.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_options.go
@@ -24,7 +24,8 @@ type AvailabilitySetsClientGetOptions struct {
 // AvailabilitySetsClientListAvailableSizesOptions contains the optional parameters for the AvailabilitySetsClient.NewListAvailableSizesPager
 // method.
 type AvailabilitySetsClientListAvailableSizesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AvailabilitySetsClientListBySubscriptionOptions contains the optional parameters for the AvailabilitySetsClient.NewListBySubscriptionPager
@@ -32,11 +33,15 @@ type AvailabilitySetsClientListAvailableSizesOptions struct {
 type AvailabilitySetsClientListBySubscriptionOptions struct {
 	// The expand expression to apply to the operation. Allowed values are 'instanceView'.
 	Expand *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AvailabilitySetsClientListOptions contains the optional parameters for the AvailabilitySetsClient.NewListPager method.
 type AvailabilitySetsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AvailabilitySetsClientUpdateOptions contains the optional parameters for the AvailabilitySetsClient.Update method.
@@ -72,6 +77,9 @@ type CapacityReservationGroupsClientListByResourceGroupOptions struct {
 	// VM Instance or both resource Ids which are associated to capacity
 	// reservation group in the response.
 	Expand *ExpandTypesForGetCapacityReservationGroups
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // CapacityReservationGroupsClientListBySubscriptionOptions contains the optional parameters for the CapacityReservationGroupsClient.NewListBySubscriptionPager
@@ -81,6 +89,9 @@ type CapacityReservationGroupsClientListBySubscriptionOptions struct {
 	// VM Instance or both resource Ids which are associated to capacity
 	// reservation group in the response.
 	Expand *ExpandTypesForGetCapacityReservationGroups
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // CapacityReservationGroupsClientUpdateOptions contains the optional parameters for the CapacityReservationGroupsClient.Update
@@ -121,7 +132,8 @@ type CapacityReservationsClientGetOptions struct {
 // CapacityReservationsClientListByCapacityReservationGroupOptions contains the optional parameters for the CapacityReservationsClient.NewListByCapacityReservationGroupPager
 // method.
 type CapacityReservationsClientListByCapacityReservationGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // CloudServiceOperatingSystemsClientGetOSFamilyOptions contains the optional parameters for the CloudServiceOperatingSystemsClient.GetOSFamily
@@ -139,13 +151,15 @@ type CloudServiceOperatingSystemsClientGetOSVersionOptions struct {
 // CloudServiceOperatingSystemsClientListOSFamiliesOptions contains the optional parameters for the CloudServiceOperatingSystemsClient.NewListOSFamiliesPager
 // method.
 type CloudServiceOperatingSystemsClientListOSFamiliesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // CloudServiceOperatingSystemsClientListOSVersionsOptions contains the optional parameters for the CloudServiceOperatingSystemsClient.NewListOSVersionsPager
 // method.
 type CloudServiceOperatingSystemsClientListOSVersionsOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // CloudServiceRoleInstancesClientBeginDeleteOptions contains the optional parameters for the CloudServiceRoleInstancesClient.BeginDelete
@@ -200,6 +214,9 @@ type CloudServiceRoleInstancesClientGetRemoteDesktopFileOptions struct {
 type CloudServiceRoleInstancesClientListOptions struct {
 	// The expand expression to apply to the operation. 'UserData' is not supported for cloud services.
 	Expand *InstanceViewTypes
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // CloudServiceRolesClientGetOptions contains the optional parameters for the CloudServiceRolesClient.Get method.
@@ -209,7 +226,8 @@ type CloudServiceRolesClientGetOptions struct {
 
 // CloudServiceRolesClientListOptions contains the optional parameters for the CloudServiceRolesClient.NewListPager method.
 type CloudServiceRolesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // CloudServicesClientBeginCreateOrUpdateOptions contains the optional parameters for the CloudServicesClient.BeginCreateOrUpdate
@@ -293,12 +311,14 @@ type CloudServicesClientGetOptions struct {
 
 // CloudServicesClientListAllOptions contains the optional parameters for the CloudServicesClient.NewListAllPager method.
 type CloudServicesClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // CloudServicesClientListOptions contains the optional parameters for the CloudServicesClient.NewListPager method.
 type CloudServicesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // CloudServicesUpdateDomainClientBeginWalkUpdateDomainOptions contains the optional parameters for the CloudServicesUpdateDomainClient.BeginWalkUpdateDomain
@@ -317,7 +337,8 @@ type CloudServicesUpdateDomainClientGetUpdateDomainOptions struct {
 // CloudServicesUpdateDomainClientListUpdateDomainsOptions contains the optional parameters for the CloudServicesUpdateDomainClient.NewListUpdateDomainsPager
 // method.
 type CloudServicesUpdateDomainClientListUpdateDomainsOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // CommunityGalleriesClientGetOptions contains the optional parameters for the CommunityGalleriesClient.Get method.
@@ -358,13 +379,15 @@ type DedicatedHostGroupsClientGetOptions struct {
 // DedicatedHostGroupsClientListByResourceGroupOptions contains the optional parameters for the DedicatedHostGroupsClient.NewListByResourceGroupPager
 // method.
 type DedicatedHostGroupsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DedicatedHostGroupsClientListBySubscriptionOptions contains the optional parameters for the DedicatedHostGroupsClient.NewListBySubscriptionPager
 // method.
 type DedicatedHostGroupsClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DedicatedHostGroupsClientUpdateOptions contains the optional parameters for the DedicatedHostGroupsClient.Update method.
@@ -407,7 +430,8 @@ type DedicatedHostsClientGetOptions struct {
 // DedicatedHostsClientListByHostGroupOptions contains the optional parameters for the DedicatedHostsClient.NewListByHostGroupPager
 // method.
 type DedicatedHostsClientListByHostGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DiskAccessesClientBeginCreateOrUpdateOptions contains the optional parameters for the DiskAccessesClient.BeginCreateOrUpdate
@@ -463,18 +487,21 @@ type DiskAccessesClientGetPrivateLinkResourcesOptions struct {
 // DiskAccessesClientListByResourceGroupOptions contains the optional parameters for the DiskAccessesClient.NewListByResourceGroupPager
 // method.
 type DiskAccessesClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DiskAccessesClientListOptions contains the optional parameters for the DiskAccessesClient.NewListPager method.
 type DiskAccessesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DiskAccessesClientListPrivateEndpointConnectionsOptions contains the optional parameters for the DiskAccessesClient.NewListPrivateEndpointConnectionsPager
 // method.
 type DiskAccessesClientListPrivateEndpointConnectionsOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DiskEncryptionSetsClientBeginCreateOrUpdateOptions contains the optional parameters for the DiskEncryptionSetsClient.BeginCreateOrUpdate
@@ -506,18 +533,21 @@ type DiskEncryptionSetsClientGetOptions struct {
 // DiskEncryptionSetsClientListAssociatedResourcesOptions contains the optional parameters for the DiskEncryptionSetsClient.NewListAssociatedResourcesPager
 // method.
 type DiskEncryptionSetsClientListAssociatedResourcesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DiskEncryptionSetsClientListByResourceGroupOptions contains the optional parameters for the DiskEncryptionSetsClient.NewListByResourceGroupPager
 // method.
 type DiskEncryptionSetsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DiskEncryptionSetsClientListOptions contains the optional parameters for the DiskEncryptionSetsClient.NewListPager method.
 type DiskEncryptionSetsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DiskRestorePointClientBeginGrantAccessOptions contains the optional parameters for the DiskRestorePointClient.BeginGrantAccess
@@ -542,7 +572,8 @@ type DiskRestorePointClientGetOptions struct {
 // DiskRestorePointClientListByRestorePointOptions contains the optional parameters for the DiskRestorePointClient.NewListByRestorePointPager
 // method.
 type DiskRestorePointClientListByRestorePointOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DisksClientBeginCreateOrUpdateOptions contains the optional parameters for the DisksClient.BeginCreateOrUpdate method.
@@ -583,12 +614,14 @@ type DisksClientGetOptions struct {
 // DisksClientListByResourceGroupOptions contains the optional parameters for the DisksClient.NewListByResourceGroupPager
 // method.
 type DisksClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DisksClientListOptions contains the optional parameters for the DisksClient.NewListPager method.
 type DisksClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // GalleriesClientBeginCreateOrUpdateOptions contains the optional parameters for the GalleriesClient.BeginCreateOrUpdate
@@ -622,12 +655,14 @@ type GalleriesClientGetOptions struct {
 // GalleriesClientListByResourceGroupOptions contains the optional parameters for the GalleriesClient.NewListByResourceGroupPager
 // method.
 type GalleriesClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // GalleriesClientListOptions contains the optional parameters for the GalleriesClient.NewListPager method.
 type GalleriesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // GalleryApplicationVersionsClientBeginCreateOrUpdateOptions contains the optional parameters for the GalleryApplicationVersionsClient.BeginCreateOrUpdate
@@ -661,7 +696,8 @@ type GalleryApplicationVersionsClientGetOptions struct {
 // GalleryApplicationVersionsClientListByGalleryApplicationOptions contains the optional parameters for the GalleryApplicationVersionsClient.NewListByGalleryApplicationPager
 // method.
 type GalleryApplicationVersionsClientListByGalleryApplicationOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // GalleryApplicationsClientBeginCreateOrUpdateOptions contains the optional parameters for the GalleryApplicationsClient.BeginCreateOrUpdate
@@ -693,7 +729,8 @@ type GalleryApplicationsClientGetOptions struct {
 // GalleryApplicationsClientListByGalleryOptions contains the optional parameters for the GalleryApplicationsClient.NewListByGalleryPager
 // method.
 type GalleryApplicationsClientListByGalleryOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // GalleryImageVersionsClientBeginCreateOrUpdateOptions contains the optional parameters for the GalleryImageVersionsClient.BeginCreateOrUpdate
@@ -726,7 +763,8 @@ type GalleryImageVersionsClientGetOptions struct {
 // GalleryImageVersionsClientListByGalleryImageOptions contains the optional parameters for the GalleryImageVersionsClient.NewListByGalleryImagePager
 // method.
 type GalleryImageVersionsClientListByGalleryImageOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // GalleryImagesClientBeginCreateOrUpdateOptions contains the optional parameters for the GalleryImagesClient.BeginCreateOrUpdate
@@ -756,7 +794,8 @@ type GalleryImagesClientGetOptions struct {
 // GalleryImagesClientListByGalleryOptions contains the optional parameters for the GalleryImagesClient.NewListByGalleryPager
 // method.
 type GalleryImagesClientListByGalleryOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // GallerySharingProfileClientBeginUpdateOptions contains the optional parameters for the GallerySharingProfileClient.BeginUpdate
@@ -793,12 +832,14 @@ type ImagesClientGetOptions struct {
 // ImagesClientListByResourceGroupOptions contains the optional parameters for the ImagesClient.NewListByResourceGroupPager
 // method.
 type ImagesClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ImagesClientListOptions contains the optional parameters for the ImagesClient.NewListPager method.
 type ImagesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LogAnalyticsClientBeginExportRequestRateByIntervalOptions contains the optional parameters for the LogAnalyticsClient.BeginExportRequestRateByInterval
@@ -817,7 +858,8 @@ type LogAnalyticsClientBeginExportThrottledRequestsOptions struct {
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 type OperationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ProximityPlacementGroupsClientCreateOrUpdateOptions contains the optional parameters for the ProximityPlacementGroupsClient.CreateOrUpdate
@@ -841,13 +883,15 @@ type ProximityPlacementGroupsClientGetOptions struct {
 // ProximityPlacementGroupsClientListByResourceGroupOptions contains the optional parameters for the ProximityPlacementGroupsClient.NewListByResourceGroupPager
 // method.
 type ProximityPlacementGroupsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ProximityPlacementGroupsClientListBySubscriptionOptions contains the optional parameters for the ProximityPlacementGroupsClient.NewListBySubscriptionPager
 // method.
 type ProximityPlacementGroupsClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ProximityPlacementGroupsClientUpdateOptions contains the optional parameters for the ProximityPlacementGroupsClient.Update
@@ -863,6 +907,9 @@ type ResourceSKUsClientListOptions struct {
 
 	// To Include Extended Locations information or not in the response.
 	IncludeExtendedLocations *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // RestorePointCollectionsClientBeginDeleteOptions contains the optional parameters for the RestorePointCollectionsClient.BeginDelete
@@ -888,13 +935,15 @@ type RestorePointCollectionsClientGetOptions struct {
 // RestorePointCollectionsClientListAllOptions contains the optional parameters for the RestorePointCollectionsClient.NewListAllPager
 // method.
 type RestorePointCollectionsClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // RestorePointCollectionsClientListOptions contains the optional parameters for the RestorePointCollectionsClient.NewListPager
 // method.
 type RestorePointCollectionsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // RestorePointCollectionsClientUpdateOptions contains the optional parameters for the RestorePointCollectionsClient.Update
@@ -946,13 +995,15 @@ type SSHPublicKeysClientGetOptions struct {
 // SSHPublicKeysClientListByResourceGroupOptions contains the optional parameters for the SSHPublicKeysClient.NewListByResourceGroupPager
 // method.
 type SSHPublicKeysClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SSHPublicKeysClientListBySubscriptionOptions contains the optional parameters for the SSHPublicKeysClient.NewListBySubscriptionPager
 // method.
 type SSHPublicKeysClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SSHPublicKeysClientUpdateOptions contains the optional parameters for the SSHPublicKeysClient.Update method.
@@ -967,6 +1018,9 @@ type SharedGalleriesClientGetOptions struct {
 
 // SharedGalleriesClientListOptions contains the optional parameters for the SharedGalleriesClient.NewListPager method.
 type SharedGalleriesClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// The query parameter to decide what shared galleries to fetch when doing listing operations.
 	SharedTo *SharedToValues
 }
@@ -980,6 +1034,9 @@ type SharedGalleryImageVersionsClientGetOptions struct {
 // SharedGalleryImageVersionsClientListOptions contains the optional parameters for the SharedGalleryImageVersionsClient.NewListPager
 // method.
 type SharedGalleryImageVersionsClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// The query parameter to decide what shared galleries to fetch when doing listing operations.
 	SharedTo *SharedToValues
 }
@@ -991,6 +1048,9 @@ type SharedGalleryImagesClientGetOptions struct {
 
 // SharedGalleryImagesClientListOptions contains the optional parameters for the SharedGalleryImagesClient.NewListPager method.
 type SharedGalleryImagesClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// The query parameter to decide what shared galleries to fetch when doing listing operations.
 	SharedTo *SharedToValues
 }
@@ -1034,17 +1094,20 @@ type SnapshotsClientGetOptions struct {
 // SnapshotsClientListByResourceGroupOptions contains the optional parameters for the SnapshotsClient.NewListByResourceGroupPager
 // method.
 type SnapshotsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SnapshotsClientListOptions contains the optional parameters for the SnapshotsClient.NewListPager method.
 type SnapshotsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // UsageClientListOptions contains the optional parameters for the UsageClient.NewListPager method.
 type UsageClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualMachineExtensionImagesClientGetOptions contains the optional parameters for the VirtualMachineExtensionImagesClient.Get
@@ -1209,12 +1272,16 @@ type VirtualMachineRunCommandsClientGetOptions struct {
 type VirtualMachineRunCommandsClientListByVirtualMachineOptions struct {
 	// The expand expression to apply on the operation.
 	Expand *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualMachineRunCommandsClientListOptions contains the optional parameters for the VirtualMachineRunCommandsClient.NewListPager
 // method.
 type VirtualMachineRunCommandsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualMachineScaleSetExtensionsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualMachineScaleSetExtensionsClient.BeginCreateOrUpdate
@@ -1248,7 +1315,8 @@ type VirtualMachineScaleSetExtensionsClientGetOptions struct {
 // VirtualMachineScaleSetExtensionsClientListOptions contains the optional parameters for the VirtualMachineScaleSetExtensionsClient.NewListPager
 // method.
 type VirtualMachineScaleSetExtensionsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientBeginCancelOptions contains the optional parameters for the VirtualMachineScaleSetRollingUpgradesClient.BeginCancel
@@ -1346,6 +1414,9 @@ type VirtualMachineScaleSetVMRunCommandsClientGetOptions struct {
 type VirtualMachineScaleSetVMRunCommandsClientListOptions struct {
 	// The expand expression to apply on the operation.
 	Expand *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualMachineScaleSetVMsClientBeginDeallocateOptions contains the optional parameters for the VirtualMachineScaleSetVMsClient.BeginDeallocate
@@ -1459,6 +1530,9 @@ type VirtualMachineScaleSetVMsClientListOptions struct {
 	// 'properties/latestModelApplied eq true', 'properties/latestModelApplied eq
 	// false'.
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 
 	// The list parameters. Allowed values are 'instanceView', 'instanceView/statuses'.
 	Select *string
@@ -1635,7 +1709,8 @@ type VirtualMachineScaleSetsClientGetInstanceViewOptions struct {
 // VirtualMachineScaleSetsClientGetOSUpgradeHistoryOptions contains the optional parameters for the VirtualMachineScaleSetsClient.NewGetOSUpgradeHistoryPager
 // method.
 type VirtualMachineScaleSetsClientGetOSUpgradeHistoryOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualMachineScaleSetsClientGetOptions contains the optional parameters for the VirtualMachineScaleSetsClient.Get method.
@@ -1648,30 +1723,35 @@ type VirtualMachineScaleSetsClientGetOptions struct {
 // VirtualMachineScaleSetsClientListAllOptions contains the optional parameters for the VirtualMachineScaleSetsClient.NewListAllPager
 // method.
 type VirtualMachineScaleSetsClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualMachineScaleSetsClientListByLocationOptions contains the optional parameters for the VirtualMachineScaleSetsClient.NewListByLocationPager
 // method.
 type VirtualMachineScaleSetsClientListByLocationOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualMachineScaleSetsClientListOptions contains the optional parameters for the VirtualMachineScaleSetsClient.NewListPager
 // method.
 type VirtualMachineScaleSetsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualMachineScaleSetsClientListSKUsOptions contains the optional parameters for the VirtualMachineScaleSetsClient.NewListSKUsPager
 // method.
 type VirtualMachineScaleSetsClientListSKUsOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualMachineSizesClientListOptions contains the optional parameters for the VirtualMachineSizesClient.NewListPager method.
 type VirtualMachineSizesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualMachinesClientBeginAssessPatchesOptions contains the optional parameters for the VirtualMachinesClient.BeginAssessPatches
@@ -1817,6 +1897,9 @@ type VirtualMachinesClientListAllOptions struct {
 	// /subscriptions/{subId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmssName}'
 	Filter *string
 
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// statusOnly=true enables fetching run time status of all Virtual Machines in the subscription.
 	StatusOnly *string
 }
@@ -1824,13 +1907,15 @@ type VirtualMachinesClientListAllOptions struct {
 // VirtualMachinesClientListAvailableSizesOptions contains the optional parameters for the VirtualMachinesClient.NewListAvailableSizesPager
 // method.
 type VirtualMachinesClientListAvailableSizesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualMachinesClientListByLocationOptions contains the optional parameters for the VirtualMachinesClient.NewListByLocationPager
 // method.
 type VirtualMachinesClientListByLocationOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualMachinesClientListOptions contains the optional parameters for the VirtualMachinesClient.NewListPager method.
@@ -1838,6 +1923,9 @@ type VirtualMachinesClientListOptions struct {
 	// The system query option to filter VMs returned in the response. Allowed value is 'virtualMachineScaleSet/id' eq
 	// /subscriptions/{subId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmssName}'
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualMachinesClientRetrieveBootDiagnosticsDataOptions contains the optional parameters for the VirtualMachinesClient.RetrieveBootDiagnosticsData

--- a/packages/autorest.go/test/compute/armcompute/zz_proximityplacementgroups_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_proximityplacementgroups_client.go
@@ -247,8 +247,10 @@ func (client *ProximityPlacementGroupsClient) NewListByResourceGroupPager(resour
 		Fetcher: func(ctx context.Context, page *ProximityPlacementGroupsClientListByResourceGroupResponse) (ProximityPlacementGroupsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ProximityPlacementGroupsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -306,8 +308,10 @@ func (client *ProximityPlacementGroupsClient) NewListBySubscriptionPager(options
 		Fetcher: func(ctx context.Context, page *ProximityPlacementGroupsClientListBySubscriptionResponse) (ProximityPlacementGroupsClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ProximityPlacementGroupsClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_resourceskus_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_resourceskus_client.go
@@ -53,8 +53,10 @@ func (client *ResourceSKUsClient) NewListPager(options *ResourceSKUsClientListOp
 		Fetcher: func(ctx context.Context, page *ResourceSKUsClientListResponse) (ResourceSKUsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ResourceSKUsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_restorepointcollections_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_restorepointcollections_client.go
@@ -271,8 +271,10 @@ func (client *RestorePointCollectionsClient) NewListPager(resourceGroupName stri
 		Fetcher: func(ctx context.Context, page *RestorePointCollectionsClientListResponse) (RestorePointCollectionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "RestorePointCollectionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -332,8 +334,10 @@ func (client *RestorePointCollectionsClient) NewListAllPager(options *RestorePoi
 		Fetcher: func(ctx context.Context, page *RestorePointCollectionsClientListAllResponse) (RestorePointCollectionsClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "RestorePointCollectionsClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_sharedgalleries_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_sharedgalleries_client.go
@@ -119,8 +119,10 @@ func (client *SharedGalleriesClient) NewListPager(location string, options *Shar
 		Fetcher: func(ctx context.Context, page *SharedGalleriesClientListResponse) (SharedGalleriesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SharedGalleriesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, location, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_sharedgalleryimages_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_sharedgalleryimages_client.go
@@ -125,8 +125,10 @@ func (client *SharedGalleryImagesClient) NewListPager(location string, galleryUn
 		Fetcher: func(ctx context.Context, page *SharedGalleryImagesClientListResponse) (SharedGalleryImagesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SharedGalleryImagesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, location, galleryUniqueName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_sharedgalleryimageversions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_sharedgalleryimageversions_client.go
@@ -134,8 +134,10 @@ func (client *SharedGalleryImageVersionsClient) NewListPager(location string, ga
 		Fetcher: func(ctx context.Context, page *SharedGalleryImageVersionsClientListResponse) (SharedGalleryImageVersionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SharedGalleryImageVersionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, location, galleryUniqueName, galleryImageName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_snapshots_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_snapshots_client.go
@@ -360,8 +360,10 @@ func (client *SnapshotsClient) NewListPager(options *SnapshotsClientListOptions)
 		Fetcher: func(ctx context.Context, page *SnapshotsClientListResponse) (SnapshotsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SnapshotsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -416,8 +418,10 @@ func (client *SnapshotsClient) NewListByResourceGroupPager(resourceGroupName str
 		Fetcher: func(ctx context.Context, page *SnapshotsClientListByResourceGroupResponse) (SnapshotsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SnapshotsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_sshpublickeys_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_sshpublickeys_client.go
@@ -309,8 +309,10 @@ func (client *SSHPublicKeysClient) NewListByResourceGroupPager(resourceGroupName
 		Fetcher: func(ctx context.Context, page *SSHPublicKeysClientListByResourceGroupResponse) (SSHPublicKeysClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SSHPublicKeysClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -369,8 +371,10 @@ func (client *SSHPublicKeysClient) NewListBySubscriptionPager(options *SSHPublic
 		Fetcher: func(ctx context.Context, page *SSHPublicKeysClientListBySubscriptionResponse) (SSHPublicKeysClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SSHPublicKeysClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_usage_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_usage_client.go
@@ -55,8 +55,10 @@ func (client *UsageClient) NewListPager(location string, options *UsageClientLis
 		Fetcher: func(ctx context.Context, page *UsageClientListResponse) (UsageClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "UsageClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, location, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachineruncommands_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachineruncommands_client.go
@@ -359,8 +359,10 @@ func (client *VirtualMachineRunCommandsClient) NewListPager(location string, opt
 		Fetcher: func(ctx context.Context, page *VirtualMachineRunCommandsClientListResponse) (VirtualMachineRunCommandsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualMachineRunCommandsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, location, options)
@@ -420,8 +422,10 @@ func (client *VirtualMachineRunCommandsClient) NewListByVirtualMachinePager(reso
 		Fetcher: func(ctx context.Context, page *VirtualMachineRunCommandsClientListByVirtualMachineResponse) (VirtualMachineRunCommandsClientListByVirtualMachineResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualMachineRunCommandsClient.NewListByVirtualMachinePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByVirtualMachineCreateRequest(ctx, resourceGroupName, vmName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachines_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachines_client.go
@@ -809,8 +809,10 @@ func (client *VirtualMachinesClient) NewListPager(resourceGroupName string, opti
 		Fetcher: func(ctx context.Context, page *VirtualMachinesClientListResponse) (VirtualMachinesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualMachinesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -872,8 +874,10 @@ func (client *VirtualMachinesClient) NewListAllPager(options *VirtualMachinesCli
 		Fetcher: func(ctx context.Context, page *VirtualMachinesClientListAllResponse) (VirtualMachinesClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualMachinesClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)
@@ -1000,8 +1004,10 @@ func (client *VirtualMachinesClient) NewListByLocationPager(location string, opt
 		Fetcher: func(ctx context.Context, page *VirtualMachinesClientListByLocationResponse) (VirtualMachinesClientListByLocationResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualMachinesClient.NewListByLocationPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByLocationCreateRequest(ctx, location, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetextensions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetextensions_client.go
@@ -295,8 +295,10 @@ func (client *VirtualMachineScaleSetExtensionsClient) NewListPager(resourceGroup
 		Fetcher: func(ctx context.Context, page *VirtualMachineScaleSetExtensionsClientListResponse) (VirtualMachineScaleSetExtensionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualMachineScaleSetExtensionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesets_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesets_client.go
@@ -651,8 +651,10 @@ func (client *VirtualMachineScaleSetsClient) NewGetOSUpgradeHistoryPager(resourc
 		Fetcher: func(ctx context.Context, page *VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse) (VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualMachineScaleSetsClient.NewGetOSUpgradeHistoryPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getOSUpgradeHistoryCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
@@ -715,8 +717,10 @@ func (client *VirtualMachineScaleSetsClient) NewListPager(resourceGroupName stri
 		Fetcher: func(ctx context.Context, page *VirtualMachineScaleSetsClientListResponse) (VirtualMachineScaleSetsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualMachineScaleSetsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -776,8 +780,10 @@ func (client *VirtualMachineScaleSetsClient) NewListAllPager(options *VirtualMac
 		Fetcher: func(ctx context.Context, page *VirtualMachineScaleSetsClientListAllResponse) (VirtualMachineScaleSetsClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualMachineScaleSetsClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)
@@ -832,8 +838,10 @@ func (client *VirtualMachineScaleSetsClient) NewListByLocationPager(location str
 		Fetcher: func(ctx context.Context, page *VirtualMachineScaleSetsClientListByLocationResponse) (VirtualMachineScaleSetsClientListByLocationResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualMachineScaleSetsClient.NewListByLocationPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByLocationCreateRequest(ctx, location, options)
@@ -894,8 +902,10 @@ func (client *VirtualMachineScaleSetsClient) NewListSKUsPager(resourceGroupName 
 		Fetcher: func(ctx context.Context, page *VirtualMachineScaleSetsClientListSKUsResponse) (VirtualMachineScaleSetsClientListSKUsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualMachineScaleSetsClient.NewListSKUsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listSKUsCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvmruncommands_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvmruncommands_client.go
@@ -311,8 +311,10 @@ func (client *VirtualMachineScaleSetVMRunCommandsClient) NewListPager(resourceGr
 		Fetcher: func(ctx context.Context, page *VirtualMachineScaleSetVMRunCommandsClientListResponse) (VirtualMachineScaleSetVMRunCommandsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualMachineScaleSetVMRunCommandsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceID, options)

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvms_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvms_client.go
@@ -369,8 +369,10 @@ func (client *VirtualMachineScaleSetVMsClient) NewListPager(resourceGroupName st
 		Fetcher: func(ctx context.Context, page *VirtualMachineScaleSetVMsClientListResponse) (VirtualMachineScaleSetVMsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualMachineScaleSetVMsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, options)

--- a/packages/autorest.go/test/consumption/armconsumption/zz_budgets_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_budgets_client.go
@@ -236,8 +236,10 @@ func (client *BudgetsClient) NewListPager(scope string, options *BudgetsClientLi
 		},
 		Fetcher: func(ctx context.Context, page *BudgetsClientListResponse) (BudgetsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, scope, options)

--- a/packages/autorest.go/test/consumption/armconsumption/zz_events_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_events_client.go
@@ -51,8 +51,10 @@ func (client *EventsClient) NewListPager(startDate string, endDate string, scope
 		},
 		Fetcher: func(ctx context.Context, page *EventsClientListResponse) (EventsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, startDate, endDate, scope, options)

--- a/packages/autorest.go/test/consumption/armconsumption/zz_lots_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_lots_client.go
@@ -49,8 +49,10 @@ func (client *LotsClient) NewListPager(scope string, options *LotsClientListOpti
 		},
 		Fetcher: func(ctx context.Context, page *LotsClientListResponse) (LotsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, scope, options)

--- a/packages/autorest.go/test/consumption/armconsumption/zz_marketplaces_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_marketplaces_client.go
@@ -57,8 +57,10 @@ func (client *MarketplacesClient) NewListPager(scope string, options *Marketplac
 		},
 		Fetcher: func(ctx context.Context, page *MarketplacesClientListResponse) (MarketplacesClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, scope, options)

--- a/packages/autorest.go/test/consumption/armconsumption/zz_operations_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_operations_client.go
@@ -45,8 +45,10 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 		},
 		Fetcher: func(ctx context.Context, page *OperationsClientListResponse) (OperationsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/autorest.go/test/consumption/armconsumption/zz_options.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_options.go
@@ -48,7 +48,8 @@ type BudgetsClientGetOptions struct {
 
 // BudgetsClientListOptions contains the optional parameters for the BudgetsClient.NewListPager method.
 type BudgetsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ChargesClientListOptions contains the optional parameters for the ChargesClient.List method.
@@ -77,7 +78,8 @@ type CreditsClientGetOptions struct {
 
 // EventsClientListOptions contains the optional parameters for the EventsClient.NewListPager method.
 type EventsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ForecastsClientListOptions contains the optional parameters for the ForecastsClient.NewListPager method.
@@ -86,11 +88,15 @@ type ForecastsClientListOptions struct {
 	// supports 'eq', 'lt', 'gt', 'le', 'ge', and 'and'. It does not currently
 	// support 'ne', 'or', or 'not'.
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LotsClientListOptions contains the optional parameters for the LotsClient.NewListPager method.
 type LotsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // MarketplacesClientListOptions contains the optional parameters for the MarketplacesClient.NewListPager method.
@@ -99,6 +105,9 @@ type MarketplacesClientListOptions struct {
 	// properties/instanceName or properties/instanceId. The filter supports
 	// 'eq', 'lt', 'gt', 'le', 'ge', and 'and'. It does not currently support 'ne', 'or', or 'not'.
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 
 	// Skiptoken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skiptoken parameter that
@@ -111,7 +120,8 @@ type MarketplacesClientListOptions struct {
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 type OperationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PriceSheetClientGetByBillingPeriodOptions contains the optional parameters for the PriceSheetClient.GetByBillingPeriod
@@ -162,6 +172,9 @@ type ReservationRecommendationsClientListOptions struct {
 	// values ['Last7Days', 'Last30Days', 'Last60Days'] and default value
 	// 'Last7Days'.
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ReservationTransactionsClientListByBillingProfileOptions contains the optional parameters for the ReservationTransactionsClient.NewListByBillingProfilePager
@@ -170,6 +183,9 @@ type ReservationTransactionsClientListByBillingProfileOptions struct {
 	// Filter reservation transactions by date range. The properties/EventDate for start date and end date. The filter supports
 	// 'le' and 'ge'
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ReservationTransactionsClientListOptions contains the optional parameters for the ReservationTransactionsClient.NewListPager
@@ -178,18 +194,23 @@ type ReservationTransactionsClientListOptions struct {
 	// Filter reservation transactions by date range. The properties/EventDate for start date and end date. The filter supports
 	// 'le' and 'ge'
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ReservationsDetailsClientListByReservationOrderAndReservationOptions contains the optional parameters for the ReservationsDetailsClient.NewListByReservationOrderAndReservationPager
 // method.
 type ReservationsDetailsClientListByReservationOrderAndReservationOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ReservationsDetailsClientListByReservationOrderOptions contains the optional parameters for the ReservationsDetailsClient.NewListByReservationOrderPager
 // method.
 type ReservationsDetailsClientListByReservationOrderOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ReservationsDetailsClientListOptions contains the optional parameters for the ReservationsDetailsClient.NewListPager method.
@@ -200,6 +221,9 @@ type ReservationsDetailsClientListOptions struct {
 	// Filter reservation details by date range. The properties/UsageDate for start date and end date. The filter supports 'le'
 	// and 'ge'. Not applicable when querying with billing profile
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 
 	// Reservation Id GUID. Only valid if reservationOrderId is also provided. Filter to a specific reservation
 	ReservationID *string
@@ -216,6 +240,9 @@ type ReservationsDetailsClientListOptions struct {
 type ReservationsSummariesClientListByReservationOrderAndReservationOptions struct {
 	// Required only for daily grain. The properties/UsageDate for start date and end date. The filter supports 'le' and 'ge'
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ReservationsSummariesClientListByReservationOrderOptions contains the optional parameters for the ReservationsSummariesClient.NewListByReservationOrderPager
@@ -223,6 +250,9 @@ type ReservationsSummariesClientListByReservationOrderAndReservationOptions stru
 type ReservationsSummariesClientListByReservationOrderOptions struct {
 	// Required only for daily grain. The properties/UsageDate for start date and end date. The filter supports 'le' and 'ge'
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ReservationsSummariesClientListOptions contains the optional parameters for the ReservationsSummariesClient.NewListPager
@@ -234,6 +264,9 @@ type ReservationsSummariesClientListOptions struct {
 	// The properties/UsageDate for start date and end date. The filter supports 'le' and 'ge'. Not required when querying with
 	// billing profile
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 
 	// Reservation Id GUID. Only valid if reservationOrderId is also provided. Filter to a specific reservation
 	ReservationID *string
@@ -265,6 +298,9 @@ type UsageDetailsClientListOptions struct {
 
 	// Allows to select different type of cost/usage records.
 	Metric *Metrictype
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 
 	// Skiptoken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skiptoken parameter that

--- a/packages/autorest.go/test/consumption/armconsumption/zz_reservationrecommendations_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_reservationrecommendations_client.go
@@ -53,8 +53,10 @@ func (client *ReservationRecommendationsClient) NewListPager(scope string, optio
 		},
 		Fetcher: func(ctx context.Context, page *ReservationRecommendationsClientListResponse) (ReservationRecommendationsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, scope, options)

--- a/packages/autorest.go/test/consumption/armconsumption/zz_reservationsdetails_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_reservationsdetails_client.go
@@ -53,8 +53,10 @@ func (client *ReservationsDetailsClient) NewListPager(scope string, options *Res
 		},
 		Fetcher: func(ctx context.Context, page *ReservationsDetailsClientListResponse) (ReservationsDetailsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, scope, options)
@@ -121,8 +123,10 @@ func (client *ReservationsDetailsClient) NewListByReservationOrderPager(reservat
 		},
 		Fetcher: func(ctx context.Context, page *ReservationsDetailsClientListByReservationOrderResponse) (ReservationsDetailsClientListByReservationOrderResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByReservationOrderCreateRequest(ctx, reservationOrderID, filter, options)
@@ -179,8 +183,10 @@ func (client *ReservationsDetailsClient) NewListByReservationOrderAndReservation
 		},
 		Fetcher: func(ctx context.Context, page *ReservationsDetailsClientListByReservationOrderAndReservationResponse) (ReservationsDetailsClientListByReservationOrderAndReservationResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByReservationOrderAndReservationCreateRequest(ctx, reservationOrderID, reservationID, filter, options)

--- a/packages/autorest.go/test/consumption/armconsumption/zz_reservationssummaries_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_reservationssummaries_client.go
@@ -54,8 +54,10 @@ func (client *ReservationsSummariesClient) NewListPager(scope string, grain Data
 		},
 		Fetcher: func(ctx context.Context, page *ReservationsSummariesClientListResponse) (ReservationsSummariesClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, scope, grain, options)
@@ -122,8 +124,10 @@ func (client *ReservationsSummariesClient) NewListByReservationOrderPager(reserv
 		},
 		Fetcher: func(ctx context.Context, page *ReservationsSummariesClientListByReservationOrderResponse) (ReservationsSummariesClientListByReservationOrderResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByReservationOrderCreateRequest(ctx, reservationOrderID, grain, options)
@@ -182,8 +186,10 @@ func (client *ReservationsSummariesClient) NewListByReservationOrderAndReservati
 		},
 		Fetcher: func(ctx context.Context, page *ReservationsSummariesClientListByReservationOrderAndReservationResponse) (ReservationsSummariesClientListByReservationOrderAndReservationResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByReservationOrderAndReservationCreateRequest(ctx, reservationOrderID, reservationID, grain, options)

--- a/packages/autorest.go/test/consumption/armconsumption/zz_reservationtransactions_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_reservationtransactions_client.go
@@ -50,8 +50,10 @@ func (client *ReservationTransactionsClient) NewListPager(billingAccountID strin
 		},
 		Fetcher: func(ctx context.Context, page *ReservationTransactionsClientListResponse) (ReservationTransactionsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, billingAccountID, options)
@@ -108,8 +110,10 @@ func (client *ReservationTransactionsClient) NewListByBillingProfilePager(billin
 		},
 		Fetcher: func(ctx context.Context, page *ReservationTransactionsClientListByBillingProfileResponse) (ReservationTransactionsClientListByBillingProfileResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByBillingProfileCreateRequest(ctx, billingAccountID, billingProfileID, options)

--- a/packages/autorest.go/test/consumption/armconsumption/zz_usagedetails_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_usagedetails_client.go
@@ -64,8 +64,10 @@ func (client *UsageDetailsClient) NewListPager(scope string, options *UsageDetai
 		},
 		Fetcher: func(ctx context.Context, page *UsageDetailsClientListResponse) (UsageDetailsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, scope, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_addons_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_addons_client.go
@@ -278,8 +278,10 @@ func (client *AddonsClient) NewListByRolePager(deviceName string, roleName strin
 		Fetcher: func(ctx context.Context, page *AddonsClientListByRoleResponse) (AddonsClientListByRoleResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AddonsClient.NewListByRolePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByRoleCreateRequest(ctx, deviceName, roleName, resourceGroupName, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_alerts_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_alerts_client.go
@@ -118,8 +118,10 @@ func (client *AlertsClient) NewListByDataBoxEdgeDevicePager(deviceName string, r
 		Fetcher: func(ctx context.Context, page *AlertsClientListByDataBoxEdgeDeviceResponse) (AlertsClientListByDataBoxEdgeDeviceResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AlertsClient.NewListByDataBoxEdgeDevicePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByDataBoxEdgeDeviceCreateRequest(ctx, deviceName, resourceGroupName, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_availableskus_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_availableskus_client.go
@@ -52,8 +52,10 @@ func (client *AvailableSKUsClient) NewListPager(options *AvailableSKUsClientList
 		Fetcher: func(ctx context.Context, page *AvailableSKUsClientListResponse) (AvailableSKUsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AvailableSKUsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_bandwidthschedules_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_bandwidthschedules_client.go
@@ -264,8 +264,10 @@ func (client *BandwidthSchedulesClient) NewListByDataBoxEdgeDevicePager(deviceNa
 		Fetcher: func(ctx context.Context, page *BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse) (BandwidthSchedulesClientListByDataBoxEdgeDeviceResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "BandwidthSchedulesClient.NewListByDataBoxEdgeDevicePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByDataBoxEdgeDeviceCreateRequest(ctx, deviceName, resourceGroupName, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_containers_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_containers_client.go
@@ -279,8 +279,10 @@ func (client *ContainersClient) NewListByStorageAccountPager(deviceName string, 
 		Fetcher: func(ctx context.Context, page *ContainersClientListByStorageAccountResponse) (ContainersClientListByStorageAccountResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ContainersClient.NewListByStorageAccountPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByStorageAccountCreateRequest(ctx, deviceName, storageAccountName, resourceGroupName, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_devices_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_devices_client.go
@@ -678,8 +678,10 @@ func (client *DevicesClient) NewListByResourceGroupPager(resourceGroupName strin
 		Fetcher: func(ctx context.Context, page *DevicesClientListByResourceGroupResponse) (DevicesClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DevicesClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -739,8 +741,10 @@ func (client *DevicesClient) NewListBySubscriptionPager(options *DevicesClientLi
 		Fetcher: func(ctx context.Context, page *DevicesClientListBySubscriptionResponse) (DevicesClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DevicesClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_monitoringconfig_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_monitoringconfig_client.go
@@ -265,8 +265,10 @@ func (client *MonitoringConfigClient) NewListPager(deviceName string, roleName s
 		Fetcher: func(ctx context.Context, page *MonitoringConfigClientListResponse) (MonitoringConfigClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "MonitoringConfigClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, deviceName, roleName, resourceGroupName, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_nodes_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_nodes_client.go
@@ -55,8 +55,10 @@ func (client *NodesClient) NewListByDataBoxEdgeDevicePager(deviceName string, re
 		Fetcher: func(ctx context.Context, page *NodesClientListByDataBoxEdgeDeviceResponse) (NodesClientListByDataBoxEdgeDeviceResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "NodesClient.NewListByDataBoxEdgeDevicePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByDataBoxEdgeDeviceCreateRequest(ctx, deviceName, resourceGroupName, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_operations_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_operations_client.go
@@ -46,8 +46,10 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 		Fetcher: func(ctx context.Context, page *OperationsClientListResponse) (OperationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "OperationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_options.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_options.go
@@ -24,7 +24,8 @@ type AddonsClientGetOptions struct {
 
 // AddonsClientListByRoleOptions contains the optional parameters for the AddonsClient.NewListByRolePager method.
 type AddonsClientListByRoleOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AlertsClientGetOptions contains the optional parameters for the AlertsClient.Get method.
@@ -35,12 +36,14 @@ type AlertsClientGetOptions struct {
 // AlertsClientListByDataBoxEdgeDeviceOptions contains the optional parameters for the AlertsClient.NewListByDataBoxEdgeDevicePager
 // method.
 type AlertsClientListByDataBoxEdgeDeviceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AvailableSKUsClientListOptions contains the optional parameters for the AvailableSKUsClient.NewListPager method.
 type AvailableSKUsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // BandwidthSchedulesClientBeginCreateOrUpdateOptions contains the optional parameters for the BandwidthSchedulesClient.BeginCreateOrUpdate
@@ -65,7 +68,8 @@ type BandwidthSchedulesClientGetOptions struct {
 // BandwidthSchedulesClientListByDataBoxEdgeDeviceOptions contains the optional parameters for the BandwidthSchedulesClient.NewListByDataBoxEdgeDevicePager
 // method.
 type BandwidthSchedulesClientListByDataBoxEdgeDeviceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ContainersClientBeginCreateOrUpdateOptions contains the optional parameters for the ContainersClient.BeginCreateOrUpdate
@@ -95,7 +99,8 @@ type ContainersClientGetOptions struct {
 // ContainersClientListByStorageAccountOptions contains the optional parameters for the ContainersClient.NewListByStorageAccountPager
 // method.
 type ContainersClientListByStorageAccountOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DevicesClientBeginCreateOrUpdateSecuritySettingsOptions contains the optional parameters for the DevicesClient.BeginCreateOrUpdateSecuritySettings
@@ -166,6 +171,9 @@ type DevicesClientListByResourceGroupOptions struct {
 	// Specify $expand=details to populate additional fields related to the resource or Specify $skipToken= to populate the next
 	// page in the list.
 	Expand *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DevicesClientListBySubscriptionOptions contains the optional parameters for the DevicesClient.NewListBySubscriptionPager
@@ -174,6 +182,9 @@ type DevicesClientListBySubscriptionOptions struct {
 	// Specify $expand=details to populate additional fields related to the resource or Specify $skipToken= to populate the next
 	// page in the list.
 	Expand *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DevicesClientUpdateExtendedInformationOptions contains the optional parameters for the DevicesClient.UpdateExtendedInformation
@@ -243,18 +254,21 @@ type MonitoringConfigClientGetOptions struct {
 
 // MonitoringConfigClientListOptions contains the optional parameters for the MonitoringConfigClient.NewListPager method.
 type MonitoringConfigClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // NodesClientListByDataBoxEdgeDeviceOptions contains the optional parameters for the NodesClient.NewListByDataBoxEdgeDevicePager
 // method.
 type NodesClientListByDataBoxEdgeDeviceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 type OperationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // OperationsStatusClientGetOptions contains the optional parameters for the OperationsStatusClient.Get method.
@@ -282,7 +296,8 @@ type OrdersClientGetOptions struct {
 // OrdersClientListByDataBoxEdgeDeviceOptions contains the optional parameters for the OrdersClient.NewListByDataBoxEdgeDevicePager
 // method.
 type OrdersClientListByDataBoxEdgeDeviceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // OrdersClientListDCAccessCodeOptions contains the optional parameters for the OrdersClient.ListDCAccessCode method.
@@ -310,7 +325,8 @@ type RolesClientGetOptions struct {
 // RolesClientListByDataBoxEdgeDeviceOptions contains the optional parameters for the RolesClient.NewListByDataBoxEdgeDevicePager
 // method.
 type RolesClientListByDataBoxEdgeDeviceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SharesClientBeginCreateOrUpdateOptions contains the optional parameters for the SharesClient.BeginCreateOrUpdate method.
@@ -339,7 +355,8 @@ type SharesClientGetOptions struct {
 // SharesClientListByDataBoxEdgeDeviceOptions contains the optional parameters for the SharesClient.NewListByDataBoxEdgeDevicePager
 // method.
 type SharesClientListByDataBoxEdgeDeviceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // StorageAccountCredentialsClientBeginCreateOrUpdateOptions contains the optional parameters for the StorageAccountCredentialsClient.BeginCreateOrUpdate
@@ -365,7 +382,8 @@ type StorageAccountCredentialsClientGetOptions struct {
 // StorageAccountCredentialsClientListByDataBoxEdgeDeviceOptions contains the optional parameters for the StorageAccountCredentialsClient.NewListByDataBoxEdgeDevicePager
 // method.
 type StorageAccountCredentialsClientListByDataBoxEdgeDeviceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // StorageAccountsClientBeginCreateOrUpdateOptions contains the optional parameters for the StorageAccountsClient.BeginCreateOrUpdate
@@ -389,7 +407,8 @@ type StorageAccountsClientGetOptions struct {
 // StorageAccountsClientListByDataBoxEdgeDeviceOptions contains the optional parameters for the StorageAccountsClient.NewListByDataBoxEdgeDevicePager
 // method.
 type StorageAccountsClientListByDataBoxEdgeDeviceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SupportPackagesClientBeginTriggerSupportPackageOptions contains the optional parameters for the SupportPackagesClient.BeginTriggerSupportPackage
@@ -421,6 +440,9 @@ type TriggersClientGetOptions struct {
 type TriggersClientListByDataBoxEdgeDeviceOptions struct {
 	// Specify $filter='CustomContextTag eq ' to filter on custom context tag property
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // UsersClientBeginCreateOrUpdateOptions contains the optional parameters for the UsersClient.BeginCreateOrUpdate method.
@@ -445,4 +467,7 @@ type UsersClientGetOptions struct {
 type UsersClientListByDataBoxEdgeDeviceOptions struct {
 	// Specify $filter='Type eq ' to filter on user type property
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_orders_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_orders_client.go
@@ -248,8 +248,10 @@ func (client *OrdersClient) NewListByDataBoxEdgeDevicePager(deviceName string, r
 		Fetcher: func(ctx context.Context, page *OrdersClientListByDataBoxEdgeDeviceResponse) (OrdersClientListByDataBoxEdgeDeviceResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "OrdersClient.NewListByDataBoxEdgeDevicePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByDataBoxEdgeDeviceCreateRequest(ctx, deviceName, resourceGroupName, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_roles_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_roles_client.go
@@ -263,8 +263,10 @@ func (client *RolesClient) NewListByDataBoxEdgeDevicePager(deviceName string, re
 		Fetcher: func(ctx context.Context, page *RolesClientListByDataBoxEdgeDeviceResponse) (RolesClientListByDataBoxEdgeDeviceResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "RolesClient.NewListByDataBoxEdgeDevicePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByDataBoxEdgeDeviceCreateRequest(ctx, deviceName, resourceGroupName, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_shares_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_shares_client.go
@@ -263,8 +263,10 @@ func (client *SharesClient) NewListByDataBoxEdgeDevicePager(deviceName string, r
 		Fetcher: func(ctx context.Context, page *SharesClientListByDataBoxEdgeDeviceResponse) (SharesClientListByDataBoxEdgeDeviceResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SharesClient.NewListByDataBoxEdgeDevicePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByDataBoxEdgeDeviceCreateRequest(ctx, deviceName, resourceGroupName, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_storageaccountcredentials_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_storageaccountcredentials_client.go
@@ -265,8 +265,10 @@ func (client *StorageAccountCredentialsClient) NewListByDataBoxEdgeDevicePager(d
 		Fetcher: func(ctx context.Context, page *StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse) (StorageAccountCredentialsClientListByDataBoxEdgeDeviceResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "StorageAccountCredentialsClient.NewListByDataBoxEdgeDevicePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByDataBoxEdgeDeviceCreateRequest(ctx, deviceName, resourceGroupName, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_storageaccounts_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_storageaccounts_client.go
@@ -264,8 +264,10 @@ func (client *StorageAccountsClient) NewListByDataBoxEdgeDevicePager(deviceName 
 		Fetcher: func(ctx context.Context, page *StorageAccountsClientListByDataBoxEdgeDeviceResponse) (StorageAccountsClientListByDataBoxEdgeDeviceResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "StorageAccountsClient.NewListByDataBoxEdgeDevicePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByDataBoxEdgeDeviceCreateRequest(ctx, deviceName, resourceGroupName, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_triggers_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_triggers_client.go
@@ -263,8 +263,10 @@ func (client *TriggersClient) NewListByDataBoxEdgeDevicePager(deviceName string,
 		Fetcher: func(ctx context.Context, page *TriggersClientListByDataBoxEdgeDeviceResponse) (TriggersClientListByDataBoxEdgeDeviceResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "TriggersClient.NewListByDataBoxEdgeDevicePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByDataBoxEdgeDeviceCreateRequest(ctx, deviceName, resourceGroupName, options)

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_users_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_users_client.go
@@ -264,8 +264,10 @@ func (client *UsersClient) NewListByDataBoxEdgeDevicePager(deviceName string, re
 		Fetcher: func(ctx context.Context, page *UsersClientListByDataBoxEdgeDeviceResponse) (UsersClientListByDataBoxEdgeDeviceResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "UsersClient.NewListByDataBoxEdgeDevicePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByDataBoxEdgeDeviceCreateRequest(ctx, deviceName, resourceGroupName, options)

--- a/packages/autorest.go/test/keyvault/azkeyvault/zz_client.go
+++ b/packages/autorest.go/test/keyvault/azkeyvault/zz_client.go
@@ -1314,8 +1314,10 @@ func (client *Client) NewGetCertificateIssuersPager(vaultBaseURL string, options
 		},
 		Fetcher: func(ctx context.Context, page *ClientGetCertificateIssuersResponse) (ClientGetCertificateIssuersResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getCertificateIssuersCreateRequest(ctx, vaultBaseURL, options)
@@ -1482,8 +1484,10 @@ func (client *Client) NewGetCertificateVersionsPager(vaultBaseURL string, certif
 		},
 		Fetcher: func(ctx context.Context, page *ClientGetCertificateVersionsResponse) (ClientGetCertificateVersionsResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getCertificateVersionsCreateRequest(ctx, vaultBaseURL, certificateName, options)
@@ -1541,8 +1545,10 @@ func (client *Client) NewGetCertificatesPager(vaultBaseURL string, options *Clie
 		},
 		Fetcher: func(ctx context.Context, page *ClientGetCertificatesResponse) (ClientGetCertificatesResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getCertificatesCreateRequest(ctx, vaultBaseURL, options)
@@ -1658,8 +1664,10 @@ func (client *Client) NewGetDeletedCertificatesPager(vaultBaseURL string, option
 		},
 		Fetcher: func(ctx context.Context, page *ClientGetDeletedCertificatesResponse) (ClientGetDeletedCertificatesResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getDeletedCertificatesCreateRequest(ctx, vaultBaseURL, options)
@@ -1775,8 +1783,10 @@ func (client *Client) NewGetDeletedKeysPager(vaultBaseURL string, options *Clien
 		},
 		Fetcher: func(ctx context.Context, page *ClientGetDeletedKeysResponse) (ClientGetDeletedKeysResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getDeletedKeysCreateRequest(ctx, vaultBaseURL, options)
@@ -1893,8 +1903,10 @@ func (client *Client) NewGetDeletedSasDefinitionsPager(vaultBaseURL string, stor
 		},
 		Fetcher: func(ctx context.Context, page *ClientGetDeletedSasDefinitionsResponse) (ClientGetDeletedSasDefinitionsResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getDeletedSasDefinitionsCreateRequest(ctx, vaultBaseURL, storageAccountName, options)
@@ -2007,8 +2019,10 @@ func (client *Client) NewGetDeletedSecretsPager(vaultBaseURL string, options *Cl
 		},
 		Fetcher: func(ctx context.Context, page *ClientGetDeletedSecretsResponse) (ClientGetDeletedSecretsResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getDeletedSecretsCreateRequest(ctx, vaultBaseURL, options)
@@ -2119,8 +2133,10 @@ func (client *Client) NewGetDeletedStorageAccountsPager(vaultBaseURL string, opt
 		},
 		Fetcher: func(ctx context.Context, page *ClientGetDeletedStorageAccountsResponse) (ClientGetDeletedStorageAccountsResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getDeletedStorageAccountsCreateRequest(ctx, vaultBaseURL, options)
@@ -2236,8 +2252,10 @@ func (client *Client) NewGetKeyVersionsPager(vaultBaseURL string, keyName string
 		},
 		Fetcher: func(ctx context.Context, page *ClientGetKeyVersionsResponse) (ClientGetKeyVersionsResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getKeyVersionsCreateRequest(ctx, vaultBaseURL, keyName, options)
@@ -2297,8 +2315,10 @@ func (client *Client) NewGetKeysPager(vaultBaseURL string, options *ClientGetKey
 		},
 		Fetcher: func(ctx context.Context, page *ClientGetKeysResponse) (ClientGetKeysResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getKeysCreateRequest(ctx, vaultBaseURL, options)
@@ -2413,8 +2433,10 @@ func (client *Client) NewGetSasDefinitionsPager(vaultBaseURL string, storageAcco
 		},
 		Fetcher: func(ctx context.Context, page *ClientGetSasDefinitionsResponse) (ClientGetSasDefinitionsResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getSasDefinitionsCreateRequest(ctx, vaultBaseURL, storageAccountName, options)
@@ -2534,8 +2556,10 @@ func (client *Client) NewGetSecretVersionsPager(vaultBaseURL string, secretName 
 		},
 		Fetcher: func(ctx context.Context, page *ClientGetSecretVersionsResponse) (ClientGetSecretVersionsResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getSecretVersionsCreateRequest(ctx, vaultBaseURL, secretName, options)
@@ -2594,8 +2618,10 @@ func (client *Client) NewGetSecretsPager(vaultBaseURL string, options *ClientGet
 		},
 		Fetcher: func(ctx context.Context, page *ClientGetSecretsResponse) (ClientGetSecretsResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getSecretsCreateRequest(ctx, vaultBaseURL, options)
@@ -2703,8 +2729,10 @@ func (client *Client) NewGetStorageAccountsPager(vaultBaseURL string, options *C
 		},
 		Fetcher: func(ctx context.Context, page *ClientGetStorageAccountsResponse) (ClientGetStorageAccountsResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getStorageAccountsCreateRequest(ctx, vaultBaseURL, options)

--- a/packages/autorest.go/test/keyvault/azkeyvault/zz_options.go
+++ b/packages/autorest.go/test/keyvault/azkeyvault/zz_options.go
@@ -133,6 +133,9 @@ type ClientGetCertificateIssuersOptions struct {
 	// and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should
 	// enumerate all pages until the nextLink becomes null.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ClientGetCertificateOperationOptions contains the optional parameters for the Client.GetCertificateOperation method.
@@ -159,6 +162,9 @@ type ClientGetCertificateVersionsOptions struct {
 	// and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should
 	// enumerate all pages until the nextLink becomes null.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ClientGetCertificatesOptions contains the optional parameters for the Client.NewGetCertificatesPager method.
@@ -173,6 +179,9 @@ type ClientGetCertificatesOptions struct {
 	// and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should
 	// enumerate all pages until the nextLink becomes null.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ClientGetDeletedCertificateOptions contains the optional parameters for the Client.GetDeletedCertificate method.
@@ -192,6 +201,9 @@ type ClientGetDeletedCertificatesOptions struct {
 	// and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should
 	// enumerate all pages until the nextLink becomes null.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ClientGetDeletedKeyOptions contains the optional parameters for the Client.GetDeletedKey method.
@@ -208,6 +220,9 @@ type ClientGetDeletedKeysOptions struct {
 	// and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should
 	// enumerate all pages until the nextLink becomes null.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ClientGetDeletedSasDefinitionOptions contains the optional parameters for the Client.GetDeletedSasDefinition method.
@@ -225,6 +240,9 @@ type ClientGetDeletedSasDefinitionsOptions struct {
 	// and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should
 	// enumerate all pages until the nextLink becomes null.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ClientGetDeletedSecretOptions contains the optional parameters for the Client.GetDeletedSecret method.
@@ -241,6 +259,9 @@ type ClientGetDeletedSecretsOptions struct {
 	// and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should
 	// enumerate all pages until the nextLink becomes null.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ClientGetDeletedStorageAccountOptions contains the optional parameters for the Client.GetDeletedStorageAccount method.
@@ -258,6 +279,9 @@ type ClientGetDeletedStorageAccountsOptions struct {
 	// and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should
 	// enumerate all pages until the nextLink becomes null.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ClientGetKeyOptions contains the optional parameters for the Client.GetKey method.
@@ -274,6 +298,9 @@ type ClientGetKeyVersionsOptions struct {
 	// and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should
 	// enumerate all pages until the nextLink becomes null.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ClientGetKeysOptions contains the optional parameters for the Client.NewGetKeysPager method.
@@ -285,6 +312,9 @@ type ClientGetKeysOptions struct {
 	// and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should
 	// enumerate all pages until the nextLink becomes null.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ClientGetSasDefinitionOptions contains the optional parameters for the Client.GetSasDefinition method.
@@ -301,6 +331,9 @@ type ClientGetSasDefinitionsOptions struct {
 	// and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should
 	// enumerate all pages until the nextLink becomes null.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ClientGetSecretOptions contains the optional parameters for the Client.GetSecret method.
@@ -317,6 +350,9 @@ type ClientGetSecretVersionsOptions struct {
 	// and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should
 	// enumerate all pages until the nextLink becomes null.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ClientGetSecretsOptions contains the optional parameters for the Client.NewGetSecretsPager method.
@@ -328,6 +364,9 @@ type ClientGetSecretsOptions struct {
 	// and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should
 	// enumerate all pages until the nextLink becomes null.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ClientGetStorageAccountOptions contains the optional parameters for the Client.GetStorageAccount method.
@@ -344,6 +383,9 @@ type ClientGetStorageAccountsOptions struct {
 	// and also return a nextLink. Clients should not make any assumptions on the minimum number of results per page, and should
 	// enumerate all pages until the nextLink becomes null.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ClientImportCertificateOptions contains the optional parameters for the Client.ImportCertificate method.
@@ -576,6 +618,9 @@ type RoleAssignmentsClientListForScopeOptions struct {
 	// eq {id} to return all role assignments at, above or below the
 	// scope for the specified principal.
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // RoleDefinitionsClientCreateOrUpdateOptions contains the optional parameters for the RoleDefinitionsClient.CreateOrUpdate
@@ -598,4 +643,7 @@ type RoleDefinitionsClientGetOptions struct {
 type RoleDefinitionsClientListOptions struct {
 	// The filter to apply on the operation. Use atScopeAndBelow filter to search below the given scope as well.
 	Filter *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/autorest.go/test/keyvault/azkeyvault/zz_roleassignments_client.go
+++ b/packages/autorest.go/test/keyvault/azkeyvault/zz_roleassignments_client.go
@@ -208,8 +208,10 @@ func (client *RoleAssignmentsClient) NewListForScopePager(vaultBaseURL string, s
 		},
 		Fetcher: func(ctx context.Context, page *RoleAssignmentsClientListForScopeResponse) (RoleAssignmentsClientListForScopeResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listForScopeCreateRequest(ctx, vaultBaseURL, scope, options)

--- a/packages/autorest.go/test/keyvault/azkeyvault/zz_roledefinitions_client.go
+++ b/packages/autorest.go/test/keyvault/azkeyvault/zz_roledefinitions_client.go
@@ -209,8 +209,10 @@ func (client *RoleDefinitionsClient) NewListPager(vaultBaseURL string, scope str
 		},
 		Fetcher: func(ctx context.Context, page *RoleDefinitionsClientListResponse) (RoleDefinitionsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, vaultBaseURL, scope, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_batchdeployments_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_batchdeployments_client.go
@@ -286,8 +286,10 @@ func (client *BatchDeploymentsClient) NewListPager(resourceGroupName string, wor
 		},
 		Fetcher: func(ctx context.Context, page *BatchDeploymentsClientListResponse) (BatchDeploymentsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, endpointName, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_batchendpoints_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_batchendpoints_client.go
@@ -269,8 +269,10 @@ func (client *BatchEndpointsClient) NewListPager(resourceGroupName string, works
 		},
 		Fetcher: func(ctx context.Context, page *BatchEndpointsClientListResponse) (BatchEndpointsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_codecontainers_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_codecontainers_client.go
@@ -243,8 +243,10 @@ func (client *CodeContainersClient) NewListPager(resourceGroupName string, works
 		},
 		Fetcher: func(ctx context.Context, page *CodeContainersClientListResponse) (CodeContainersClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_codeversions_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_codeversions_client.go
@@ -260,8 +260,10 @@ func (client *CodeVersionsClient) NewListPager(resourceGroupName string, workspa
 		},
 		Fetcher: func(ctx context.Context, page *CodeVersionsClientListResponse) (CodeVersionsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, name, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_componentcontainers_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_componentcontainers_client.go
@@ -245,8 +245,10 @@ func (client *ComponentContainersClient) NewListPager(resourceGroupName string, 
 		},
 		Fetcher: func(ctx context.Context, page *ComponentContainersClientListResponse) (ComponentContainersClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_componentversions_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_componentversions_client.go
@@ -262,8 +262,10 @@ func (client *ComponentVersionsClient) NewListPager(resourceGroupName string, wo
 		},
 		Fetcher: func(ctx context.Context, page *ComponentVersionsClientListResponse) (ComponentVersionsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, name, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_compute_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_compute_client.go
@@ -275,8 +275,10 @@ func (client *ComputeClient) NewListPager(resourceGroupName string, workspaceNam
 		},
 		Fetcher: func(ctx context.Context, page *ComputeClientListResponse) (ComputeClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, options)
@@ -406,8 +408,10 @@ func (client *ComputeClient) NewListNodesPager(resourceGroupName string, workspa
 		},
 		Fetcher: func(ctx context.Context, page *ComputeClientListNodesResponse) (ComputeClientListNodesResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listNodesCreateRequest(ctx, resourceGroupName, workspaceName, computeName, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_datacontainers_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_datacontainers_client.go
@@ -243,8 +243,10 @@ func (client *DataContainersClient) NewListPager(resourceGroupName string, works
 		},
 		Fetcher: func(ctx context.Context, page *DataContainersClientListResponse) (DataContainersClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_datastores_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_datastores_client.go
@@ -247,8 +247,10 @@ func (client *DatastoresClient) NewListPager(resourceGroupName string, workspace
 		},
 		Fetcher: func(ctx context.Context, page *DatastoresClientListResponse) (DatastoresClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_dataversions_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_dataversions_client.go
@@ -260,8 +260,10 @@ func (client *DataVersionsClient) NewListPager(resourceGroupName string, workspa
 		},
 		Fetcher: func(ctx context.Context, page *DataVersionsClientListResponse) (DataVersionsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, name, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_environmentcontainers_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_environmentcontainers_client.go
@@ -246,8 +246,10 @@ func (client *EnvironmentContainersClient) NewListPager(resourceGroupName string
 		},
 		Fetcher: func(ctx context.Context, page *EnvironmentContainersClientListResponse) (EnvironmentContainersClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_environmentversions_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_environmentversions_client.go
@@ -262,8 +262,10 @@ func (client *EnvironmentVersionsClient) NewListPager(resourceGroupName string, 
 		},
 		Fetcher: func(ctx context.Context, page *EnvironmentVersionsClientListResponse) (EnvironmentVersionsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, name, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_jobs_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_jobs_client.go
@@ -315,8 +315,10 @@ func (client *JobsClient) NewListPager(resourceGroupName string, workspaceName s
 		},
 		Fetcher: func(ctx context.Context, page *JobsClientListResponse) (JobsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_modelcontainers_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_modelcontainers_client.go
@@ -245,8 +245,10 @@ func (client *ModelContainersClient) NewListPager(resourceGroupName string, work
 		},
 		Fetcher: func(ctx context.Context, page *ModelContainersClientListResponse) (ModelContainersClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_modelversions_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_modelversions_client.go
@@ -260,8 +260,10 @@ func (client *ModelVersionsClient) NewListPager(resourceGroupName string, worksp
 		},
 		Fetcher: func(ctx context.Context, page *ModelVersionsClientListResponse) (ModelVersionsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, name, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_onlinedeployments_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_onlinedeployments_client.go
@@ -361,8 +361,10 @@ func (client *OnlineDeploymentsClient) NewListPager(resourceGroupName string, wo
 		},
 		Fetcher: func(ctx context.Context, page *OnlineDeploymentsClientListResponse) (OnlineDeploymentsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, endpointName, options)
@@ -439,8 +441,10 @@ func (client *OnlineDeploymentsClient) NewListSKUsPager(resourceGroupName string
 		},
 		Fetcher: func(ctx context.Context, page *OnlineDeploymentsClientListSKUsResponse) (OnlineDeploymentsClientListSKUsResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listSKUsCreateRequest(ctx, resourceGroupName, workspaceName, endpointName, deploymentName, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_onlineendpoints_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_onlineendpoints_client.go
@@ -336,8 +336,10 @@ func (client *OnlineEndpointsClient) NewListPager(resourceGroupName string, work
 		},
 		Fetcher: func(ctx context.Context, page *OnlineEndpointsClientListResponse) (OnlineEndpointsClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_options.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_options.go
@@ -31,6 +31,9 @@ type BatchDeploymentsClientGetOptions struct {
 
 // BatchDeploymentsClientListOptions contains the optional parameters for the BatchDeploymentsClient.NewListPager method.
 type BatchDeploymentsClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Ordering of list.
 	OrderBy *string
 
@@ -75,6 +78,9 @@ type BatchEndpointsClientListOptions struct {
 	// Number of endpoints to be retrieved in a page of results.
 	Count *int32
 
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Continuation token for pagination.
 	Skip *string
 }
@@ -97,6 +103,9 @@ type CodeContainersClientGetOptions struct {
 
 // CodeContainersClientListOptions contains the optional parameters for the CodeContainersClient.NewListPager method.
 type CodeContainersClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Continuation token for pagination.
 	Skip *string
 }
@@ -118,6 +127,9 @@ type CodeVersionsClientGetOptions struct {
 
 // CodeVersionsClientListOptions contains the optional parameters for the CodeVersionsClient.NewListPager method.
 type CodeVersionsClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Ordering of list.
 	OrderBy *string
 
@@ -149,6 +161,9 @@ type ComponentContainersClientListOptions struct {
 	// View type for including/excluding (for example) archived entities.
 	ListViewType *ListViewType
 
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Continuation token for pagination.
 	Skip *string
 }
@@ -173,6 +188,9 @@ type ComponentVersionsClientGetOptions struct {
 type ComponentVersionsClientListOptions struct {
 	// View type for including/excluding (for example) archived entities.
 	ListViewType *ListViewType
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 
 	// Ordering of list.
 	OrderBy *string
@@ -232,11 +250,15 @@ type ComputeClientListKeysOptions struct {
 
 // ComputeClientListNodesOptions contains the optional parameters for the ComputeClient.NewListNodesPager method.
 type ComputeClientListNodesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ComputeClientListOptions contains the optional parameters for the ComputeClient.NewListPager method.
 type ComputeClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Continuation token for pagination.
 	Skip *string
 }
@@ -262,6 +284,9 @@ type DataContainersClientListOptions struct {
 	// View type for including/excluding (for example) archived entities.
 	ListViewType *ListViewType
 
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Continuation token for pagination.
 	Skip *string
 }
@@ -286,6 +311,9 @@ type DataVersionsClientListOptions struct {
 	// [ListViewType.ActiveOnly, ListViewType.ArchivedOnly, ListViewType.All]View type for including/excluding (for example) archived
 	// entities.
 	ListViewType *ListViewType
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 
 	// Please choose OrderBy value from ['createdtime', 'modifiedtime']
 	OrderBy *string
@@ -328,6 +356,9 @@ type DatastoresClientListOptions struct {
 	// Names of datastores to return.
 	Names []string
 
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Order by property (createdtime | modifiedtime | name).
 	OrderBy *string
 
@@ -368,6 +399,9 @@ type EnvironmentContainersClientListOptions struct {
 	// View type for including/excluding (for example) archived entities.
 	ListViewType *ListViewType
 
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Continuation token for pagination.
 	Skip *string
 }
@@ -392,6 +426,9 @@ type EnvironmentVersionsClientGetOptions struct {
 type EnvironmentVersionsClientListOptions struct {
 	// View type for including/excluding (for example) archived entities.
 	ListViewType *ListViewType
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 
 	// Ordering of list.
 	OrderBy *string
@@ -432,6 +469,9 @@ type JobsClientListOptions struct {
 	// View type for including/excluding (for example) archived entities.
 	ListViewType *ListViewType
 
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// The scheduled id for listing the job triggered from
 	ScheduleID *string
 
@@ -469,6 +509,9 @@ type ModelContainersClientListOptions struct {
 	// View type for including/excluding (for example) archived entities.
 	ListViewType *ListViewType
 
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Continuation token for pagination.
 	Skip *string
 }
@@ -498,6 +541,9 @@ type ModelVersionsClientListOptions struct {
 
 	// View type for including/excluding (for example) archived entities.
 	ListViewType *ListViewType
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 
 	// Number of initial results to skip.
 	Offset *int32
@@ -554,6 +600,9 @@ type OnlineDeploymentsClientGetOptions struct {
 
 // OnlineDeploymentsClientListOptions contains the optional parameters for the OnlineDeploymentsClient.NewListPager method.
 type OnlineDeploymentsClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Ordering of list.
 	OrderBy *string
 
@@ -569,6 +618,9 @@ type OnlineDeploymentsClientListOptions struct {
 type OnlineDeploymentsClientListSKUsOptions struct {
 	// Number of Skus to be retrieved in a page of results.
 	Count *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 
 	// Continuation token for pagination.
 	Skip *string
@@ -626,6 +678,9 @@ type OnlineEndpointsClientListOptions struct {
 	// Name of the endpoint.
 	Name *string
 
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// The option to order the response.
 	OrderBy *OrderString
 
@@ -643,7 +698,8 @@ type OnlineEndpointsClientListOptions struct {
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 type OperationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PrivateEndpointConnectionsClientCreateOrUpdateOptions contains the optional parameters for the PrivateEndpointConnectionsClient.CreateOrUpdate
@@ -667,7 +723,8 @@ type PrivateEndpointConnectionsClientGetOptions struct {
 // PrivateEndpointConnectionsClientListOptions contains the optional parameters for the PrivateEndpointConnectionsClient.NewListPager
 // method.
 type PrivateEndpointConnectionsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PrivateLinkResourcesClientListOptions contains the optional parameters for the PrivateLinkResourcesClient.List method.
@@ -677,7 +734,8 @@ type PrivateLinkResourcesClientListOptions struct {
 
 // QuotasClientListOptions contains the optional parameters for the QuotasClient.NewListPager method.
 type QuotasClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // QuotasClientUpdateOptions contains the optional parameters for the QuotasClient.Update method.
@@ -687,7 +745,8 @@ type QuotasClientUpdateOptions struct {
 
 // UsagesClientListOptions contains the optional parameters for the UsagesClient.NewListPager method.
 type UsagesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualMachineSizesClientListOptions contains the optional parameters for the VirtualMachineSizesClient.List method.
@@ -716,13 +775,17 @@ type WorkspaceConnectionsClientListOptions struct {
 	// Category of the workspace connection.
 	Category *string
 
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Target of the workspace connection.
 	Target *string
 }
 
 // WorkspaceFeaturesClientListOptions contains the optional parameters for the WorkspaceFeaturesClient.NewListPager method.
 type WorkspaceFeaturesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // WorkspacesClientBeginCreateOrUpdateOptions contains the optional parameters for the WorkspacesClient.BeginCreateOrUpdate
@@ -774,6 +837,9 @@ type WorkspacesClientGetOptions struct {
 // WorkspacesClientListByResourceGroupOptions contains the optional parameters for the WorkspacesClient.NewListByResourceGroupPager
 // method.
 type WorkspacesClientListByResourceGroupOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Continuation token for pagination.
 	Skip *string
 }
@@ -781,6 +847,9 @@ type WorkspacesClientListByResourceGroupOptions struct {
 // WorkspacesClientListBySubscriptionOptions contains the optional parameters for the WorkspacesClient.NewListBySubscriptionPager
 // method.
 type WorkspacesClientListBySubscriptionOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Continuation token for pagination.
 	Skip *string
 }

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_quotas_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_quotas_client.go
@@ -52,8 +52,10 @@ func (client *QuotasClient) NewListPager(location string, options *QuotasClientL
 		},
 		Fetcher: func(ctx context.Context, page *QuotasClientListResponse) (QuotasClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, location, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_usages_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_usages_client.go
@@ -52,8 +52,10 @@ func (client *UsagesClient) NewListPager(location string, options *UsagesClientL
 		},
 		Fetcher: func(ctx context.Context, page *UsagesClientListResponse) (UsagesClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, location, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspacefeatures_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspacefeatures_client.go
@@ -54,8 +54,10 @@ func (client *WorkspaceFeaturesClient) NewListPager(resourceGroupName string, wo
 		},
 		Fetcher: func(ctx context.Context, page *WorkspaceFeaturesClientListResponse) (WorkspaceFeaturesClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, workspaceName, options)

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspaces_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspaces_client.go
@@ -328,8 +328,10 @@ func (client *WorkspacesClient) NewListByResourceGroupPager(resourceGroupName st
 		},
 		Fetcher: func(ctx context.Context, page *WorkspacesClientListByResourceGroupResponse) (WorkspacesClientListByResourceGroupResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -388,8 +390,10 @@ func (client *WorkspacesClient) NewListBySubscriptionPager(options *WorkspacesCl
 		},
 		Fetcher: func(ctx context.Context, page *WorkspacesClientListBySubscriptionResponse) (WorkspacesClientListBySubscriptionResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/autorest.go/test/maps/azalias/zz_client.go
+++ b/packages/autorest.go/test/maps/azalias/zz_client.go
@@ -230,8 +230,10 @@ func (client *Client) NewListPager(headerEnums []IntEnum, queryEnum IntEnum, opt
 		Fetcher: func(ctx context.Context, page *ListResponseEnvelope) (ListResponseEnvelope, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "Client.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, headerEnums, queryEnum, options)
@@ -386,8 +388,10 @@ func (client *Client) NewListWithSharedNextOnePager(options *ListWithSharedNextO
 		Fetcher: func(ctx context.Context, page *ListWithSharedNextOneResponse) (ListWithSharedNextOneResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "Client.NewListWithSharedNextOnePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listWithSharedNextOneCreateRequest(ctx, options)
@@ -439,8 +443,10 @@ func (client *Client) NewListWithSharedNextTwoPager(options *ListWithSharedNextT
 		Fetcher: func(ctx context.Context, page *ListWithSharedNextTwoResponse) (ListWithSharedNextTwoResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "Client.NewListWithSharedNextTwoPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listWithSharedNextTwoCreateRequest(ctx, options)

--- a/packages/autorest.go/test/maps/azalias/zz_client.go
+++ b/packages/autorest.go/test/maps/azalias/zz_client.go
@@ -302,7 +302,7 @@ func (client *Client) BeginListLRO(ctx context.Context, options *BeginListLROOpt
 				return client.listLROCreateRequest(ctx, options)
 			}, &runtime.FetcherForNextLinkOptions{
 				NextReq: func(ctx context.Context, encodedNextLink string) (*policy.Request, error) {
-					return client.listLRONextCreateRequest(ctx, encodedNextLink)
+					return client.listLRONextCreateRequest(ctx, encodedNextLink, nextLink)
 				},
 			})
 			if err != nil {
@@ -397,7 +397,7 @@ func (client *Client) NewListWithSharedNextOnePager(options *ListWithSharedNextO
 				return client.listWithSharedNextOneCreateRequest(ctx, options)
 			}, &runtime.FetcherForNextLinkOptions{
 				NextReq: func(ctx context.Context, encodedNextLink string) (*policy.Request, error) {
-					return client.listWithSharedNextCreateRequest(ctx, encodedNextLink)
+					return client.listWithSharedNextCreateRequest(ctx, encodedNextLink, nextLink)
 				},
 			})
 			if err != nil {
@@ -452,7 +452,7 @@ func (client *Client) NewListWithSharedNextTwoPager(options *ListWithSharedNextT
 				return client.listWithSharedNextTwoCreateRequest(ctx, options)
 			}, &runtime.FetcherForNextLinkOptions{
 				NextReq: func(ctx context.Context, encodedNextLink string) (*policy.Request, error) {
-					return client.listWithSharedNextCreateRequest(ctx, encodedNextLink)
+					return client.listWithSharedNextCreateRequest(ctx, encodedNextLink, nextLink)
 				},
 			})
 			if err != nil {
@@ -611,7 +611,7 @@ func (client *Client) uploadFormCreateRequest(ctx context.Context, requiredStrin
 }
 
 // listLRONextCreateRequest creates the listLRONextCreateRequest request.
-func (client *Client) listLRONextCreateRequest(ctx context.Context, nextLink string) (*policy.Request, error) {
+func (client *Client) listLRONextCreateRequest(ctx context.Context, nextLink string, nextLink *string) (*policy.Request, error) {
 	host := "https://{geography}.atlas.microsoft.com"
 	host = strings.ReplaceAll(host, "{geography}", string(client.geography))
 	urlPath := "/paged"
@@ -625,7 +625,7 @@ func (client *Client) listLRONextCreateRequest(ctx context.Context, nextLink str
 }
 
 // listWithSharedNextCreateRequest creates the listWithSharedNextCreateRequest request.
-func (client *Client) listWithSharedNextCreateRequest(ctx context.Context, nextLink string) (*policy.Request, error) {
+func (client *Client) listWithSharedNextCreateRequest(ctx context.Context, nextLink string, nextLink *string) (*policy.Request, error) {
 	host := "https://{geography}.atlas.microsoft.com"
 	host = strings.ReplaceAll(host, "{geography}", string(client.geography))
 	urlPath := "/listWithSharedNext"

--- a/packages/autorest.go/test/maps/azalias/zz_options.go
+++ b/packages/autorest.go/test/maps/azalias/zz_options.go
@@ -61,17 +61,22 @@ type GetScriptOptions struct {
 type ListOptions struct {
 	GroupBy    []LogMetricsGroupBy
 	HeaderEnum *IntEnum
+
+	// Resumes the paging operation from the provided link.
+	NextLink   string
 	QueryEnums []IntEnum
 }
 
 // ListWithSharedNextOneOptions contains the optional parameters for the Client.NewListWithSharedNextOnePager method.
 type ListWithSharedNextOneOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ListWithSharedNextTwoOptions contains the optional parameters for the Client.NewListWithSharedNextTwoPager method.
 type ListWithSharedNextTwoOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PolicyAssignmentOptions contains the optional parameters for the Client.PolicyAssignment method.

--- a/packages/autorest.go/test/network/armnetwork/zz_adminrulecollections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_adminrulecollections_client.go
@@ -302,8 +302,10 @@ func (client *AdminRuleCollectionsClient) NewListPager(resourceGroupName string,
 		Fetcher: func(ctx context.Context, page *AdminRuleCollectionsClientListResponse) (AdminRuleCollectionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AdminRuleCollectionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, networkManagerName, configurationName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_adminrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_adminrules_client.go
@@ -315,8 +315,10 @@ func (client *AdminRulesClient) NewListPager(resourceGroupName string, networkMa
 		Fetcher: func(ctx context.Context, page *AdminRulesClientListResponse) (AdminRulesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AdminRulesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, networkManagerName, configurationName, ruleCollectionName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationgatewayprivateendpointconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationgatewayprivateendpointconnections_client.go
@@ -209,8 +209,10 @@ func (client *ApplicationGatewayPrivateEndpointConnectionsClient) NewListPager(r
 		Fetcher: func(ctx context.Context, page *ApplicationGatewayPrivateEndpointConnectionsClientListResponse) (ApplicationGatewayPrivateEndpointConnectionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ApplicationGatewayPrivateEndpointConnectionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, applicationGatewayName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationgatewayprivatelinkresources_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationgatewayprivatelinkresources_client.go
@@ -56,8 +56,10 @@ func (client *ApplicationGatewayPrivateLinkResourcesClient) NewListPager(resourc
 		Fetcher: func(ctx context.Context, page *ApplicationGatewayPrivateLinkResourcesClientListResponse) (ApplicationGatewayPrivateLinkResourcesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ApplicationGatewayPrivateLinkResourcesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, applicationGatewayName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationgateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationgateways_client.go
@@ -503,8 +503,10 @@ func (client *ApplicationGatewaysClient) NewListPager(resourceGroupName string, 
 		Fetcher: func(ctx context.Context, page *ApplicationGatewaysClientListResponse) (ApplicationGatewaysClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ApplicationGatewaysClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -562,8 +564,10 @@ func (client *ApplicationGatewaysClient) NewListAllPager(options *ApplicationGat
 		Fetcher: func(ctx context.Context, page *ApplicationGatewaysClientListAllResponse) (ApplicationGatewaysClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ApplicationGatewaysClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)
@@ -782,8 +786,10 @@ func (client *ApplicationGatewaysClient) NewListAvailableSSLPredefinedPoliciesPa
 		Fetcher: func(ctx context.Context, page *ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse) (ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ApplicationGatewaysClient.NewListAvailableSSLPredefinedPoliciesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAvailableSSLPredefinedPoliciesCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationgatewaywafdynamicmanifests_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationgatewaywafdynamicmanifests_client.go
@@ -55,8 +55,10 @@ func (client *ApplicationGatewayWafDynamicManifestsClient) NewGetPager(location 
 		Fetcher: func(ctx context.Context, page *ApplicationGatewayWafDynamicManifestsClientGetResponse) (ApplicationGatewayWafDynamicManifestsClientGetResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ApplicationGatewayWafDynamicManifestsClient.NewGetPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getCreateRequest(ctx, location, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationsecuritygroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationsecuritygroups_client.go
@@ -278,8 +278,10 @@ func (client *ApplicationSecurityGroupsClient) NewListPager(resourceGroupName st
 		Fetcher: func(ctx context.Context, page *ApplicationSecurityGroupsClientListResponse) (ApplicationSecurityGroupsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ApplicationSecurityGroupsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -337,8 +339,10 @@ func (client *ApplicationSecurityGroupsClient) NewListAllPager(options *Applicat
 		Fetcher: func(ctx context.Context, page *ApplicationSecurityGroupsClientListAllResponse) (ApplicationSecurityGroupsClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ApplicationSecurityGroupsClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_availabledelegations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_availabledelegations_client.go
@@ -55,8 +55,10 @@ func (client *AvailableDelegationsClient) NewListPager(location string, options 
 		Fetcher: func(ctx context.Context, page *AvailableDelegationsClientListResponse) (AvailableDelegationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AvailableDelegationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, location, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_availableendpointservices_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_availableendpointservices_client.go
@@ -55,8 +55,10 @@ func (client *AvailableEndpointServicesClient) NewListPager(location string, opt
 		Fetcher: func(ctx context.Context, page *AvailableEndpointServicesClientListResponse) (AvailableEndpointServicesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AvailableEndpointServicesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, location, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_availableprivateendpointtypes_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_availableprivateendpointtypes_client.go
@@ -56,8 +56,10 @@ func (client *AvailablePrivateEndpointTypesClient) NewListPager(location string,
 		Fetcher: func(ctx context.Context, page *AvailablePrivateEndpointTypesClientListResponse) (AvailablePrivateEndpointTypesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AvailablePrivateEndpointTypesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, location, options)
@@ -118,8 +120,10 @@ func (client *AvailablePrivateEndpointTypesClient) NewListByResourceGroupPager(l
 		Fetcher: func(ctx context.Context, page *AvailablePrivateEndpointTypesClientListByResourceGroupResponse) (AvailablePrivateEndpointTypesClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AvailablePrivateEndpointTypesClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, location, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_availableresourcegroupdelegations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_availableresourcegroupdelegations_client.go
@@ -56,8 +56,10 @@ func (client *AvailableResourceGroupDelegationsClient) NewListPager(location str
 		Fetcher: func(ctx context.Context, page *AvailableResourceGroupDelegationsClientListResponse) (AvailableResourceGroupDelegationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AvailableResourceGroupDelegationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, location, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_availableservicealiases_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_availableservicealiases_client.go
@@ -55,8 +55,10 @@ func (client *AvailableServiceAliasesClient) NewListPager(location string, optio
 		Fetcher: func(ctx context.Context, page *AvailableServiceAliasesClientListResponse) (AvailableServiceAliasesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AvailableServiceAliasesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, location, options)
@@ -116,8 +118,10 @@ func (client *AvailableServiceAliasesClient) NewListByResourceGroupPager(resourc
 		Fetcher: func(ctx context.Context, page *AvailableServiceAliasesClientListByResourceGroupResponse) (AvailableServiceAliasesClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AvailableServiceAliasesClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, location, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_azurefirewallfqdntags_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_azurefirewallfqdntags_client.go
@@ -54,8 +54,10 @@ func (client *AzureFirewallFqdnTagsClient) NewListAllPager(options *AzureFirewal
 		Fetcher: func(ctx context.Context, page *AzureFirewallFqdnTagsClientListAllResponse) (AzureFirewallFqdnTagsClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AzureFirewallFqdnTagsClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_azurefirewalls_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_azurefirewalls_client.go
@@ -276,8 +276,10 @@ func (client *AzureFirewallsClient) NewListPager(resourceGroupName string, optio
 		Fetcher: func(ctx context.Context, page *AzureFirewallsClientListResponse) (AzureFirewallsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AzureFirewallsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -335,8 +337,10 @@ func (client *AzureFirewallsClient) NewListAllPager(options *AzureFirewallsClien
 		Fetcher: func(ctx context.Context, page *AzureFirewallsClientListAllResponse) (AzureFirewallsClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AzureFirewallsClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_bastionhosts_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_bastionhosts_client.go
@@ -275,8 +275,10 @@ func (client *BastionHostsClient) NewListPager(options *BastionHostsClientListOp
 		Fetcher: func(ctx context.Context, page *BastionHostsClientListResponse) (BastionHostsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "BastionHostsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -331,8 +333,10 @@ func (client *BastionHostsClient) NewListByResourceGroupPager(resourceGroupName 
 		Fetcher: func(ctx context.Context, page *BastionHostsClientListByResourceGroupResponse) (BastionHostsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "BastionHostsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_bgpservicecommunities_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_bgpservicecommunities_client.go
@@ -54,8 +54,10 @@ func (client *BgpServiceCommunitiesClient) NewListPager(options *BgpServiceCommu
 		Fetcher: func(ctx context.Context, page *BgpServiceCommunitiesClientListResponse) (BgpServiceCommunitiesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "BgpServiceCommunitiesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_configurationpolicygroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_configurationpolicygroups_client.go
@@ -294,8 +294,10 @@ func (client *ConfigurationPolicyGroupsClient) NewListByVPNServerConfigurationPa
 		Fetcher: func(ctx context.Context, page *ConfigurationPolicyGroupsClientListByVPNServerConfigurationResponse) (ConfigurationPolicyGroupsClientListByVPNServerConfigurationResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ConfigurationPolicyGroupsClient.NewListByVPNServerConfigurationPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByVPNServerConfigurationCreateRequest(ctx, resourceGroupName, vpnServerConfigurationName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_connectivityconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_connectivityconfigurations_client.go
@@ -289,8 +289,10 @@ func (client *ConnectivityConfigurationsClient) NewListPager(resourceGroupName s
 		Fetcher: func(ctx context.Context, page *ConnectivityConfigurationsClientListResponse) (ConnectivityConfigurationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ConnectivityConfigurationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, networkManagerName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_customipprefixes_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_customipprefixes_client.go
@@ -280,8 +280,10 @@ func (client *CustomIPPrefixesClient) NewListPager(resourceGroupName string, opt
 		Fetcher: func(ctx context.Context, page *CustomIPPrefixesClientListResponse) (CustomIPPrefixesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "CustomIPPrefixesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -339,8 +341,10 @@ func (client *CustomIPPrefixesClient) NewListAllPager(options *CustomIPPrefixesC
 		Fetcher: func(ctx context.Context, page *CustomIPPrefixesClientListAllResponse) (CustomIPPrefixesClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "CustomIPPrefixesClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_ddosprotectionplans_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_ddosprotectionplans_client.go
@@ -276,8 +276,10 @@ func (client *DdosProtectionPlansClient) NewListPager(options *DdosProtectionPla
 		Fetcher: func(ctx context.Context, page *DdosProtectionPlansClientListResponse) (DdosProtectionPlansClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DdosProtectionPlansClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -332,8 +334,10 @@ func (client *DdosProtectionPlansClient) NewListByResourceGroupPager(resourceGro
 		Fetcher: func(ctx context.Context, page *DdosProtectionPlansClientListByResourceGroupResponse) (DdosProtectionPlansClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DdosProtectionPlansClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_defaultsecurityrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_defaultsecurityrules_client.go
@@ -126,8 +126,10 @@ func (client *DefaultSecurityRulesClient) NewListPager(resourceGroupName string,
 		Fetcher: func(ctx context.Context, page *DefaultSecurityRulesClientListResponse) (DefaultSecurityRulesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DefaultSecurityRulesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_dscpconfiguration_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_dscpconfiguration_client.go
@@ -277,8 +277,10 @@ func (client *DscpConfigurationClient) NewListPager(resourceGroupName string, op
 		Fetcher: func(ctx context.Context, page *DscpConfigurationClientListResponse) (DscpConfigurationClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DscpConfigurationClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -336,8 +338,10 @@ func (client *DscpConfigurationClient) NewListAllPager(options *DscpConfiguratio
 		Fetcher: func(ctx context.Context, page *DscpConfigurationClientListAllResponse) (DscpConfigurationClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DscpConfigurationClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitauthorizations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitauthorizations_client.go
@@ -294,8 +294,10 @@ func (client *ExpressRouteCircuitAuthorizationsClient) NewListPager(resourceGrou
 		Fetcher: func(ctx context.Context, page *ExpressRouteCircuitAuthorizationsClientListResponse) (ExpressRouteCircuitAuthorizationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ExpressRouteCircuitAuthorizationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, circuitName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitconnections_client.go
@@ -311,8 +311,10 @@ func (client *ExpressRouteCircuitConnectionsClient) NewListPager(resourceGroupNa
 		Fetcher: func(ctx context.Context, page *ExpressRouteCircuitConnectionsClientListResponse) (ExpressRouteCircuitConnectionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ExpressRouteCircuitConnectionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, circuitName, peeringName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitpeerings_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitpeerings_client.go
@@ -294,8 +294,10 @@ func (client *ExpressRouteCircuitPeeringsClient) NewListPager(resourceGroupName 
 		Fetcher: func(ctx context.Context, page *ExpressRouteCircuitPeeringsClientListResponse) (ExpressRouteCircuitPeeringsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ExpressRouteCircuitPeeringsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, circuitName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuits_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuits_client.go
@@ -413,8 +413,10 @@ func (client *ExpressRouteCircuitsClient) NewListPager(resourceGroupName string,
 		Fetcher: func(ctx context.Context, page *ExpressRouteCircuitsClientListResponse) (ExpressRouteCircuitsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ExpressRouteCircuitsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -472,8 +474,10 @@ func (client *ExpressRouteCircuitsClient) NewListAllPager(options *ExpressRouteC
 		Fetcher: func(ctx context.Context, page *ExpressRouteCircuitsClientListAllResponse) (ExpressRouteCircuitsClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ExpressRouteCircuitsClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecrossconnectionpeerings_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecrossconnectionpeerings_client.go
@@ -294,8 +294,10 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) NewListPager(resourceGr
 		Fetcher: func(ctx context.Context, page *ExpressRouteCrossConnectionPeeringsClientListResponse) (ExpressRouteCrossConnectionPeeringsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ExpressRouteCrossConnectionPeeringsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, crossConnectionName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecrossconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecrossconnections_client.go
@@ -200,8 +200,10 @@ func (client *ExpressRouteCrossConnectionsClient) NewListPager(options *ExpressR
 		Fetcher: func(ctx context.Context, page *ExpressRouteCrossConnectionsClientListResponse) (ExpressRouteCrossConnectionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ExpressRouteCrossConnectionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -345,8 +347,10 @@ func (client *ExpressRouteCrossConnectionsClient) NewListByResourceGroupPager(re
 		Fetcher: func(ctx context.Context, page *ExpressRouteCrossConnectionsClientListByResourceGroupResponse) (ExpressRouteCrossConnectionsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ExpressRouteCrossConnectionsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutelinks_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutelinks_client.go
@@ -125,8 +125,10 @@ func (client *ExpressRouteLinksClient) NewListPager(resourceGroupName string, ex
 		Fetcher: func(ctx context.Context, page *ExpressRouteLinksClientListResponse) (ExpressRouteLinksClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ExpressRouteLinksClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, expressRoutePortName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteportauthorizations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteportauthorizations_client.go
@@ -294,8 +294,10 @@ func (client *ExpressRoutePortAuthorizationsClient) NewListPager(resourceGroupNa
 		Fetcher: func(ctx context.Context, page *ExpressRoutePortAuthorizationsClientListResponse) (ExpressRoutePortAuthorizationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ExpressRoutePortAuthorizationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, expressRoutePortName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteports_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteports_client.go
@@ -345,8 +345,10 @@ func (client *ExpressRoutePortsClient) NewListPager(options *ExpressRoutePortsCl
 		Fetcher: func(ctx context.Context, page *ExpressRoutePortsClientListResponse) (ExpressRoutePortsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ExpressRoutePortsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -401,8 +403,10 @@ func (client *ExpressRoutePortsClient) NewListByResourceGroupPager(resourceGroup
 		Fetcher: func(ctx context.Context, page *ExpressRoutePortsClientListByResourceGroupResponse) (ExpressRoutePortsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ExpressRoutePortsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteportslocations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteportslocations_client.go
@@ -116,8 +116,10 @@ func (client *ExpressRoutePortsLocationsClient) NewListPager(options *ExpressRou
 		Fetcher: func(ctx context.Context, page *ExpressRoutePortsLocationsClientListResponse) (ExpressRoutePortsLocationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ExpressRoutePortsLocationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteserviceproviders_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteserviceproviders_client.go
@@ -54,8 +54,10 @@ func (client *ExpressRouteServiceProvidersClient) NewListPager(options *ExpressR
 		Fetcher: func(ctx context.Context, page *ExpressRouteServiceProvidersClientListResponse) (ExpressRouteServiceProvidersClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ExpressRouteServiceProvidersClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_firewallpolicies_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_firewallpolicies_client.go
@@ -280,8 +280,10 @@ func (client *FirewallPoliciesClient) NewListPager(resourceGroupName string, opt
 		Fetcher: func(ctx context.Context, page *FirewallPoliciesClientListResponse) (FirewallPoliciesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "FirewallPoliciesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -339,8 +341,10 @@ func (client *FirewallPoliciesClient) NewListAllPager(options *FirewallPoliciesC
 		Fetcher: func(ctx context.Context, page *FirewallPoliciesClientListAllResponse) (FirewallPoliciesClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "FirewallPoliciesClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyrulecollectiongroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyrulecollectiongroups_client.go
@@ -294,8 +294,10 @@ func (client *FirewallPolicyRuleCollectionGroupsClient) NewListPager(resourceGro
 		Fetcher: func(ctx context.Context, page *FirewallPolicyRuleCollectionGroupsClientListResponse) (FirewallPolicyRuleCollectionGroupsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "FirewallPolicyRuleCollectionGroupsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, firewallPolicyName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_flowlogs_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_flowlogs_client.go
@@ -291,8 +291,10 @@ func (client *FlowLogsClient) NewListPager(resourceGroupName string, networkWatc
 		Fetcher: func(ctx context.Context, page *FlowLogsClientListResponse) (FlowLogsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "FlowLogsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, networkWatcherName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_groups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_groups_client.go
@@ -288,8 +288,10 @@ func (client *GroupsClient) NewListPager(resourceGroupName string, networkManage
 		Fetcher: func(ctx context.Context, page *GroupsClientListResponse) (GroupsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "GroupsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, networkManagerName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_hubroutetables_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_hubroutetables_client.go
@@ -292,8 +292,10 @@ func (client *HubRouteTablesClient) NewListPager(resourceGroupName string, virtu
 		Fetcher: func(ctx context.Context, page *HubRouteTablesClientListResponse) (HubRouteTablesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "HubRouteTablesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, virtualHubName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_hubvirtualnetworkconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_hubvirtualnetworkconnections_client.go
@@ -294,8 +294,10 @@ func (client *HubVirtualNetworkConnectionsClient) NewListPager(resourceGroupName
 		Fetcher: func(ctx context.Context, page *HubVirtualNetworkConnectionsClientListResponse) (HubVirtualNetworkConnectionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "HubVirtualNetworkConnectionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, virtualHubName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_inboundnatrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_inboundnatrules_client.go
@@ -296,8 +296,10 @@ func (client *InboundNatRulesClient) NewListPager(resourceGroupName string, load
 		Fetcher: func(ctx context.Context, page *InboundNatRulesClientListResponse) (InboundNatRulesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "InboundNatRulesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, loadBalancerName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_interfaceipconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_interfaceipconfigurations_client.go
@@ -126,8 +126,10 @@ func (client *InterfaceIPConfigurationsClient) NewListPager(resourceGroupName st
 		Fetcher: func(ctx context.Context, page *InterfaceIPConfigurationsClientListResponse) (InterfaceIPConfigurationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "InterfaceIPConfigurationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_interfaceloadbalancers_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_interfaceloadbalancers_client.go
@@ -56,8 +56,10 @@ func (client *InterfaceLoadBalancersClient) NewListPager(resourceGroupName strin
 		Fetcher: func(ctx context.Context, page *InterfaceLoadBalancersClientListResponse) (InterfaceLoadBalancersClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "InterfaceLoadBalancersClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_interfaces_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_interfaces_client.go
@@ -595,8 +595,10 @@ func (client *InterfacesClient) NewListPager(resourceGroupName string, options *
 		Fetcher: func(ctx context.Context, page *InterfacesClientListResponse) (InterfacesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "InterfacesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -653,8 +655,10 @@ func (client *InterfacesClient) NewListAllPager(options *InterfacesClientListAll
 		Fetcher: func(ctx context.Context, page *InterfacesClientListAllResponse) (InterfacesClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "InterfacesClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)
@@ -710,8 +714,10 @@ func (client *InterfacesClient) NewListCloudServiceNetworkInterfacesPager(resour
 		Fetcher: func(ctx context.Context, page *InterfacesClientListCloudServiceNetworkInterfacesResponse) (InterfacesClientListCloudServiceNetworkInterfacesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "InterfacesClient.NewListCloudServiceNetworkInterfacesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCloudServiceNetworkInterfacesCreateRequest(ctx, resourceGroupName, cloudServiceName, options)
@@ -777,8 +783,10 @@ func (client *InterfacesClient) NewListCloudServiceRoleInstanceNetworkInterfaces
 		Fetcher: func(ctx context.Context, page *InterfacesClientListCloudServiceRoleInstanceNetworkInterfacesResponse) (InterfacesClientListCloudServiceRoleInstanceNetworkInterfacesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "InterfacesClient.NewListCloudServiceRoleInstanceNetworkInterfacesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCloudServiceRoleInstanceNetworkInterfacesCreateRequest(ctx, resourceGroupName, cloudServiceName, roleInstanceName, options)
@@ -926,8 +934,10 @@ func (client *InterfacesClient) NewListVirtualMachineScaleSetIPConfigurationsPag
 		Fetcher: func(ctx context.Context, page *InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse) (InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "InterfacesClient.NewListVirtualMachineScaleSetIPConfigurationsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listVirtualMachineScaleSetIPConfigurationsCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, options)
@@ -1002,8 +1012,10 @@ func (client *InterfacesClient) NewListVirtualMachineScaleSetNetworkInterfacesPa
 		Fetcher: func(ctx context.Context, page *InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse) (InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "InterfacesClient.NewListVirtualMachineScaleSetNetworkInterfacesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listVirtualMachineScaleSetNetworkInterfacesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, options)
@@ -1069,8 +1081,10 @@ func (client *InterfacesClient) NewListVirtualMachineScaleSetVMNetworkInterfaces
 		Fetcher: func(ctx context.Context, page *InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse) (InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "InterfacesClient.NewListVirtualMachineScaleSetVMNetworkInterfacesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listVirtualMachineScaleSetVMNetworkInterfacesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_interfacetapconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_interfacetapconfigurations_client.go
@@ -294,8 +294,10 @@ func (client *InterfaceTapConfigurationsClient) NewListPager(resourceGroupName s
 		Fetcher: func(ctx context.Context, page *InterfaceTapConfigurationsClientListResponse) (InterfaceTapConfigurationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "InterfaceTapConfigurationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_ipallocations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_ipallocations_client.go
@@ -278,8 +278,10 @@ func (client *IPAllocationsClient) NewListPager(options *IPAllocationsClientList
 		Fetcher: func(ctx context.Context, page *IPAllocationsClientListResponse) (IPAllocationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "IPAllocationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -334,8 +336,10 @@ func (client *IPAllocationsClient) NewListByResourceGroupPager(resourceGroupName
 		Fetcher: func(ctx context.Context, page *IPAllocationsClientListByResourceGroupResponse) (IPAllocationsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "IPAllocationsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_ipgroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_ipgroups_client.go
@@ -277,8 +277,10 @@ func (client *IPGroupsClient) NewListPager(options *IPGroupsClientListOptions) *
 		Fetcher: func(ctx context.Context, page *IPGroupsClientListResponse) (IPGroupsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "IPGroupsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -333,8 +335,10 @@ func (client *IPGroupsClient) NewListByResourceGroupPager(resourceGroupName stri
 		Fetcher: func(ctx context.Context, page *IPGroupsClientListByResourceGroupResponse) (IPGroupsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "IPGroupsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancerbackendaddresspools_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancerbackendaddresspools_client.go
@@ -294,8 +294,10 @@ func (client *LoadBalancerBackendAddressPoolsClient) NewListPager(resourceGroupN
 		Fetcher: func(ctx context.Context, page *LoadBalancerBackendAddressPoolsClientListResponse) (LoadBalancerBackendAddressPoolsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LoadBalancerBackendAddressPoolsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, loadBalancerName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancerfrontendipconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancerfrontendipconfigurations_client.go
@@ -126,8 +126,10 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) NewListPager(resourceG
 		Fetcher: func(ctx context.Context, page *LoadBalancerFrontendIPConfigurationsClientListResponse) (LoadBalancerFrontendIPConfigurationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LoadBalancerFrontendIPConfigurationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, loadBalancerName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancerloadbalancingrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancerloadbalancingrules_client.go
@@ -126,8 +126,10 @@ func (client *LoadBalancerLoadBalancingRulesClient) NewListPager(resourceGroupNa
 		Fetcher: func(ctx context.Context, page *LoadBalancerLoadBalancingRulesClientListResponse) (LoadBalancerLoadBalancingRulesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LoadBalancerLoadBalancingRulesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, loadBalancerName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancernetworkinterfaces_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancernetworkinterfaces_client.go
@@ -56,8 +56,10 @@ func (client *LoadBalancerNetworkInterfacesClient) NewListPager(resourceGroupNam
 		Fetcher: func(ctx context.Context, page *LoadBalancerNetworkInterfacesClientListResponse) (LoadBalancerNetworkInterfacesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LoadBalancerNetworkInterfacesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, loadBalancerName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalanceroutboundrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalanceroutboundrules_client.go
@@ -126,8 +126,10 @@ func (client *LoadBalancerOutboundRulesClient) NewListPager(resourceGroupName st
 		Fetcher: func(ctx context.Context, page *LoadBalancerOutboundRulesClientListResponse) (LoadBalancerOutboundRulesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LoadBalancerOutboundRulesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, loadBalancerName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancerprobes_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancerprobes_client.go
@@ -125,8 +125,10 @@ func (client *LoadBalancerProbesClient) NewListPager(resourceGroupName string, l
 		Fetcher: func(ctx context.Context, page *LoadBalancerProbesClientListResponse) (LoadBalancerProbesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LoadBalancerProbesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, loadBalancerName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancers_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancers_client.go
@@ -279,8 +279,10 @@ func (client *LoadBalancersClient) NewListPager(resourceGroupName string, option
 		Fetcher: func(ctx context.Context, page *LoadBalancersClientListResponse) (LoadBalancersClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LoadBalancersClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -338,8 +340,10 @@ func (client *LoadBalancersClient) NewListAllPager(options *LoadBalancersClientL
 		Fetcher: func(ctx context.Context, page *LoadBalancersClientListAllResponse) (LoadBalancersClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LoadBalancersClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_localnetworkgateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_localnetworkgateways_client.go
@@ -278,8 +278,10 @@ func (client *LocalNetworkGatewaysClient) NewListPager(resourceGroupName string,
 		Fetcher: func(ctx context.Context, page *LocalNetworkGatewaysClientListResponse) (LocalNetworkGatewaysClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LocalNetworkGatewaysClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_management_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_management_client.go
@@ -201,8 +201,10 @@ func (client *ManagementClient) NewDisconnectActiveSessionsPager(resourceGroupNa
 		Fetcher: func(ctx context.Context, page *ManagementClientDisconnectActiveSessionsResponse) (ManagementClientDisconnectActiveSessionsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ManagementClient.NewDisconnectActiveSessionsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.disconnectActiveSessionsCreateRequest(ctx, resourceGroupName, bastionHostName, sessionIDs, options)
@@ -515,8 +517,10 @@ func (client *ManagementClient) NewGetBastionShareableLinkPager(resourceGroupNam
 		Fetcher: func(ctx context.Context, page *ManagementClientGetBastionShareableLinkResponse) (ManagementClientGetBastionShareableLinkResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ManagementClient.NewGetBastionShareableLinkPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getBastionShareableLinkCreateRequest(ctx, resourceGroupName, bastionHostName, bslRequest, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_managementgroupnetworkmanagerconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_managementgroupnetworkmanagerconnections_client.go
@@ -229,8 +229,10 @@ func (client *ManagementGroupNetworkManagerConnectionsClient) NewListPager(manag
 		Fetcher: func(ctx context.Context, page *ManagementGroupNetworkManagerConnectionsClientListResponse) (ManagementGroupNetworkManagerConnectionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ManagementGroupNetworkManagerConnectionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, managementGroupID, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_managers_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_managers_client.go
@@ -266,8 +266,10 @@ func (client *ManagersClient) NewListPager(resourceGroupName string, options *Ma
 		Fetcher: func(ctx context.Context, page *ManagersClientListResponse) (ManagersClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ManagersClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -331,8 +333,10 @@ func (client *ManagersClient) NewListBySubscriptionPager(options *ManagersClient
 		Fetcher: func(ctx context.Context, page *ManagersClientListBySubscriptionResponse) (ManagersClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ManagersClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_natgateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_natgateways_client.go
@@ -278,8 +278,10 @@ func (client *NatGatewaysClient) NewListPager(resourceGroupName string, options 
 		Fetcher: func(ctx context.Context, page *NatGatewaysClientListResponse) (NatGatewaysClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "NatGatewaysClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -336,8 +338,10 @@ func (client *NatGatewaysClient) NewListAllPager(options *NatGatewaysClientListA
 		Fetcher: func(ctx context.Context, page *NatGatewaysClientListAllResponse) (NatGatewaysClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "NatGatewaysClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_natrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_natrules_client.go
@@ -292,8 +292,10 @@ func (client *NatRulesClient) NewListByVPNGatewayPager(resourceGroupName string,
 		Fetcher: func(ctx context.Context, page *NatRulesClientListByVPNGatewayResponse) (NatRulesClientListByVPNGatewayResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "NatRulesClient.NewListByVPNGatewayPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByVPNGatewayCreateRequest(ctx, resourceGroupName, gatewayName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_operations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_operations_client.go
@@ -46,8 +46,10 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 		Fetcher: func(ctx context.Context, page *OperationsClientListResponse) (OperationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "OperationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_options.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_options.go
@@ -30,6 +30,9 @@ type AdminRuleCollectionsClientGetOptions struct {
 // AdminRuleCollectionsClientListOptions contains the optional parameters for the AdminRuleCollectionsClient.NewListPager
 // method.
 type AdminRuleCollectionsClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
@@ -61,6 +64,9 @@ type AdminRulesClientGetOptions struct {
 
 // AdminRulesClientListOptions contains the optional parameters for the AdminRulesClient.NewListPager method.
 type AdminRulesClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
@@ -93,19 +99,22 @@ type ApplicationGatewayPrivateEndpointConnectionsClientGetOptions struct {
 // ApplicationGatewayPrivateEndpointConnectionsClientListOptions contains the optional parameters for the ApplicationGatewayPrivateEndpointConnectionsClient.NewListPager
 // method.
 type ApplicationGatewayPrivateEndpointConnectionsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ApplicationGatewayPrivateLinkResourcesClientListOptions contains the optional parameters for the ApplicationGatewayPrivateLinkResourcesClient.NewListPager
 // method.
 type ApplicationGatewayPrivateLinkResourcesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ApplicationGatewayWafDynamicManifestsClientGetOptions contains the optional parameters for the ApplicationGatewayWafDynamicManifestsClient.NewGetPager
 // method.
 type ApplicationGatewayWafDynamicManifestsClientGetOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ApplicationGatewayWafDynamicManifestsDefaultClientGetOptions contains the optional parameters for the ApplicationGatewayWafDynamicManifestsDefaultClient.Get
@@ -176,7 +185,8 @@ type ApplicationGatewaysClientGetSSLPredefinedPolicyOptions struct {
 // ApplicationGatewaysClientListAllOptions contains the optional parameters for the ApplicationGatewaysClient.NewListAllPager
 // method.
 type ApplicationGatewaysClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ApplicationGatewaysClientListAvailableRequestHeadersOptions contains the optional parameters for the ApplicationGatewaysClient.ListAvailableRequestHeaders
@@ -200,7 +210,8 @@ type ApplicationGatewaysClientListAvailableSSLOptionsOptions struct {
 // ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesOptions contains the optional parameters for the ApplicationGatewaysClient.NewListAvailableSSLPredefinedPoliciesPager
 // method.
 type ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ApplicationGatewaysClientListAvailableServerVariablesOptions contains the optional parameters for the ApplicationGatewaysClient.ListAvailableServerVariables
@@ -217,7 +228,8 @@ type ApplicationGatewaysClientListAvailableWafRuleSetsOptions struct {
 
 // ApplicationGatewaysClientListOptions contains the optional parameters for the ApplicationGatewaysClient.NewListPager method.
 type ApplicationGatewaysClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ApplicationGatewaysClientUpdateTagsOptions contains the optional parameters for the ApplicationGatewaysClient.UpdateTags
@@ -249,13 +261,15 @@ type ApplicationSecurityGroupsClientGetOptions struct {
 // ApplicationSecurityGroupsClientListAllOptions contains the optional parameters for the ApplicationSecurityGroupsClient.NewListAllPager
 // method.
 type ApplicationSecurityGroupsClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ApplicationSecurityGroupsClientListOptions contains the optional parameters for the ApplicationSecurityGroupsClient.NewListPager
 // method.
 type ApplicationSecurityGroupsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ApplicationSecurityGroupsClientUpdateTagsOptions contains the optional parameters for the ApplicationSecurityGroupsClient.UpdateTags
@@ -267,49 +281,57 @@ type ApplicationSecurityGroupsClientUpdateTagsOptions struct {
 // AvailableDelegationsClientListOptions contains the optional parameters for the AvailableDelegationsClient.NewListPager
 // method.
 type AvailableDelegationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AvailableEndpointServicesClientListOptions contains the optional parameters for the AvailableEndpointServicesClient.NewListPager
 // method.
 type AvailableEndpointServicesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AvailablePrivateEndpointTypesClientListByResourceGroupOptions contains the optional parameters for the AvailablePrivateEndpointTypesClient.NewListByResourceGroupPager
 // method.
 type AvailablePrivateEndpointTypesClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AvailablePrivateEndpointTypesClientListOptions contains the optional parameters for the AvailablePrivateEndpointTypesClient.NewListPager
 // method.
 type AvailablePrivateEndpointTypesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AvailableResourceGroupDelegationsClientListOptions contains the optional parameters for the AvailableResourceGroupDelegationsClient.NewListPager
 // method.
 type AvailableResourceGroupDelegationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AvailableServiceAliasesClientListByResourceGroupOptions contains the optional parameters for the AvailableServiceAliasesClient.NewListByResourceGroupPager
 // method.
 type AvailableServiceAliasesClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AvailableServiceAliasesClientListOptions contains the optional parameters for the AvailableServiceAliasesClient.NewListPager
 // method.
 type AvailableServiceAliasesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AzureFirewallFqdnTagsClientListAllOptions contains the optional parameters for the AzureFirewallFqdnTagsClient.NewListAllPager
 // method.
 type AzureFirewallFqdnTagsClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AzureFirewallsClientBeginCreateOrUpdateOptions contains the optional parameters for the AzureFirewallsClient.BeginCreateOrUpdate
@@ -346,12 +368,14 @@ type AzureFirewallsClientGetOptions struct {
 
 // AzureFirewallsClientListAllOptions contains the optional parameters for the AzureFirewallsClient.NewListAllPager method.
 type AzureFirewallsClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AzureFirewallsClientListOptions contains the optional parameters for the AzureFirewallsClient.NewListPager method.
 type AzureFirewallsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // BastionHostsClientBeginCreateOrUpdateOptions contains the optional parameters for the BastionHostsClient.BeginCreateOrUpdate
@@ -381,18 +405,21 @@ type BastionHostsClientGetOptions struct {
 // BastionHostsClientListByResourceGroupOptions contains the optional parameters for the BastionHostsClient.NewListByResourceGroupPager
 // method.
 type BastionHostsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // BastionHostsClientListOptions contains the optional parameters for the BastionHostsClient.NewListPager method.
 type BastionHostsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // BgpServiceCommunitiesClientListOptions contains the optional parameters for the BgpServiceCommunitiesClient.NewListPager
 // method.
 type BgpServiceCommunitiesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ConfigurationPolicyGroupsClientBeginCreateOrUpdateOptions contains the optional parameters for the ConfigurationPolicyGroupsClient.BeginCreateOrUpdate
@@ -418,7 +445,8 @@ type ConfigurationPolicyGroupsClientGetOptions struct {
 // ConfigurationPolicyGroupsClientListByVPNServerConfigurationOptions contains the optional parameters for the ConfigurationPolicyGroupsClient.NewListByVPNServerConfigurationPager
 // method.
 type ConfigurationPolicyGroupsClientListByVPNServerConfigurationOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ConnectionMonitorsClientBeginCreateOrUpdateOptions contains the optional parameters for the ConnectionMonitorsClient.BeginCreateOrUpdate
@@ -465,7 +493,8 @@ type ConnectionMonitorsClientGetOptions struct {
 
 // ConnectionMonitorsClientListOptions contains the optional parameters for the ConnectionMonitorsClient.NewListPager method.
 type ConnectionMonitorsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ConnectionMonitorsClientUpdateTagsOptions contains the optional parameters for the ConnectionMonitorsClient.UpdateTags
@@ -500,6 +529,9 @@ type ConnectivityConfigurationsClientGetOptions struct {
 // ConnectivityConfigurationsClientListOptions contains the optional parameters for the ConnectivityConfigurationsClient.NewListPager
 // method.
 type ConnectivityConfigurationsClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
@@ -530,12 +562,14 @@ type CustomIPPrefixesClientGetOptions struct {
 
 // CustomIPPrefixesClientListAllOptions contains the optional parameters for the CustomIPPrefixesClient.NewListAllPager method.
 type CustomIPPrefixesClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // CustomIPPrefixesClientListOptions contains the optional parameters for the CustomIPPrefixesClient.NewListPager method.
 type CustomIPPrefixesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // CustomIPPrefixesClientUpdateTagsOptions contains the optional parameters for the CustomIPPrefixesClient.UpdateTags method.
@@ -590,12 +624,14 @@ type DdosProtectionPlansClientGetOptions struct {
 // DdosProtectionPlansClientListByResourceGroupOptions contains the optional parameters for the DdosProtectionPlansClient.NewListByResourceGroupPager
 // method.
 type DdosProtectionPlansClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DdosProtectionPlansClientListOptions contains the optional parameters for the DdosProtectionPlansClient.NewListPager method.
 type DdosProtectionPlansClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DdosProtectionPlansClientUpdateTagsOptions contains the optional parameters for the DdosProtectionPlansClient.UpdateTags
@@ -612,7 +648,8 @@ type DefaultSecurityRulesClientGetOptions struct {
 // DefaultSecurityRulesClientListOptions contains the optional parameters for the DefaultSecurityRulesClient.NewListPager
 // method.
 type DefaultSecurityRulesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DscpConfigurationClientBeginCreateOrUpdateOptions contains the optional parameters for the DscpConfigurationClient.BeginCreateOrUpdate
@@ -637,12 +674,14 @@ type DscpConfigurationClientGetOptions struct {
 // DscpConfigurationClientListAllOptions contains the optional parameters for the DscpConfigurationClient.NewListAllPager
 // method.
 type DscpConfigurationClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DscpConfigurationClientListOptions contains the optional parameters for the DscpConfigurationClient.NewListPager method.
 type DscpConfigurationClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ExpressRouteCircuitAuthorizationsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuitAuthorizationsClient.BeginCreateOrUpdate
@@ -668,7 +707,8 @@ type ExpressRouteCircuitAuthorizationsClientGetOptions struct {
 // ExpressRouteCircuitAuthorizationsClientListOptions contains the optional parameters for the ExpressRouteCircuitAuthorizationsClient.NewListPager
 // method.
 type ExpressRouteCircuitAuthorizationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ExpressRouteCircuitConnectionsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuitConnectionsClient.BeginCreateOrUpdate
@@ -694,7 +734,8 @@ type ExpressRouteCircuitConnectionsClientGetOptions struct {
 // ExpressRouteCircuitConnectionsClientListOptions contains the optional parameters for the ExpressRouteCircuitConnectionsClient.NewListPager
 // method.
 type ExpressRouteCircuitConnectionsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ExpressRouteCircuitPeeringsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuitPeeringsClient.BeginCreateOrUpdate
@@ -720,7 +761,8 @@ type ExpressRouteCircuitPeeringsClientGetOptions struct {
 // ExpressRouteCircuitPeeringsClientListOptions contains the optional parameters for the ExpressRouteCircuitPeeringsClient.NewListPager
 // method.
 type ExpressRouteCircuitPeeringsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ExpressRouteCircuitsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuitsClient.BeginCreateOrUpdate
@@ -778,13 +820,15 @@ type ExpressRouteCircuitsClientGetStatsOptions struct {
 // ExpressRouteCircuitsClientListAllOptions contains the optional parameters for the ExpressRouteCircuitsClient.NewListAllPager
 // method.
 type ExpressRouteCircuitsClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ExpressRouteCircuitsClientListOptions contains the optional parameters for the ExpressRouteCircuitsClient.NewListPager
 // method.
 type ExpressRouteCircuitsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ExpressRouteCircuitsClientUpdateTagsOptions contains the optional parameters for the ExpressRouteCircuitsClient.UpdateTags
@@ -840,7 +884,8 @@ type ExpressRouteCrossConnectionPeeringsClientGetOptions struct {
 // ExpressRouteCrossConnectionPeeringsClientListOptions contains the optional parameters for the ExpressRouteCrossConnectionPeeringsClient.NewListPager
 // method.
 type ExpressRouteCrossConnectionPeeringsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ExpressRouteCrossConnectionsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCrossConnectionsClient.BeginCreateOrUpdate
@@ -880,13 +925,15 @@ type ExpressRouteCrossConnectionsClientGetOptions struct {
 // ExpressRouteCrossConnectionsClientListByResourceGroupOptions contains the optional parameters for the ExpressRouteCrossConnectionsClient.NewListByResourceGroupPager
 // method.
 type ExpressRouteCrossConnectionsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ExpressRouteCrossConnectionsClientListOptions contains the optional parameters for the ExpressRouteCrossConnectionsClient.NewListPager
 // method.
 type ExpressRouteCrossConnectionsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ExpressRouteCrossConnectionsClientUpdateTagsOptions contains the optional parameters for the ExpressRouteCrossConnectionsClient.UpdateTags
@@ -940,7 +987,8 @@ type ExpressRouteLinksClientGetOptions struct {
 
 // ExpressRouteLinksClientListOptions contains the optional parameters for the ExpressRouteLinksClient.NewListPager method.
 type ExpressRouteLinksClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ExpressRoutePortAuthorizationsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRoutePortAuthorizationsClient.BeginCreateOrUpdate
@@ -966,7 +1014,8 @@ type ExpressRoutePortAuthorizationsClientGetOptions struct {
 // ExpressRoutePortAuthorizationsClientListOptions contains the optional parameters for the ExpressRoutePortAuthorizationsClient.NewListPager
 // method.
 type ExpressRoutePortAuthorizationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ExpressRoutePortsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRoutePortsClient.BeginCreateOrUpdate
@@ -997,12 +1046,14 @@ type ExpressRoutePortsClientGetOptions struct {
 // ExpressRoutePortsClientListByResourceGroupOptions contains the optional parameters for the ExpressRoutePortsClient.NewListByResourceGroupPager
 // method.
 type ExpressRoutePortsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ExpressRoutePortsClientListOptions contains the optional parameters for the ExpressRoutePortsClient.NewListPager method.
 type ExpressRoutePortsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ExpressRoutePortsClientUpdateTagsOptions contains the optional parameters for the ExpressRoutePortsClient.UpdateTags method.
@@ -1019,7 +1070,8 @@ type ExpressRoutePortsLocationsClientGetOptions struct {
 // ExpressRoutePortsLocationsClientListOptions contains the optional parameters for the ExpressRoutePortsLocationsClient.NewListPager
 // method.
 type ExpressRoutePortsLocationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ExpressRouteProviderPortsLocationClientListOptions contains the optional parameters for the ExpressRouteProviderPortsLocationClient.List
@@ -1032,7 +1084,8 @@ type ExpressRouteProviderPortsLocationClientListOptions struct {
 // ExpressRouteServiceProvidersClientListOptions contains the optional parameters for the ExpressRouteServiceProvidersClient.NewListPager
 // method.
 type ExpressRouteServiceProvidersClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // FirewallPoliciesClientBeginCreateOrUpdateOptions contains the optional parameters for the FirewallPoliciesClient.BeginCreateOrUpdate
@@ -1056,12 +1109,14 @@ type FirewallPoliciesClientGetOptions struct {
 
 // FirewallPoliciesClientListAllOptions contains the optional parameters for the FirewallPoliciesClient.NewListAllPager method.
 type FirewallPoliciesClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // FirewallPoliciesClientListOptions contains the optional parameters for the FirewallPoliciesClient.NewListPager method.
 type FirewallPoliciesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // FirewallPoliciesClientUpdateTagsOptions contains the optional parameters for the FirewallPoliciesClient.UpdateTags method.
@@ -1128,7 +1183,8 @@ type FirewallPolicyRuleCollectionGroupsClientGetOptions struct {
 // FirewallPolicyRuleCollectionGroupsClientListOptions contains the optional parameters for the FirewallPolicyRuleCollectionGroupsClient.NewListPager
 // method.
 type FirewallPolicyRuleCollectionGroupsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // FlowLogsClientBeginCreateOrUpdateOptions contains the optional parameters for the FlowLogsClient.BeginCreateOrUpdate method.
@@ -1150,7 +1206,8 @@ type FlowLogsClientGetOptions struct {
 
 // FlowLogsClientListOptions contains the optional parameters for the FlowLogsClient.NewListPager method.
 type FlowLogsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // FlowLogsClientUpdateTagsOptions contains the optional parameters for the FlowLogsClient.UpdateTags method.
@@ -1182,6 +1239,9 @@ type GroupsClientGetOptions struct {
 
 // GroupsClientListOptions contains the optional parameters for the GroupsClient.NewListPager method.
 type GroupsClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
@@ -1211,7 +1271,8 @@ type HubRouteTablesClientGetOptions struct {
 
 // HubRouteTablesClientListOptions contains the optional parameters for the HubRouteTablesClient.NewListPager method.
 type HubRouteTablesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // HubVirtualNetworkConnectionsClientBeginCreateOrUpdateOptions contains the optional parameters for the HubVirtualNetworkConnectionsClient.BeginCreateOrUpdate
@@ -1237,7 +1298,8 @@ type HubVirtualNetworkConnectionsClientGetOptions struct {
 // HubVirtualNetworkConnectionsClientListOptions contains the optional parameters for the HubVirtualNetworkConnectionsClient.NewListPager
 // method.
 type HubVirtualNetworkConnectionsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // IPAllocationsClientBeginCreateOrUpdateOptions contains the optional parameters for the IPAllocationsClient.BeginCreateOrUpdate
@@ -1262,12 +1324,14 @@ type IPAllocationsClientGetOptions struct {
 // IPAllocationsClientListByResourceGroupOptions contains the optional parameters for the IPAllocationsClient.NewListByResourceGroupPager
 // method.
 type IPAllocationsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // IPAllocationsClientListOptions contains the optional parameters for the IPAllocationsClient.NewListPager method.
 type IPAllocationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // IPAllocationsClientUpdateTagsOptions contains the optional parameters for the IPAllocationsClient.UpdateTags method.
@@ -1296,12 +1360,14 @@ type IPGroupsClientGetOptions struct {
 // IPGroupsClientListByResourceGroupOptions contains the optional parameters for the IPGroupsClient.NewListByResourceGroupPager
 // method.
 type IPGroupsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // IPGroupsClientListOptions contains the optional parameters for the IPGroupsClient.NewListPager method.
 type IPGroupsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // IPGroupsClientUpdateGroupsOptions contains the optional parameters for the IPGroupsClient.UpdateGroups method.
@@ -1330,7 +1396,8 @@ type InboundNatRulesClientGetOptions struct {
 
 // InboundNatRulesClientListOptions contains the optional parameters for the InboundNatRulesClient.NewListPager method.
 type InboundNatRulesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // InboundSecurityRuleClientBeginCreateOrUpdateOptions contains the optional parameters for the InboundSecurityRuleClient.BeginCreateOrUpdate
@@ -1349,13 +1416,15 @@ type InterfaceIPConfigurationsClientGetOptions struct {
 // InterfaceIPConfigurationsClientListOptions contains the optional parameters for the InterfaceIPConfigurationsClient.NewListPager
 // method.
 type InterfaceIPConfigurationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // InterfaceLoadBalancersClientListOptions contains the optional parameters for the InterfaceLoadBalancersClient.NewListPager
 // method.
 type InterfaceLoadBalancersClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // InterfaceTapConfigurationsClientBeginCreateOrUpdateOptions contains the optional parameters for the InterfaceTapConfigurationsClient.BeginCreateOrUpdate
@@ -1381,7 +1450,8 @@ type InterfaceTapConfigurationsClientGetOptions struct {
 // InterfaceTapConfigurationsClientListOptions contains the optional parameters for the InterfaceTapConfigurationsClient.NewListPager
 // method.
 type InterfaceTapConfigurationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // InterfacesClientBeginCreateOrUpdateOptions contains the optional parameters for the InterfacesClient.BeginCreateOrUpdate
@@ -1440,24 +1510,28 @@ type InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceOptions struct {
 
 // InterfacesClientListAllOptions contains the optional parameters for the InterfacesClient.NewListAllPager method.
 type InterfacesClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // InterfacesClientListCloudServiceNetworkInterfacesOptions contains the optional parameters for the InterfacesClient.NewListCloudServiceNetworkInterfacesPager
 // method.
 type InterfacesClientListCloudServiceNetworkInterfacesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // InterfacesClientListCloudServiceRoleInstanceNetworkInterfacesOptions contains the optional parameters for the InterfacesClient.NewListCloudServiceRoleInstanceNetworkInterfacesPager
 // method.
 type InterfacesClientListCloudServiceRoleInstanceNetworkInterfacesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // InterfacesClientListOptions contains the optional parameters for the InterfacesClient.NewListPager method.
 type InterfacesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // InterfacesClientListVirtualMachineScaleSetIPConfigurationsOptions contains the optional parameters for the InterfacesClient.NewListVirtualMachineScaleSetIPConfigurationsPager
@@ -1465,18 +1539,23 @@ type InterfacesClientListOptions struct {
 type InterfacesClientListVirtualMachineScaleSetIPConfigurationsOptions struct {
 	// Expands referenced resources.
 	Expand *string
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // InterfacesClientListVirtualMachineScaleSetNetworkInterfacesOptions contains the optional parameters for the InterfacesClient.NewListVirtualMachineScaleSetNetworkInterfacesPager
 // method.
 type InterfacesClientListVirtualMachineScaleSetNetworkInterfacesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesOptions contains the optional parameters for the InterfacesClient.NewListVirtualMachineScaleSetVMNetworkInterfacesPager
 // method.
 type InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // InterfacesClientUpdateTagsOptions contains the optional parameters for the InterfacesClient.UpdateTags method.
@@ -1507,7 +1586,8 @@ type LoadBalancerBackendAddressPoolsClientGetOptions struct {
 // LoadBalancerBackendAddressPoolsClientListOptions contains the optional parameters for the LoadBalancerBackendAddressPoolsClient.NewListPager
 // method.
 type LoadBalancerBackendAddressPoolsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LoadBalancerFrontendIPConfigurationsClientGetOptions contains the optional parameters for the LoadBalancerFrontendIPConfigurationsClient.Get
@@ -1519,7 +1599,8 @@ type LoadBalancerFrontendIPConfigurationsClientGetOptions struct {
 // LoadBalancerFrontendIPConfigurationsClientListOptions contains the optional parameters for the LoadBalancerFrontendIPConfigurationsClient.NewListPager
 // method.
 type LoadBalancerFrontendIPConfigurationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LoadBalancerLoadBalancingRulesClientGetOptions contains the optional parameters for the LoadBalancerLoadBalancingRulesClient.Get
@@ -1531,13 +1612,15 @@ type LoadBalancerLoadBalancingRulesClientGetOptions struct {
 // LoadBalancerLoadBalancingRulesClientListOptions contains the optional parameters for the LoadBalancerLoadBalancingRulesClient.NewListPager
 // method.
 type LoadBalancerLoadBalancingRulesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LoadBalancerNetworkInterfacesClientListOptions contains the optional parameters for the LoadBalancerNetworkInterfacesClient.NewListPager
 // method.
 type LoadBalancerNetworkInterfacesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LoadBalancerOutboundRulesClientGetOptions contains the optional parameters for the LoadBalancerOutboundRulesClient.Get
@@ -1549,7 +1632,8 @@ type LoadBalancerOutboundRulesClientGetOptions struct {
 // LoadBalancerOutboundRulesClientListOptions contains the optional parameters for the LoadBalancerOutboundRulesClient.NewListPager
 // method.
 type LoadBalancerOutboundRulesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LoadBalancerProbesClientGetOptions contains the optional parameters for the LoadBalancerProbesClient.Get method.
@@ -1559,7 +1643,8 @@ type LoadBalancerProbesClientGetOptions struct {
 
 // LoadBalancerProbesClientListOptions contains the optional parameters for the LoadBalancerProbesClient.NewListPager method.
 type LoadBalancerProbesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LoadBalancersClientBeginCreateOrUpdateOptions contains the optional parameters for the LoadBalancersClient.BeginCreateOrUpdate
@@ -1597,12 +1682,14 @@ type LoadBalancersClientGetOptions struct {
 
 // LoadBalancersClientListAllOptions contains the optional parameters for the LoadBalancersClient.NewListAllPager method.
 type LoadBalancersClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LoadBalancersClientListOptions contains the optional parameters for the LoadBalancersClient.NewListPager method.
 type LoadBalancersClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LoadBalancersClientUpdateTagsOptions contains the optional parameters for the LoadBalancersClient.UpdateTags method.
@@ -1632,7 +1719,8 @@ type LocalNetworkGatewaysClientGetOptions struct {
 // LocalNetworkGatewaysClientListOptions contains the optional parameters for the LocalNetworkGatewaysClient.NewListPager
 // method.
 type LocalNetworkGatewaysClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LocalNetworkGatewaysClientUpdateTagsOptions contains the optional parameters for the LocalNetworkGatewaysClient.UpdateTags
@@ -1678,7 +1766,8 @@ type ManagementClientCheckDNSNameAvailabilityOptions struct {
 // ManagementClientDisconnectActiveSessionsOptions contains the optional parameters for the ManagementClient.NewDisconnectActiveSessionsPager
 // method.
 type ManagementClientDisconnectActiveSessionsOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ManagementClientExpressRouteProviderPortOptions contains the optional parameters for the ManagementClient.ExpressRouteProviderPort
@@ -1690,7 +1779,8 @@ type ManagementClientExpressRouteProviderPortOptions struct {
 // ManagementClientGetBastionShareableLinkOptions contains the optional parameters for the ManagementClient.NewGetBastionShareableLinkPager
 // method.
 type ManagementClientGetBastionShareableLinkOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ManagementClientListActiveConnectivityConfigurationsOptions contains the optional parameters for the ManagementClient.ListActiveConnectivityConfigurations
@@ -1748,6 +1838,9 @@ type ManagementGroupNetworkManagerConnectionsClientGetOptions struct {
 // ManagementGroupNetworkManagerConnectionsClientListOptions contains the optional parameters for the ManagementGroupNetworkManagerConnectionsClient.NewListPager
 // method.
 type ManagementGroupNetworkManagerConnectionsClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
@@ -1792,6 +1885,9 @@ type ManagersClientGetOptions struct {
 // ManagersClientListBySubscriptionOptions contains the optional parameters for the ManagersClient.NewListBySubscriptionPager
 // method.
 type ManagersClientListBySubscriptionOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
@@ -1803,6 +1899,9 @@ type ManagersClientListBySubscriptionOptions struct {
 
 // ManagersClientListOptions contains the optional parameters for the ManagersClient.NewListPager method.
 type ManagersClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
@@ -1838,12 +1937,14 @@ type NatGatewaysClientGetOptions struct {
 
 // NatGatewaysClientListAllOptions contains the optional parameters for the NatGatewaysClient.NewListAllPager method.
 type NatGatewaysClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // NatGatewaysClientListOptions contains the optional parameters for the NatGatewaysClient.NewListPager method.
 type NatGatewaysClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // NatGatewaysClientUpdateTagsOptions contains the optional parameters for the NatGatewaysClient.UpdateTags method.
@@ -1871,12 +1972,14 @@ type NatRulesClientGetOptions struct {
 // NatRulesClientListByVPNGatewayOptions contains the optional parameters for the NatRulesClient.NewListByVPNGatewayPager
 // method.
 type NatRulesClientListByVPNGatewayOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 type OperationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // P2SVPNGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the P2SVPNGatewaysClient.BeginCreateOrUpdate
@@ -1941,12 +2044,14 @@ type P2SVPNGatewaysClientGetOptions struct {
 // P2SVPNGatewaysClientListByResourceGroupOptions contains the optional parameters for the P2SVPNGatewaysClient.NewListByResourceGroupPager
 // method.
 type P2SVPNGatewaysClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // P2SVPNGatewaysClientListOptions contains the optional parameters for the P2SVPNGatewaysClient.NewListPager method.
 type P2SVPNGatewaysClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PacketCapturesClientBeginCreateOptions contains the optional parameters for the PacketCapturesClient.BeginCreate method.
@@ -1981,7 +2086,8 @@ type PacketCapturesClientGetOptions struct {
 
 // PacketCapturesClientListOptions contains the optional parameters for the PacketCapturesClient.NewListPager method.
 type PacketCapturesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PeerExpressRouteCircuitConnectionsClientGetOptions contains the optional parameters for the PeerExpressRouteCircuitConnectionsClient.Get
@@ -1993,7 +2099,8 @@ type PeerExpressRouteCircuitConnectionsClientGetOptions struct {
 // PeerExpressRouteCircuitConnectionsClientListOptions contains the optional parameters for the PeerExpressRouteCircuitConnectionsClient.NewListPager
 // method.
 type PeerExpressRouteCircuitConnectionsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PrivateDNSZoneGroupsClientBeginCreateOrUpdateOptions contains the optional parameters for the PrivateDNSZoneGroupsClient.BeginCreateOrUpdate
@@ -2018,7 +2125,8 @@ type PrivateDNSZoneGroupsClientGetOptions struct {
 // PrivateDNSZoneGroupsClientListOptions contains the optional parameters for the PrivateDNSZoneGroupsClient.NewListPager
 // method.
 type PrivateDNSZoneGroupsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PrivateEndpointsClientBeginCreateOrUpdateOptions contains the optional parameters for the PrivateEndpointsClient.BeginCreateOrUpdate
@@ -2043,12 +2151,14 @@ type PrivateEndpointsClientGetOptions struct {
 // PrivateEndpointsClientListBySubscriptionOptions contains the optional parameters for the PrivateEndpointsClient.NewListBySubscriptionPager
 // method.
 type PrivateEndpointsClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PrivateEndpointsClientListOptions contains the optional parameters for the PrivateEndpointsClient.NewListPager method.
 type PrivateEndpointsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PrivateLinkServicesClientBeginCheckPrivateLinkServiceVisibilityByResourceGroupOptions contains the optional parameters
@@ -2102,30 +2212,35 @@ type PrivateLinkServicesClientGetPrivateEndpointConnectionOptions struct {
 // PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupOptions contains the optional parameters for
 // the PrivateLinkServicesClient.NewListAutoApprovedPrivateLinkServicesByResourceGroupPager method.
 type PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesOptions contains the optional parameters for the PrivateLinkServicesClient.NewListAutoApprovedPrivateLinkServicesPager
 // method.
 type PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PrivateLinkServicesClientListBySubscriptionOptions contains the optional parameters for the PrivateLinkServicesClient.NewListBySubscriptionPager
 // method.
 type PrivateLinkServicesClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PrivateLinkServicesClientListOptions contains the optional parameters for the PrivateLinkServicesClient.NewListPager method.
 type PrivateLinkServicesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PrivateLinkServicesClientListPrivateEndpointConnectionsOptions contains the optional parameters for the PrivateLinkServicesClient.NewListPrivateEndpointConnectionsPager
 // method.
 type PrivateLinkServicesClientListPrivateEndpointConnectionsOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PrivateLinkServicesClientUpdatePrivateEndpointConnectionOptions contains the optional parameters for the PrivateLinkServicesClient.UpdatePrivateEndpointConnection
@@ -2153,12 +2268,14 @@ type ProfilesClientGetOptions struct {
 
 // ProfilesClientListAllOptions contains the optional parameters for the ProfilesClient.NewListAllPager method.
 type ProfilesClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ProfilesClientListOptions contains the optional parameters for the ProfilesClient.NewListPager method.
 type ProfilesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ProfilesClientUpdateTagsOptions contains the optional parameters for the ProfilesClient.UpdateTags method.
@@ -2210,36 +2327,42 @@ type PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressOptions stru
 // PublicIPAddressesClientListAllOptions contains the optional parameters for the PublicIPAddressesClient.NewListAllPager
 // method.
 type PublicIPAddressesClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PublicIPAddressesClientListCloudServicePublicIPAddressesOptions contains the optional parameters for the PublicIPAddressesClient.NewListCloudServicePublicIPAddressesPager
 // method.
 type PublicIPAddressesClientListCloudServicePublicIPAddressesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PublicIPAddressesClientListCloudServiceRoleInstancePublicIPAddressesOptions contains the optional parameters for the PublicIPAddressesClient.NewListCloudServiceRoleInstancePublicIPAddressesPager
 // method.
 type PublicIPAddressesClientListCloudServiceRoleInstancePublicIPAddressesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PublicIPAddressesClientListOptions contains the optional parameters for the PublicIPAddressesClient.NewListPager method.
 type PublicIPAddressesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesOptions contains the optional parameters for the PublicIPAddressesClient.NewListVirtualMachineScaleSetPublicIPAddressesPager
 // method.
 type PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesOptions contains the optional parameters for the PublicIPAddressesClient.NewListVirtualMachineScaleSetVMPublicIPAddressesPager
 // method.
 type PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PublicIPAddressesClientUpdateTagsOptions contains the optional parameters for the PublicIPAddressesClient.UpdateTags method.
@@ -2268,12 +2391,14 @@ type PublicIPPrefixesClientGetOptions struct {
 
 // PublicIPPrefixesClientListAllOptions contains the optional parameters for the PublicIPPrefixesClient.NewListAllPager method.
 type PublicIPPrefixesClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PublicIPPrefixesClientListOptions contains the optional parameters for the PublicIPPrefixesClient.NewListPager method.
 type PublicIPPrefixesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PublicIPPrefixesClientUpdateTagsOptions contains the optional parameters for the PublicIPPrefixesClient.UpdateTags method.
@@ -2307,7 +2432,8 @@ type RouteFilterRulesClientGetOptions struct {
 // RouteFilterRulesClientListByRouteFilterOptions contains the optional parameters for the RouteFilterRulesClient.NewListByRouteFilterPager
 // method.
 type RouteFilterRulesClientListByRouteFilterOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // RouteFiltersClientBeginCreateOrUpdateOptions contains the optional parameters for the RouteFiltersClient.BeginCreateOrUpdate
@@ -2332,12 +2458,14 @@ type RouteFiltersClientGetOptions struct {
 // RouteFiltersClientListByResourceGroupOptions contains the optional parameters for the RouteFiltersClient.NewListByResourceGroupPager
 // method.
 type RouteFiltersClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // RouteFiltersClientListOptions contains the optional parameters for the RouteFiltersClient.NewListPager method.
 type RouteFiltersClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // RouteFiltersClientUpdateTagsOptions contains the optional parameters for the RouteFiltersClient.UpdateTags method.
@@ -2365,7 +2493,8 @@ type RouteMapsClientGetOptions struct {
 
 // RouteMapsClientListOptions contains the optional parameters for the RouteMapsClient.NewListPager method.
 type RouteMapsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // RouteTablesClientBeginCreateOrUpdateOptions contains the optional parameters for the RouteTablesClient.BeginCreateOrUpdate
@@ -2389,12 +2518,14 @@ type RouteTablesClientGetOptions struct {
 
 // RouteTablesClientListAllOptions contains the optional parameters for the RouteTablesClient.NewListAllPager method.
 type RouteTablesClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // RouteTablesClientListOptions contains the optional parameters for the RouteTablesClient.NewListPager method.
 type RouteTablesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // RouteTablesClientUpdateTagsOptions contains the optional parameters for the RouteTablesClient.UpdateTags method.
@@ -2421,7 +2552,8 @@ type RoutesClientGetOptions struct {
 
 // RoutesClientListOptions contains the optional parameters for the RoutesClient.NewListPager method.
 type RoutesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // RoutingIntentClientBeginCreateOrUpdateOptions contains the optional parameters for the RoutingIntentClient.BeginCreateOrUpdate
@@ -2444,7 +2576,8 @@ type RoutingIntentClientGetOptions struct {
 
 // RoutingIntentClientListOptions contains the optional parameters for the RoutingIntentClient.NewListPager method.
 type RoutingIntentClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ScopeConnectionsClientCreateOrUpdateOptions contains the optional parameters for the ScopeConnectionsClient.CreateOrUpdate
@@ -2465,6 +2598,9 @@ type ScopeConnectionsClientGetOptions struct {
 
 // ScopeConnectionsClientListOptions contains the optional parameters for the ScopeConnectionsClient.NewListPager method.
 type ScopeConnectionsClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
@@ -2500,6 +2636,9 @@ type SecurityAdminConfigurationsClientGetOptions struct {
 // SecurityAdminConfigurationsClientListOptions contains the optional parameters for the SecurityAdminConfigurationsClient.NewListPager
 // method.
 type SecurityAdminConfigurationsClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
@@ -2530,12 +2669,14 @@ type SecurityGroupsClientGetOptions struct {
 
 // SecurityGroupsClientListAllOptions contains the optional parameters for the SecurityGroupsClient.NewListAllPager method.
 type SecurityGroupsClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SecurityGroupsClientListOptions contains the optional parameters for the SecurityGroupsClient.NewListPager method.
 type SecurityGroupsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SecurityGroupsClientUpdateTagsOptions contains the optional parameters for the SecurityGroupsClient.UpdateTags method.
@@ -2565,13 +2706,15 @@ type SecurityPartnerProvidersClientGetOptions struct {
 // SecurityPartnerProvidersClientListByResourceGroupOptions contains the optional parameters for the SecurityPartnerProvidersClient.NewListByResourceGroupPager
 // method.
 type SecurityPartnerProvidersClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SecurityPartnerProvidersClientListOptions contains the optional parameters for the SecurityPartnerProvidersClient.NewListPager
 // method.
 type SecurityPartnerProvidersClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SecurityPartnerProvidersClientUpdateTagsOptions contains the optional parameters for the SecurityPartnerProvidersClient.UpdateTags
@@ -2600,7 +2743,8 @@ type SecurityRulesClientGetOptions struct {
 
 // SecurityRulesClientListOptions contains the optional parameters for the SecurityRulesClient.NewListPager method.
 type SecurityRulesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ServiceAssociationLinksClientListOptions contains the optional parameters for the ServiceAssociationLinksClient.List method.
@@ -2631,13 +2775,15 @@ type ServiceEndpointPoliciesClientGetOptions struct {
 // ServiceEndpointPoliciesClientListByResourceGroupOptions contains the optional parameters for the ServiceEndpointPoliciesClient.NewListByResourceGroupPager
 // method.
 type ServiceEndpointPoliciesClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ServiceEndpointPoliciesClientListOptions contains the optional parameters for the ServiceEndpointPoliciesClient.NewListPager
 // method.
 type ServiceEndpointPoliciesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ServiceEndpointPoliciesClientUpdateTagsOptions contains the optional parameters for the ServiceEndpointPoliciesClient.UpdateTags
@@ -2669,12 +2815,16 @@ type ServiceEndpointPolicyDefinitionsClientGetOptions struct {
 // ServiceEndpointPolicyDefinitionsClientListByResourceGroupOptions contains the optional parameters for the ServiceEndpointPolicyDefinitionsClient.NewListByResourceGroupPager
 // method.
 type ServiceEndpointPolicyDefinitionsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ServiceTagInformationClientListOptions contains the optional parameters for the ServiceTagInformationClient.NewListPager
 // method.
 type ServiceTagInformationClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Do not return address prefixes for the tag(s).
 	NoAddressPrefixes *bool
 
@@ -2704,6 +2854,9 @@ type StaticMembersClientGetOptions struct {
 
 // StaticMembersClientListOptions contains the optional parameters for the StaticMembersClient.NewListPager method.
 type StaticMembersClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
@@ -2747,7 +2900,8 @@ type SubnetsClientGetOptions struct {
 
 // SubnetsClientListOptions contains the optional parameters for the SubnetsClient.NewListPager method.
 type SubnetsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SubscriptionNetworkManagerConnectionsClientCreateOrUpdateOptions contains the optional parameters for the SubscriptionNetworkManagerConnectionsClient.CreateOrUpdate
@@ -2771,6 +2925,9 @@ type SubscriptionNetworkManagerConnectionsClientGetOptions struct {
 // SubscriptionNetworkManagerConnectionsClientListOptions contains the optional parameters for the SubscriptionNetworkManagerConnectionsClient.NewListPager
 // method.
 type SubscriptionNetworkManagerConnectionsClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
@@ -2782,7 +2939,8 @@ type SubscriptionNetworkManagerConnectionsClientListOptions struct {
 
 // UsagesClientListOptions contains the optional parameters for the UsagesClient.NewListPager method.
 type UsagesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VPNConnectionsClientBeginCreateOrUpdateOptions contains the optional parameters for the VPNConnectionsClient.BeginCreateOrUpdate
@@ -2826,7 +2984,8 @@ type VPNConnectionsClientGetOptions struct {
 // VPNConnectionsClientListByVPNGatewayOptions contains the optional parameters for the VPNConnectionsClient.NewListByVPNGatewayPager
 // method.
 type VPNConnectionsClientListByVPNGatewayOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VPNGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the VPNGatewaysClient.BeginCreateOrUpdate
@@ -2885,12 +3044,14 @@ type VPNGatewaysClientGetOptions struct {
 // VPNGatewaysClientListByResourceGroupOptions contains the optional parameters for the VPNGatewaysClient.NewListByResourceGroupPager
 // method.
 type VPNGatewaysClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VPNGatewaysClientListOptions contains the optional parameters for the VPNGatewaysClient.NewListPager method.
 type VPNGatewaysClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VPNLinkConnectionsClientBeginGetIkeSasOptions contains the optional parameters for the VPNLinkConnectionsClient.BeginGetIkeSas
@@ -2910,7 +3071,8 @@ type VPNLinkConnectionsClientBeginResetConnectionOptions struct {
 // VPNLinkConnectionsClientListByVPNConnectionOptions contains the optional parameters for the VPNLinkConnectionsClient.NewListByVPNConnectionPager
 // method.
 type VPNLinkConnectionsClientListByVPNConnectionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VPNServerConfigurationsAssociatedWithVirtualWanClientBeginListOptions contains the optional parameters for the VPNServerConfigurationsAssociatedWithVirtualWanClient.BeginList
@@ -2942,13 +3104,15 @@ type VPNServerConfigurationsClientGetOptions struct {
 // VPNServerConfigurationsClientListByResourceGroupOptions contains the optional parameters for the VPNServerConfigurationsClient.NewListByResourceGroupPager
 // method.
 type VPNServerConfigurationsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VPNServerConfigurationsClientListOptions contains the optional parameters for the VPNServerConfigurationsClient.NewListPager
 // method.
 type VPNServerConfigurationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VPNServerConfigurationsClientUpdateTagsOptions contains the optional parameters for the VPNServerConfigurationsClient.UpdateTags
@@ -2970,7 +3134,8 @@ type VPNSiteLinksClientGetOptions struct {
 // VPNSiteLinksClientListByVPNSiteOptions contains the optional parameters for the VPNSiteLinksClient.NewListByVPNSitePager
 // method.
 type VPNSiteLinksClientListByVPNSiteOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VPNSitesClientBeginCreateOrUpdateOptions contains the optional parameters for the VPNSitesClient.BeginCreateOrUpdate method.
@@ -2993,12 +3158,14 @@ type VPNSitesClientGetOptions struct {
 // VPNSitesClientListByResourceGroupOptions contains the optional parameters for the VPNSitesClient.NewListByResourceGroupPager
 // method.
 type VPNSitesClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VPNSitesClientListOptions contains the optional parameters for the VPNSitesClient.NewListPager method.
 type VPNSitesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VPNSitesClientUpdateTagsOptions contains the optional parameters for the VPNSitesClient.UpdateTags method.
@@ -3037,7 +3204,8 @@ type VirtualApplianceSKUsClientGetOptions struct {
 // VirtualApplianceSKUsClientListOptions contains the optional parameters for the VirtualApplianceSKUsClient.NewListPager
 // method.
 type VirtualApplianceSKUsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualApplianceSitesClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualApplianceSitesClient.BeginCreateOrUpdate
@@ -3062,7 +3230,8 @@ type VirtualApplianceSitesClientGetOptions struct {
 // VirtualApplianceSitesClientListOptions contains the optional parameters for the VirtualApplianceSitesClient.NewListPager
 // method.
 type VirtualApplianceSitesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualAppliancesClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualAppliancesClient.BeginCreateOrUpdate
@@ -3088,12 +3257,14 @@ type VirtualAppliancesClientGetOptions struct {
 // VirtualAppliancesClientListByResourceGroupOptions contains the optional parameters for the VirtualAppliancesClient.NewListByResourceGroupPager
 // method.
 type VirtualAppliancesClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualAppliancesClientListOptions contains the optional parameters for the VirtualAppliancesClient.NewListPager method.
 type VirtualAppliancesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualAppliancesClientUpdateTagsOptions contains the optional parameters for the VirtualAppliancesClient.UpdateTags method.
@@ -3137,7 +3308,8 @@ type VirtualHubBgpConnectionsClientBeginListLearnedRoutesOptions struct {
 // VirtualHubBgpConnectionsClientListOptions contains the optional parameters for the VirtualHubBgpConnectionsClient.NewListPager
 // method.
 type VirtualHubBgpConnectionsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualHubIPConfigurationClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualHubIPConfigurationClient.BeginCreateOrUpdate
@@ -3163,7 +3335,8 @@ type VirtualHubIPConfigurationClientGetOptions struct {
 // VirtualHubIPConfigurationClientListOptions contains the optional parameters for the VirtualHubIPConfigurationClient.NewListPager
 // method.
 type VirtualHubIPConfigurationClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualHubRouteTableV2SClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualHubRouteTableV2SClient.BeginCreateOrUpdate
@@ -3188,7 +3361,8 @@ type VirtualHubRouteTableV2SClientGetOptions struct {
 // VirtualHubRouteTableV2SClientListOptions contains the optional parameters for the VirtualHubRouteTableV2SClient.NewListPager
 // method.
 type VirtualHubRouteTableV2SClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualHubsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualHubsClient.BeginCreateOrUpdate
@@ -3236,12 +3410,14 @@ type VirtualHubsClientGetOptions struct {
 // VirtualHubsClientListByResourceGroupOptions contains the optional parameters for the VirtualHubsClient.NewListByResourceGroupPager
 // method.
 type VirtualHubsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualHubsClientListOptions contains the optional parameters for the VirtualHubsClient.NewListPager method.
 type VirtualHubsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualHubsClientUpdateTagsOptions contains the optional parameters for the VirtualHubsClient.UpdateTags method.
@@ -3330,7 +3506,8 @@ type VirtualNetworkGatewayConnectionsClientGetSharedKeyOptions struct {
 // VirtualNetworkGatewayConnectionsClientListOptions contains the optional parameters for the VirtualNetworkGatewayConnectionsClient.NewListPager
 // method.
 type VirtualNetworkGatewayConnectionsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualNetworkGatewayNatRulesClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualNetworkGatewayNatRulesClient.BeginCreateOrUpdate
@@ -3356,7 +3533,8 @@ type VirtualNetworkGatewayNatRulesClientGetOptions struct {
 // VirtualNetworkGatewayNatRulesClientListByVirtualNetworkGatewayOptions contains the optional parameters for the VirtualNetworkGatewayNatRulesClient.NewListByVirtualNetworkGatewayPager
 // method.
 type VirtualNetworkGatewayNatRulesClientListByVirtualNetworkGatewayOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualNetworkGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualNetworkGatewaysClient.BeginCreateOrUpdate
@@ -3495,13 +3673,15 @@ type VirtualNetworkGatewaysClientGetOptions struct {
 // VirtualNetworkGatewaysClientListConnectionsOptions contains the optional parameters for the VirtualNetworkGatewaysClient.NewListConnectionsPager
 // method.
 type VirtualNetworkGatewaysClientListConnectionsOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualNetworkGatewaysClientListOptions contains the optional parameters for the VirtualNetworkGatewaysClient.NewListPager
 // method.
 type VirtualNetworkGatewaysClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualNetworkGatewaysClientSupportedVPNDevicesOptions contains the optional parameters for the VirtualNetworkGatewaysClient.SupportedVPNDevices
@@ -3541,7 +3721,8 @@ type VirtualNetworkPeeringsClientGetOptions struct {
 // VirtualNetworkPeeringsClientListOptions contains the optional parameters for the VirtualNetworkPeeringsClient.NewListPager
 // method.
 type VirtualNetworkPeeringsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualNetworkTapsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualNetworkTapsClient.BeginCreateOrUpdate
@@ -3566,13 +3747,15 @@ type VirtualNetworkTapsClientGetOptions struct {
 // VirtualNetworkTapsClientListAllOptions contains the optional parameters for the VirtualNetworkTapsClient.NewListAllPager
 // method.
 type VirtualNetworkTapsClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualNetworkTapsClientListByResourceGroupOptions contains the optional parameters for the VirtualNetworkTapsClient.NewListByResourceGroupPager
 // method.
 type VirtualNetworkTapsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualNetworkTapsClientUpdateTagsOptions contains the optional parameters for the VirtualNetworkTapsClient.UpdateTags
@@ -3621,18 +3804,21 @@ type VirtualNetworksClientGetOptions struct {
 
 // VirtualNetworksClientListAllOptions contains the optional parameters for the VirtualNetworksClient.NewListAllPager method.
 type VirtualNetworksClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualNetworksClientListOptions contains the optional parameters for the VirtualNetworksClient.NewListPager method.
 type VirtualNetworksClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualNetworksClientListUsageOptions contains the optional parameters for the VirtualNetworksClient.NewListUsagePager
 // method.
 type VirtualNetworksClientListUsageOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualNetworksClientUpdateTagsOptions contains the optional parameters for the VirtualNetworksClient.UpdateTags method.
@@ -3662,7 +3848,8 @@ type VirtualRouterPeeringsClientGetOptions struct {
 // VirtualRouterPeeringsClientListOptions contains the optional parameters for the VirtualRouterPeeringsClient.NewListPager
 // method.
 type VirtualRouterPeeringsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualRoutersClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualRoutersClient.BeginCreateOrUpdate
@@ -3687,12 +3874,14 @@ type VirtualRoutersClientGetOptions struct {
 // VirtualRoutersClientListByResourceGroupOptions contains the optional parameters for the VirtualRoutersClient.NewListByResourceGroupPager
 // method.
 type VirtualRoutersClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualRoutersClientListOptions contains the optional parameters for the VirtualRoutersClient.NewListPager method.
 type VirtualRoutersClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualWansClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualWansClient.BeginCreateOrUpdate
@@ -3716,12 +3905,14 @@ type VirtualWansClientGetOptions struct {
 // VirtualWansClientListByResourceGroupOptions contains the optional parameters for the VirtualWansClient.NewListByResourceGroupPager
 // method.
 type VirtualWansClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualWansClientListOptions contains the optional parameters for the VirtualWansClient.NewListPager method.
 type VirtualWansClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // VirtualWansClientUpdateTagsOptions contains the optional parameters for the VirtualWansClient.UpdateTags method.
@@ -3827,12 +4018,14 @@ type WatchersClientGetTopologyOptions struct {
 
 // WatchersClientListAllOptions contains the optional parameters for the WatchersClient.NewListAllPager method.
 type WatchersClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // WatchersClientListOptions contains the optional parameters for the WatchersClient.NewListPager method.
 type WatchersClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // WatchersClientUpdateTagsOptions contains the optional parameters for the WatchersClient.UpdateTags method.
@@ -3862,13 +4055,15 @@ type WebApplicationFirewallPoliciesClientGetOptions struct {
 // WebApplicationFirewallPoliciesClientListAllOptions contains the optional parameters for the WebApplicationFirewallPoliciesClient.NewListAllPager
 // method.
 type WebApplicationFirewallPoliciesClientListAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // WebApplicationFirewallPoliciesClientListOptions contains the optional parameters for the WebApplicationFirewallPoliciesClient.NewListPager
 // method.
 type WebApplicationFirewallPoliciesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // WebCategoriesClientGetOptions contains the optional parameters for the WebCategoriesClient.Get method.
@@ -3880,5 +4075,6 @@ type WebCategoriesClientGetOptions struct {
 // WebCategoriesClientListBySubscriptionOptions contains the optional parameters for the WebCategoriesClient.NewListBySubscriptionPager
 // method.
 type WebCategoriesClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/autorest.go/test/network/armnetwork/zz_p2svpngateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_p2svpngateways_client.go
@@ -601,8 +601,10 @@ func (client *P2SVPNGatewaysClient) NewListPager(options *P2SVPNGatewaysClientLi
 		Fetcher: func(ctx context.Context, page *P2SVPNGatewaysClientListResponse) (P2SVPNGatewaysClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "P2SVPNGatewaysClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -657,8 +659,10 @@ func (client *P2SVPNGatewaysClient) NewListByResourceGroupPager(resourceGroupNam
 		Fetcher: func(ctx context.Context, page *P2SVPNGatewaysClientListByResourceGroupResponse) (P2SVPNGatewaysClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "P2SVPNGatewaysClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_peerexpressroutecircuitconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_peerexpressroutecircuitconnections_client.go
@@ -132,8 +132,10 @@ func (client *PeerExpressRouteCircuitConnectionsClient) NewListPager(resourceGro
 		Fetcher: func(ctx context.Context, page *PeerExpressRouteCircuitConnectionsClientListResponse) (PeerExpressRouteCircuitConnectionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PeerExpressRouteCircuitConnectionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, circuitName, peeringName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_privatednszonegroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_privatednszonegroups_client.go
@@ -294,8 +294,10 @@ func (client *PrivateDNSZoneGroupsClient) NewListPager(privateEndpointName strin
 		Fetcher: func(ctx context.Context, page *PrivateDNSZoneGroupsClientListResponse) (PrivateDNSZoneGroupsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PrivateDNSZoneGroupsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, privateEndpointName, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_privateendpoints_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_privateendpoints_client.go
@@ -280,8 +280,10 @@ func (client *PrivateEndpointsClient) NewListPager(resourceGroupName string, opt
 		Fetcher: func(ctx context.Context, page *PrivateEndpointsClientListResponse) (PrivateEndpointsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PrivateEndpointsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -339,8 +341,10 @@ func (client *PrivateEndpointsClient) NewListBySubscriptionPager(options *Privat
 		Fetcher: func(ctx context.Context, page *PrivateEndpointsClientListBySubscriptionResponse) (PrivateEndpointsClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PrivateEndpointsClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_privatelinkservices_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_privatelinkservices_client.go
@@ -595,8 +595,10 @@ func (client *PrivateLinkServicesClient) NewListPager(resourceGroupName string, 
 		Fetcher: func(ctx context.Context, page *PrivateLinkServicesClientListResponse) (PrivateLinkServicesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PrivateLinkServicesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -656,8 +658,10 @@ func (client *PrivateLinkServicesClient) NewListAutoApprovedPrivateLinkServicesP
 		Fetcher: func(ctx context.Context, page *PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse) (PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PrivateLinkServicesClient.NewListAutoApprovedPrivateLinkServicesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAutoApprovedPrivateLinkServicesCreateRequest(ctx, location, options)
@@ -718,8 +722,10 @@ func (client *PrivateLinkServicesClient) NewListAutoApprovedPrivateLinkServicesB
 		Fetcher: func(ctx context.Context, page *PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse) (PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PrivateLinkServicesClient.NewListAutoApprovedPrivateLinkServicesByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAutoApprovedPrivateLinkServicesByResourceGroupCreateRequest(ctx, location, resourceGroupName, options)
@@ -781,8 +787,10 @@ func (client *PrivateLinkServicesClient) NewListBySubscriptionPager(options *Pri
 		Fetcher: func(ctx context.Context, page *PrivateLinkServicesClientListBySubscriptionResponse) (PrivateLinkServicesClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PrivateLinkServicesClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)
@@ -838,8 +846,10 @@ func (client *PrivateLinkServicesClient) NewListPrivateEndpointConnectionsPager(
 		Fetcher: func(ctx context.Context, page *PrivateLinkServicesClientListPrivateEndpointConnectionsResponse) (PrivateLinkServicesClientListPrivateEndpointConnectionsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PrivateLinkServicesClient.NewListPrivateEndpointConnectionsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listPrivateEndpointConnectionsCreateRequest(ctx, resourceGroupName, serviceName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_profiles_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_profiles_client.go
@@ -265,8 +265,10 @@ func (client *ProfilesClient) NewListPager(resourceGroupName string, options *Pr
 		Fetcher: func(ctx context.Context, page *ProfilesClientListResponse) (ProfilesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ProfilesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -323,8 +325,10 @@ func (client *ProfilesClient) NewListAllPager(options *ProfilesClientListAllOpti
 		Fetcher: func(ctx context.Context, page *ProfilesClientListAllResponse) (ProfilesClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ProfilesClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_publicipaddresses_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_publicipaddresses_client.go
@@ -533,8 +533,10 @@ func (client *PublicIPAddressesClient) NewListPager(resourceGroupName string, op
 		Fetcher: func(ctx context.Context, page *PublicIPAddressesClientListResponse) (PublicIPAddressesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PublicIPAddressesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -592,8 +594,10 @@ func (client *PublicIPAddressesClient) NewListAllPager(options *PublicIPAddresse
 		Fetcher: func(ctx context.Context, page *PublicIPAddressesClientListAllResponse) (PublicIPAddressesClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PublicIPAddressesClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)
@@ -649,8 +653,10 @@ func (client *PublicIPAddressesClient) NewListCloudServicePublicIPAddressesPager
 		Fetcher: func(ctx context.Context, page *PublicIPAddressesClientListCloudServicePublicIPAddressesResponse) (PublicIPAddressesClientListCloudServicePublicIPAddressesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PublicIPAddressesClient.NewListCloudServicePublicIPAddressesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCloudServicePublicIPAddressesCreateRequest(ctx, resourceGroupName, cloudServiceName, options)
@@ -718,8 +724,10 @@ func (client *PublicIPAddressesClient) NewListCloudServiceRoleInstancePublicIPAd
 		Fetcher: func(ctx context.Context, page *PublicIPAddressesClientListCloudServiceRoleInstancePublicIPAddressesResponse) (PublicIPAddressesClientListCloudServiceRoleInstancePublicIPAddressesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PublicIPAddressesClient.NewListCloudServiceRoleInstancePublicIPAddressesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCloudServiceRoleInstancePublicIPAddressesCreateRequest(ctx, resourceGroupName, cloudServiceName, roleInstanceName, networkInterfaceName, ipConfigurationName, options)
@@ -796,8 +804,10 @@ func (client *PublicIPAddressesClient) NewListVirtualMachineScaleSetPublicIPAddr
 		Fetcher: func(ctx context.Context, page *PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse) (PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PublicIPAddressesClient.NewListVirtualMachineScaleSetPublicIPAddressesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listVirtualMachineScaleSetPublicIPAddressesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, options)
@@ -865,8 +875,10 @@ func (client *PublicIPAddressesClient) NewListVirtualMachineScaleSetVMPublicIPAd
 		Fetcher: func(ctx context.Context, page *PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse) (PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PublicIPAddressesClient.NewListVirtualMachineScaleSetVMPublicIPAddressesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listVirtualMachineScaleSetVMPublicIPAddressesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, ipConfigurationName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_publicipprefixes_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_publicipprefixes_client.go
@@ -280,8 +280,10 @@ func (client *PublicIPPrefixesClient) NewListPager(resourceGroupName string, opt
 		Fetcher: func(ctx context.Context, page *PublicIPPrefixesClientListResponse) (PublicIPPrefixesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PublicIPPrefixesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -339,8 +341,10 @@ func (client *PublicIPPrefixesClient) NewListAllPager(options *PublicIPPrefixesC
 		Fetcher: func(ctx context.Context, page *PublicIPPrefixesClientListAllResponse) (PublicIPPrefixesClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PublicIPPrefixesClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_routefilterrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routefilterrules_client.go
@@ -293,8 +293,10 @@ func (client *RouteFilterRulesClient) NewListByRouteFilterPager(resourceGroupNam
 		Fetcher: func(ctx context.Context, page *RouteFilterRulesClientListByRouteFilterResponse) (RouteFilterRulesClientListByRouteFilterResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "RouteFilterRulesClient.NewListByRouteFilterPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByRouteFilterCreateRequest(ctx, resourceGroupName, routeFilterName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_routefilters_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routefilters_client.go
@@ -278,8 +278,10 @@ func (client *RouteFiltersClient) NewListPager(options *RouteFiltersClientListOp
 		Fetcher: func(ctx context.Context, page *RouteFiltersClientListResponse) (RouteFiltersClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "RouteFiltersClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -334,8 +336,10 @@ func (client *RouteFiltersClient) NewListByResourceGroupPager(resourceGroupName 
 		Fetcher: func(ctx context.Context, page *RouteFiltersClientListByResourceGroupResponse) (RouteFiltersClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "RouteFiltersClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_routemaps_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routemaps_client.go
@@ -291,8 +291,10 @@ func (client *RouteMapsClient) NewListPager(resourceGroupName string, virtualHub
 		Fetcher: func(ctx context.Context, page *RouteMapsClientListResponse) (RouteMapsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "RouteMapsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, virtualHubName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_routes_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routes_client.go
@@ -291,8 +291,10 @@ func (client *RoutesClient) NewListPager(resourceGroupName string, routeTableNam
 		Fetcher: func(ctx context.Context, page *RoutesClientListResponse) (RoutesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "RoutesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, routeTableName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_routetables_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routetables_client.go
@@ -278,8 +278,10 @@ func (client *RouteTablesClient) NewListPager(resourceGroupName string, options 
 		Fetcher: func(ctx context.Context, page *RouteTablesClientListResponse) (RouteTablesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "RouteTablesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -336,8 +338,10 @@ func (client *RouteTablesClient) NewListAllPager(options *RouteTablesClientListA
 		Fetcher: func(ctx context.Context, page *RouteTablesClientListAllResponse) (RouteTablesClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "RouteTablesClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_routingintent_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routingintent_client.go
@@ -292,8 +292,10 @@ func (client *RoutingIntentClient) NewListPager(resourceGroupName string, virtua
 		Fetcher: func(ctx context.Context, page *RoutingIntentClientListResponse) (RoutingIntentClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "RoutingIntentClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, virtualHubName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_scopeconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_scopeconnections_client.go
@@ -259,8 +259,10 @@ func (client *ScopeConnectionsClient) NewListPager(resourceGroupName string, net
 		Fetcher: func(ctx context.Context, page *ScopeConnectionsClientListResponse) (ScopeConnectionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ScopeConnectionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, networkManagerName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_securityadminconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_securityadminconfigurations_client.go
@@ -286,8 +286,10 @@ func (client *SecurityAdminConfigurationsClient) NewListPager(resourceGroupName 
 		Fetcher: func(ctx context.Context, page *SecurityAdminConfigurationsClientListResponse) (SecurityAdminConfigurationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SecurityAdminConfigurationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, networkManagerName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_securitygroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_securitygroups_client.go
@@ -279,8 +279,10 @@ func (client *SecurityGroupsClient) NewListPager(resourceGroupName string, optio
 		Fetcher: func(ctx context.Context, page *SecurityGroupsClientListResponse) (SecurityGroupsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SecurityGroupsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -338,8 +340,10 @@ func (client *SecurityGroupsClient) NewListAllPager(options *SecurityGroupsClien
 		Fetcher: func(ctx context.Context, page *SecurityGroupsClientListAllResponse) (SecurityGroupsClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SecurityGroupsClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_securitypartnerproviders_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_securitypartnerproviders_client.go
@@ -277,8 +277,10 @@ func (client *SecurityPartnerProvidersClient) NewListPager(options *SecurityPart
 		Fetcher: func(ctx context.Context, page *SecurityPartnerProvidersClientListResponse) (SecurityPartnerProvidersClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SecurityPartnerProvidersClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -333,8 +335,10 @@ func (client *SecurityPartnerProvidersClient) NewListByResourceGroupPager(resour
 		Fetcher: func(ctx context.Context, page *SecurityPartnerProvidersClientListByResourceGroupResponse) (SecurityPartnerProvidersClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SecurityPartnerProvidersClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_securityrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_securityrules_client.go
@@ -292,8 +292,10 @@ func (client *SecurityRulesClient) NewListPager(resourceGroupName string, networ
 		Fetcher: func(ctx context.Context, page *SecurityRulesClientListResponse) (SecurityRulesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SecurityRulesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_serviceendpointpolicies_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_serviceendpointpolicies_client.go
@@ -280,8 +280,10 @@ func (client *ServiceEndpointPoliciesClient) NewListPager(options *ServiceEndpoi
 		Fetcher: func(ctx context.Context, page *ServiceEndpointPoliciesClientListResponse) (ServiceEndpointPoliciesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ServiceEndpointPoliciesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -336,8 +338,10 @@ func (client *ServiceEndpointPoliciesClient) NewListByResourceGroupPager(resourc
 		Fetcher: func(ctx context.Context, page *ServiceEndpointPoliciesClientListByResourceGroupResponse) (ServiceEndpointPoliciesClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ServiceEndpointPoliciesClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_serviceendpointpolicydefinitions_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_serviceendpointpolicydefinitions_client.go
@@ -294,8 +294,10 @@ func (client *ServiceEndpointPolicyDefinitionsClient) NewListByResourceGroupPage
 		Fetcher: func(ctx context.Context, page *ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse) (ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ServiceEndpointPolicyDefinitionsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_servicetaginformation_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_servicetaginformation_client.go
@@ -58,8 +58,10 @@ func (client *ServiceTagInformationClient) NewListPager(location string, options
 		Fetcher: func(ctx context.Context, page *ServiceTagInformationClientListResponse) (ServiceTagInformationClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ServiceTagInformationClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, location, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_staticmembers_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_staticmembers_client.go
@@ -274,8 +274,10 @@ func (client *StaticMembersClient) NewListPager(resourceGroupName string, networ
 		Fetcher: func(ctx context.Context, page *StaticMembersClientListResponse) (StaticMembersClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "StaticMembersClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, networkManagerName, networkGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_subnets_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_subnets_client.go
@@ -294,8 +294,10 @@ func (client *SubnetsClient) NewListPager(resourceGroupName string, virtualNetwo
 		Fetcher: func(ctx context.Context, page *SubnetsClientListResponse) (SubnetsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SubnetsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, virtualNetworkName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_subscriptionnetworkmanagerconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_subscriptionnetworkmanagerconnections_client.go
@@ -229,8 +229,10 @@ func (client *SubscriptionNetworkManagerConnectionsClient) NewListPager(options 
 		Fetcher: func(ctx context.Context, page *SubscriptionNetworkManagerConnectionsClientListResponse) (SubscriptionNetworkManagerConnectionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SubscriptionNetworkManagerConnectionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_usages_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_usages_client.go
@@ -54,8 +54,10 @@ func (client *UsagesClient) NewListPager(location string, options *UsagesClientL
 		Fetcher: func(ctx context.Context, page *UsagesClientListResponse) (UsagesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "UsagesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, location, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualappliances_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualappliances_client.go
@@ -279,8 +279,10 @@ func (client *VirtualAppliancesClient) NewListPager(options *VirtualAppliancesCl
 		Fetcher: func(ctx context.Context, page *VirtualAppliancesClientListResponse) (VirtualAppliancesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualAppliancesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -335,8 +337,10 @@ func (client *VirtualAppliancesClient) NewListByResourceGroupPager(resourceGroup
 		Fetcher: func(ctx context.Context, page *VirtualAppliancesClientListByResourceGroupResponse) (VirtualAppliancesClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualAppliancesClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualappliancesites_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualappliancesites_client.go
@@ -294,8 +294,10 @@ func (client *VirtualApplianceSitesClient) NewListPager(resourceGroupName string
 		Fetcher: func(ctx context.Context, page *VirtualApplianceSitesClientListResponse) (VirtualApplianceSitesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualApplianceSitesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, networkVirtualApplianceName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualapplianceskus_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualapplianceskus_client.go
@@ -114,8 +114,10 @@ func (client *VirtualApplianceSKUsClient) NewListPager(options *VirtualAppliance
 		Fetcher: func(ctx context.Context, page *VirtualApplianceSKUsClientListResponse) (VirtualApplianceSKUsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualApplianceSKUsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualhubbgpconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualhubbgpconnections_client.go
@@ -56,8 +56,10 @@ func (client *VirtualHubBgpConnectionsClient) NewListPager(resourceGroupName str
 		Fetcher: func(ctx context.Context, page *VirtualHubBgpConnectionsClientListResponse) (VirtualHubBgpConnectionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualHubBgpConnectionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, virtualHubName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualhubipconfiguration_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualhubipconfiguration_client.go
@@ -294,8 +294,10 @@ func (client *VirtualHubIPConfigurationClient) NewListPager(resourceGroupName st
 		Fetcher: func(ctx context.Context, page *VirtualHubIPConfigurationClientListResponse) (VirtualHubIPConfigurationClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualHubIPConfigurationClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, virtualHubName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualhubroutetablev2s_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualhubroutetablev2s_client.go
@@ -294,8 +294,10 @@ func (client *VirtualHubRouteTableV2SClient) NewListPager(resourceGroupName stri
 		Fetcher: func(ctx context.Context, page *VirtualHubRouteTableV2SClientListResponse) (VirtualHubRouteTableV2SClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualHubRouteTableV2SClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, virtualHubName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualhubs_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualhubs_client.go
@@ -521,8 +521,10 @@ func (client *VirtualHubsClient) NewListPager(options *VirtualHubsClientListOpti
 		Fetcher: func(ctx context.Context, page *VirtualHubsClientListResponse) (VirtualHubsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualHubsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -577,8 +579,10 @@ func (client *VirtualHubsClient) NewListByResourceGroupPager(resourceGroupName s
 		Fetcher: func(ctx context.Context, page *VirtualHubsClientListByResourceGroupResponse) (VirtualHubsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualHubsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgatewayconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgatewayconnections_client.go
@@ -422,8 +422,10 @@ func (client *VirtualNetworkGatewayConnectionsClient) NewListPager(resourceGroup
 		Fetcher: func(ctx context.Context, page *VirtualNetworkGatewayConnectionsClientListResponse) (VirtualNetworkGatewayConnectionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualNetworkGatewayConnectionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgatewaynatrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgatewaynatrules_client.go
@@ -296,8 +296,10 @@ func (client *VirtualNetworkGatewayNatRulesClient) NewListByVirtualNetworkGatewa
 		Fetcher: func(ctx context.Context, page *VirtualNetworkGatewayNatRulesClientListByVirtualNetworkGatewayResponse) (VirtualNetworkGatewayNatRulesClientListByVirtualNetworkGatewayResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualNetworkGatewayNatRulesClient.NewListByVirtualNetworkGatewayPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByVirtualNetworkGatewayCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgateways_client.go
@@ -1006,8 +1006,10 @@ func (client *VirtualNetworkGatewaysClient) NewListPager(resourceGroupName strin
 		Fetcher: func(ctx context.Context, page *VirtualNetworkGatewaysClientListResponse) (VirtualNetworkGatewaysClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualNetworkGatewaysClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -1067,8 +1069,10 @@ func (client *VirtualNetworkGatewaysClient) NewListConnectionsPager(resourceGrou
 		Fetcher: func(ctx context.Context, page *VirtualNetworkGatewaysClientListConnectionsResponse) (VirtualNetworkGatewaysClientListConnectionsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualNetworkGatewaysClient.NewListConnectionsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listConnectionsCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkpeerings_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkpeerings_client.go
@@ -297,8 +297,10 @@ func (client *VirtualNetworkPeeringsClient) NewListPager(resourceGroupName strin
 		Fetcher: func(ctx context.Context, page *VirtualNetworkPeeringsClientListResponse) (VirtualNetworkPeeringsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualNetworkPeeringsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, virtualNetworkName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworks_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworks_client.go
@@ -348,8 +348,10 @@ func (client *VirtualNetworksClient) NewListPager(resourceGroupName string, opti
 		Fetcher: func(ctx context.Context, page *VirtualNetworksClientListResponse) (VirtualNetworksClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualNetworksClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -407,8 +409,10 @@ func (client *VirtualNetworksClient) NewListAllPager(options *VirtualNetworksCli
 		Fetcher: func(ctx context.Context, page *VirtualNetworksClientListAllResponse) (VirtualNetworksClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualNetworksClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)
@@ -572,8 +576,10 @@ func (client *VirtualNetworksClient) NewListUsagePager(resourceGroupName string,
 		Fetcher: func(ctx context.Context, page *VirtualNetworksClientListUsageResponse) (VirtualNetworksClientListUsageResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualNetworksClient.NewListUsagePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listUsageCreateRequest(ctx, resourceGroupName, virtualNetworkName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworktaps_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworktaps_client.go
@@ -276,8 +276,10 @@ func (client *VirtualNetworkTapsClient) NewListAllPager(options *VirtualNetworkT
 		Fetcher: func(ctx context.Context, page *VirtualNetworkTapsClientListAllResponse) (VirtualNetworkTapsClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualNetworkTapsClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)
@@ -332,8 +334,10 @@ func (client *VirtualNetworkTapsClient) NewListByResourceGroupPager(resourceGrou
 		Fetcher: func(ctx context.Context, page *VirtualNetworkTapsClientListByResourceGroupResponse) (VirtualNetworkTapsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualNetworkTapsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualrouterpeerings_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualrouterpeerings_client.go
@@ -294,8 +294,10 @@ func (client *VirtualRouterPeeringsClient) NewListPager(resourceGroupName string
 		Fetcher: func(ctx context.Context, page *VirtualRouterPeeringsClientListResponse) (VirtualRouterPeeringsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualRouterPeeringsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, virtualRouterName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualrouters_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualrouters_client.go
@@ -278,8 +278,10 @@ func (client *VirtualRoutersClient) NewListPager(options *VirtualRoutersClientLi
 		Fetcher: func(ctx context.Context, page *VirtualRoutersClientListResponse) (VirtualRoutersClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualRoutersClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -334,8 +336,10 @@ func (client *VirtualRoutersClient) NewListByResourceGroupPager(resourceGroupNam
 		Fetcher: func(ctx context.Context, page *VirtualRoutersClientListByResourceGroupResponse) (VirtualRoutersClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualRoutersClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualwans_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualwans_client.go
@@ -274,8 +274,10 @@ func (client *VirtualWansClient) NewListPager(options *VirtualWansClientListOpti
 		Fetcher: func(ctx context.Context, page *VirtualWansClientListResponse) (VirtualWansClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualWansClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -330,8 +332,10 @@ func (client *VirtualWansClient) NewListByResourceGroupPager(resourceGroupName s
 		Fetcher: func(ctx context.Context, page *VirtualWansClientListByResourceGroupResponse) (VirtualWansClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VirtualWansClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnconnections_client.go
@@ -294,8 +294,10 @@ func (client *VPNConnectionsClient) NewListByVPNGatewayPager(resourceGroupName s
 		Fetcher: func(ctx context.Context, page *VPNConnectionsClientListByVPNGatewayResponse) (VPNConnectionsClientListByVPNGatewayResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VPNConnectionsClient.NewListByVPNGatewayPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByVPNGatewayCreateRequest(ctx, resourceGroupName, gatewayName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_vpngateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpngateways_client.go
@@ -274,8 +274,10 @@ func (client *VPNGatewaysClient) NewListPager(options *VPNGatewaysClientListOpti
 		Fetcher: func(ctx context.Context, page *VPNGatewaysClientListResponse) (VPNGatewaysClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VPNGatewaysClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -330,8 +332,10 @@ func (client *VPNGatewaysClient) NewListByResourceGroupPager(resourceGroupName s
 		Fetcher: func(ctx context.Context, page *VPNGatewaysClientListByResourceGroupResponse) (VPNGatewaysClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VPNGatewaysClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnlinkconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnlinkconnections_client.go
@@ -144,8 +144,10 @@ func (client *VPNLinkConnectionsClient) NewListByVPNConnectionPager(resourceGrou
 		Fetcher: func(ctx context.Context, page *VPNLinkConnectionsClientListByVPNConnectionResponse) (VPNLinkConnectionsClientListByVPNConnectionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VPNLinkConnectionsClient.NewListByVPNConnectionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByVPNConnectionCreateRequest(ctx, resourceGroupName, gatewayName, connectionName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnserverconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnserverconfigurations_client.go
@@ -277,8 +277,10 @@ func (client *VPNServerConfigurationsClient) NewListPager(options *VPNServerConf
 		Fetcher: func(ctx context.Context, page *VPNServerConfigurationsClientListResponse) (VPNServerConfigurationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VPNServerConfigurationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -333,8 +335,10 @@ func (client *VPNServerConfigurationsClient) NewListByResourceGroupPager(resourc
 		Fetcher: func(ctx context.Context, page *VPNServerConfigurationsClientListByResourceGroupResponse) (VPNServerConfigurationsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VPNServerConfigurationsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnsitelinks_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnsitelinks_client.go
@@ -125,8 +125,10 @@ func (client *VPNSiteLinksClient) NewListByVPNSitePager(resourceGroupName string
 		Fetcher: func(ctx context.Context, page *VPNSiteLinksClientListByVPNSiteResponse) (VPNSiteLinksClientListByVPNSiteResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VPNSiteLinksClient.NewListByVPNSitePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByVPNSiteCreateRequest(ctx, resourceGroupName, vpnSiteName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnsites_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnsites_client.go
@@ -274,8 +274,10 @@ func (client *VPNSitesClient) NewListPager(options *VPNSitesClientListOptions) *
 		Fetcher: func(ctx context.Context, page *VPNSitesClientListResponse) (VPNSitesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VPNSitesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -330,8 +332,10 @@ func (client *VPNSitesClient) NewListByResourceGroupPager(resourceGroupName stri
 		Fetcher: func(ctx context.Context, page *VPNSitesClientListByResourceGroupResponse) (VPNSitesClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "VPNSitesClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_webapplicationfirewallpolicies_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_webapplicationfirewallpolicies_client.go
@@ -266,8 +266,10 @@ func (client *WebApplicationFirewallPoliciesClient) NewListPager(resourceGroupNa
 		Fetcher: func(ctx context.Context, page *WebApplicationFirewallPoliciesClientListResponse) (WebApplicationFirewallPoliciesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "WebApplicationFirewallPoliciesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -325,8 +327,10 @@ func (client *WebApplicationFirewallPoliciesClient) NewListAllPager(options *Web
 		Fetcher: func(ctx context.Context, page *WebApplicationFirewallPoliciesClientListAllResponse) (WebApplicationFirewallPoliciesClientListAllResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "WebApplicationFirewallPoliciesClient.NewListAllPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/network/armnetwork/zz_webcategories_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_webcategories_client.go
@@ -116,8 +116,10 @@ func (client *WebCategoriesClient) NewListBySubscriptionPager(options *WebCatego
 		Fetcher: func(ctx context.Context, page *WebCategoriesClientListBySubscriptionResponse) (WebCategoriesClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "WebCategoriesClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/autorest.go/test/storage/azblob/zz_container_client.go
+++ b/packages/autorest.go/test/storage/azblob/zz_container_client.go
@@ -954,8 +954,10 @@ func (client *ContainerClient) NewListBlobFlatSegmentPager(containerName string,
 		},
 		Fetcher: func(ctx context.Context, page *ContainerClientListBlobFlatSegmentResponse) (ContainerClientListBlobFlatSegmentResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextMarker != nil {
 				nextLink = *page.NextMarker
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBlobFlatSegmentCreateRequest(ctx, containerName, restype, comp, options)
@@ -1053,8 +1055,10 @@ func (client *ContainerClient) NewListBlobHierarchySegmentPager(containerName st
 		},
 		Fetcher: func(ctx context.Context, page *ContainerClientListBlobHierarchySegmentResponse) (ContainerClientListBlobHierarchySegmentResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextMarker != nil {
 				nextLink = *page.NextMarker
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBlobHierarchySegmentCreateRequest(ctx, containerName, restype, comp, delimiter, options)

--- a/packages/autorest.go/test/storage/azblob/zz_options.go
+++ b/packages/autorest.go/test/storage/azblob/zz_options.go
@@ -920,6 +920,9 @@ type ContainerClientListBlobFlatSegmentOptions struct {
 	// return fewer results than specified by maxresults, or than the default of 5000.
 	Maxresults *int32
 
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Filters the results to return only containers whose name begins with the specified prefix.
 	Prefix *string
 
@@ -951,6 +954,9 @@ type ContainerClientListBlobHierarchySegmentOptions struct {
 	// of the results. For this reason, it is possible that the service will
 	// return fewer results than specified by maxresults, or than the default of 5000.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 
 	// Filters the results to return only containers whose name begins with the specified prefix.
 	Prefix *string
@@ -1202,6 +1208,9 @@ type PageBlobClientGetPageRangesDiffOptions struct {
 	// return fewer results than specified by maxresults, or than the default of 5000.
 	Maxresults *int32
 
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Optional. This header is only supported in service versions 2019-04-19 and after and specifies the URL of a previous snapshot
 	// of the target blob. The response will only contain pages that were changed
 	// between the target blob and its previous snapshot.
@@ -1246,6 +1255,9 @@ type PageBlobClientGetPageRangesOptions struct {
 	// of the results. For this reason, it is possible that the service will
 	// return fewer results than specified by maxresults, or than the default of 5000.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 
 	// Return only the bytes of the blob in the specified range.
 	Range *string
@@ -1431,6 +1443,9 @@ type ServiceClientListContainersSegmentOptions struct {
 	// of the results. For this reason, it is possible that the service will
 	// return fewer results than specified by maxresults, or than the default of 5000.
 	Maxresults *int32
+
+	// Resumes the paging operation from the provided link.
+	NextLink string
 
 	// Filters the results to return only containers whose name begins with the specified prefix.
 	Prefix *string

--- a/packages/autorest.go/test/storage/azblob/zz_pageblob_client.go
+++ b/packages/autorest.go/test/storage/azblob/zz_pageblob_client.go
@@ -521,8 +521,10 @@ func (client *PageBlobClient) NewGetPageRangesPager(containerName string, blob s
 		},
 		Fetcher: func(ctx context.Context, page *PageBlobClientGetPageRangesResponse) (PageBlobClientGetPageRangesResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextMarker != nil {
 				nextLink = *page.NextMarker
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getPageRangesCreateRequest(ctx, containerName, blob, comp, options, leaseAccessConditions, modifiedAccessConditions)
@@ -655,8 +657,10 @@ func (client *PageBlobClient) NewGetPageRangesDiffPager(containerName string, bl
 		},
 		Fetcher: func(ctx context.Context, page *PageBlobClientGetPageRangesDiffResponse) (PageBlobClientGetPageRangesDiffResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextMarker != nil {
 				nextLink = *page.NextMarker
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getPageRangesDiffCreateRequest(ctx, containerName, blob, comp, options, leaseAccessConditions, modifiedAccessConditions)

--- a/packages/autorest.go/test/storage/azblob/zz_service_client.go
+++ b/packages/autorest.go/test/storage/azblob/zz_service_client.go
@@ -422,8 +422,10 @@ func (client *ServiceClient) NewListContainersSegmentPager(comp Enum5, options *
 		},
 		Fetcher: func(ctx context.Context, page *ServiceClientListContainersSegmentResponse) (ServiceClientListContainersSegmentResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextMarker != nil {
 				nextLink = *page.NextMarker
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listContainersSegmentCreateRequest(ctx, comp, options)

--- a/packages/autorest.go/test/synapse/azartifacts/zz_dataflow_client.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_dataflow_client.go
@@ -214,8 +214,10 @@ func (client *DataFlowClient) NewGetDataFlowsByWorkspacePager(options *DataFlowC
 		},
 		Fetcher: func(ctx context.Context, page *DataFlowClientGetDataFlowsByWorkspaceResponse) (DataFlowClientGetDataFlowsByWorkspaceResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getDataFlowsByWorkspaceCreateRequest(ctx, options)

--- a/packages/autorest.go/test/synapse/azartifacts/zz_dataflowdebugsession_client.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_dataflowdebugsession_client.go
@@ -240,8 +240,10 @@ func (client *DataFlowDebugSessionClient) NewQueryDataFlowDebugSessionsByWorkspa
 		},
 		Fetcher: func(ctx context.Context, page *DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse) (DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.queryDataFlowDebugSessionsByWorkspaceCreateRequest(ctx, options)

--- a/packages/autorest.go/test/synapse/azartifacts/zz_dataset_client.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_dataset_client.go
@@ -214,8 +214,10 @@ func (client *DatasetClient) NewGetDatasetsByWorkspacePager(options *DatasetClie
 		},
 		Fetcher: func(ctx context.Context, page *DatasetClientGetDatasetsByWorkspaceResponse) (DatasetClientGetDatasetsByWorkspaceResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getDatasetsByWorkspaceCreateRequest(ctx, options)

--- a/packages/autorest.go/test/synapse/azartifacts/zz_kqlscripts_client.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_kqlscripts_client.go
@@ -31,8 +31,10 @@ func (client *KqlScriptsClient) NewGetAllPager(options *KqlScriptsClientGetAllOp
 		},
 		Fetcher: func(ctx context.Context, page *KqlScriptsClientGetAllResponse) (KqlScriptsClientGetAllResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getAllCreateRequest(ctx, options)

--- a/packages/autorest.go/test/synapse/azartifacts/zz_library_client.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_library_client.go
@@ -377,8 +377,10 @@ func (client *LibraryClient) NewListPager(options *LibraryClientListOptions) *ru
 		},
 		Fetcher: func(ctx context.Context, page *LibraryClientListResponse) (LibraryClientListResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/autorest.go/test/synapse/azartifacts/zz_linkconnection_client.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_linkconnection_client.go
@@ -281,8 +281,10 @@ func (client *LinkConnectionClient) NewListByWorkspacePager(options *LinkConnect
 		},
 		Fetcher: func(ctx context.Context, page *LinkConnectionClientListByWorkspaceResponse) (LinkConnectionClientListByWorkspaceResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByWorkspaceCreateRequest(ctx, options)

--- a/packages/autorest.go/test/synapse/azartifacts/zz_linkedservice_client.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_linkedservice_client.go
@@ -215,8 +215,10 @@ func (client *LinkedServiceClient) NewGetLinkedServicesByWorkspacePager(options 
 		},
 		Fetcher: func(ctx context.Context, page *LinkedServiceClientGetLinkedServicesByWorkspaceResponse) (LinkedServiceClientGetLinkedServicesByWorkspaceResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getLinkedServicesByWorkspaceCreateRequest(ctx, options)

--- a/packages/autorest.go/test/synapse/azartifacts/zz_notebook_client.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_notebook_client.go
@@ -214,8 +214,10 @@ func (client *NotebookClient) NewGetNotebookSummaryByWorkSpacePager(options *Not
 		},
 		Fetcher: func(ctx context.Context, page *NotebookClientGetNotebookSummaryByWorkSpaceResponse) (NotebookClientGetNotebookSummaryByWorkSpaceResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getNotebookSummaryByWorkSpaceCreateRequest(ctx, options)
@@ -263,8 +265,10 @@ func (client *NotebookClient) NewGetNotebooksByWorkspacePager(options *NotebookC
 		},
 		Fetcher: func(ctx context.Context, page *NotebookClientGetNotebooksByWorkspaceResponse) (NotebookClientGetNotebooksByWorkspaceResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getNotebooksByWorkspaceCreateRequest(ctx, options)

--- a/packages/autorest.go/test/synapse/azartifacts/zz_options.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_options.go
@@ -48,7 +48,8 @@ type DataFlowClientGetDataFlowOptions struct {
 // DataFlowClientGetDataFlowsByWorkspaceOptions contains the optional parameters for the DataFlowClient.NewGetDataFlowsByWorkspacePager
 // method.
 type DataFlowClientGetDataFlowsByWorkspaceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DataFlowDebugSessionClientAddDataFlowOptions contains the optional parameters for the DataFlowDebugSessionClient.AddDataFlow
@@ -80,7 +81,8 @@ type DataFlowDebugSessionClientDeleteDataFlowDebugSessionOptions struct {
 // DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceOptions contains the optional parameters for the DataFlowDebugSessionClient.NewQueryDataFlowDebugSessionsByWorkspacePager
 // method.
 type DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DatasetClientBeginCreateOrUpdateDatasetOptions contains the optional parameters for the DatasetClient.BeginCreateOrUpdateDataset
@@ -116,7 +118,8 @@ type DatasetClientGetDatasetOptions struct {
 // DatasetClientGetDatasetsByWorkspaceOptions contains the optional parameters for the DatasetClient.NewGetDatasetsByWorkspacePager
 // method.
 type DatasetClientGetDatasetsByWorkspaceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // IntegrationRuntimesClientGetOptions contains the optional parameters for the IntegrationRuntimesClient.Get method.
@@ -155,7 +158,8 @@ type KqlScriptClientGetByNameOptions struct {
 
 // KqlScriptsClientGetAllOptions contains the optional parameters for the KqlScriptsClient.NewGetAllPager method.
 type KqlScriptsClientGetAllOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LibraryClientAppendOptions contains the optional parameters for the LibraryClient.Append method.
@@ -196,7 +200,8 @@ type LibraryClientGetOptions struct {
 
 // LibraryClientListOptions contains the optional parameters for the LibraryClient.NewListPager method.
 type LibraryClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LinkConnectionClientCreateOrUpdateOptions contains the optional parameters for the LinkConnectionClient.CreateOrUpdate
@@ -229,7 +234,8 @@ type LinkConnectionClientGetOptions struct {
 // LinkConnectionClientListByWorkspaceOptions contains the optional parameters for the LinkConnectionClient.NewListByWorkspacePager
 // method.
 type LinkConnectionClientListByWorkspaceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LinkConnectionClientListLinkTablesOptions contains the optional parameters for the LinkConnectionClient.ListLinkTables
@@ -306,7 +312,8 @@ type LinkedServiceClientGetLinkedServiceOptions struct {
 // LinkedServiceClientGetLinkedServicesByWorkspaceOptions contains the optional parameters for the LinkedServiceClient.NewGetLinkedServicesByWorkspacePager
 // method.
 type LinkedServiceClientGetLinkedServicesByWorkspaceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // MetastoreClientDeleteOptions contains the optional parameters for the MetastoreClient.Delete method.
@@ -363,13 +370,15 @@ type NotebookClientGetNotebookOptions struct {
 // NotebookClientGetNotebookSummaryByWorkSpaceOptions contains the optional parameters for the NotebookClient.NewGetNotebookSummaryByWorkSpacePager
 // method.
 type NotebookClientGetNotebookSummaryByWorkSpaceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // NotebookClientGetNotebooksByWorkspaceOptions contains the optional parameters for the NotebookClient.NewGetNotebooksByWorkspacePager
 // method.
 type NotebookClientGetNotebooksByWorkspaceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // NotebookOperationResultClientGetOptions contains the optional parameters for the NotebookOperationResultClient.Get method.
@@ -426,7 +435,8 @@ type PipelineClientGetPipelineOptions struct {
 // PipelineClientGetPipelinesByWorkspaceOptions contains the optional parameters for the PipelineClient.NewGetPipelinesByWorkspacePager
 // method.
 type PipelineClientGetPipelinesByWorkspaceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PipelineRunClientCancelPipelineRunOptions contains the optional parameters for the PipelineRunClient.CancelPipelineRun
@@ -498,7 +508,8 @@ type SQLScriptClientGetSQLScriptOptions struct {
 // SQLScriptClientGetSQLScriptsByWorkspaceOptions contains the optional parameters for the SQLScriptClient.NewGetSQLScriptsByWorkspacePager
 // method.
 type SQLScriptClientGetSQLScriptsByWorkspaceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SparkConfigurationClientBeginCreateOrUpdateSparkConfigurationOptions contains the optional parameters for the SparkConfigurationClient.BeginCreateOrUpdateSparkConfiguration
@@ -537,7 +548,8 @@ type SparkConfigurationClientGetSparkConfigurationOptions struct {
 // SparkConfigurationClientGetSparkConfigurationsByWorkspaceOptions contains the optional parameters for the SparkConfigurationClient.NewGetSparkConfigurationsByWorkspacePager
 // method.
 type SparkConfigurationClientGetSparkConfigurationsByWorkspaceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinitionClient.BeginCreateOrUpdateSparkJobDefinition
@@ -590,7 +602,8 @@ type SparkJobDefinitionClientGetSparkJobDefinitionOptions struct {
 // SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceOptions contains the optional parameters for the SparkJobDefinitionClient.NewGetSparkJobDefinitionsByWorkspacePager
 // method.
 type SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // TriggerClientBeginCreateOrUpdateTriggerOptions contains the optional parameters for the TriggerClient.BeginCreateOrUpdateTrigger
@@ -652,7 +665,8 @@ type TriggerClientGetTriggerOptions struct {
 // TriggerClientGetTriggersByWorkspaceOptions contains the optional parameters for the TriggerClient.NewGetTriggersByWorkspacePager
 // method.
 type TriggerClientGetTriggersByWorkspaceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // TriggerRunClientCancelTriggerInstanceOptions contains the optional parameters for the TriggerRunClient.CancelTriggerInstance

--- a/packages/autorest.go/test/synapse/azartifacts/zz_pipeline_client.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_pipeline_client.go
@@ -282,8 +282,10 @@ func (client *PipelineClient) NewGetPipelinesByWorkspacePager(options *PipelineC
 		},
 		Fetcher: func(ctx context.Context, page *PipelineClientGetPipelinesByWorkspaceResponse) (PipelineClientGetPipelinesByWorkspaceResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getPipelinesByWorkspaceCreateRequest(ctx, options)

--- a/packages/autorest.go/test/synapse/azartifacts/zz_sparkconfiguration_client.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_sparkconfiguration_client.go
@@ -215,8 +215,10 @@ func (client *SparkConfigurationClient) NewGetSparkConfigurationsByWorkspacePage
 		},
 		Fetcher: func(ctx context.Context, page *SparkConfigurationClientGetSparkConfigurationsByWorkspaceResponse) (SparkConfigurationClientGetSparkConfigurationsByWorkspaceResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getSparkConfigurationsByWorkspaceCreateRequest(ctx, options)

--- a/packages/autorest.go/test/synapse/azartifacts/zz_sparkjobdefinition_client.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_sparkjobdefinition_client.go
@@ -336,8 +336,10 @@ func (client *SparkJobDefinitionClient) NewGetSparkJobDefinitionsByWorkspacePage
 		},
 		Fetcher: func(ctx context.Context, page *SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse) (SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getSparkJobDefinitionsByWorkspaceCreateRequest(ctx, options)

--- a/packages/autorest.go/test/synapse/azartifacts/zz_sqlscript_client.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_sqlscript_client.go
@@ -214,8 +214,10 @@ func (client *SQLScriptClient) NewGetSQLScriptsByWorkspacePager(options *SQLScri
 		},
 		Fetcher: func(ctx context.Context, page *SQLScriptClientGetSQLScriptsByWorkspaceResponse) (SQLScriptClientGetSQLScriptsByWorkspaceResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getSQLScriptsByWorkspaceCreateRequest(ctx, options)

--- a/packages/autorest.go/test/synapse/azartifacts/zz_trigger_client.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_trigger_client.go
@@ -266,8 +266,10 @@ func (client *TriggerClient) NewGetTriggersByWorkspacePager(options *TriggerClie
 		},
 		Fetcher: func(ctx context.Context, page *TriggerClientGetTriggersByWorkspaceResponse) (TriggerClientGetTriggersByWorkspaceResponse, error) {
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getTriggersByWorkspaceCreateRequest(ctx, options)

--- a/packages/codegen.go/src/fake/servers.ts
+++ b/packages/codegen.go/src/fake/servers.ts
@@ -831,8 +831,8 @@ function parseHeaderPathQueryParams(clientPkg: string, method: go.Method, import
       // client params and parameter literals aren't passed to APIs
       continue;
     }
-    if (go.isResumeTokenParameter(param)) {
-      // skip the ResumeToken param as we don't send that back to the caller
+    if (go.isResumeTokenParameter(param) || go.isNextLinkParameter(param)) {
+      // skip the ResumeToken and NextLink params as we don't send them back to the caller
       continue;
     }
 
@@ -1183,7 +1183,7 @@ function populateApiParams(clientPkg: string, method: go.Method, paramValues: Ma
     if (helpers.isParameterGroup(param)) {
       if (param.groupName === method.optionalParamsGroup.groupName) {
         // this is the optional params type. in some cases we just pass nil
-        const countParams = values(param.params).where((each: go.Parameter) => { return !go.isResumeTokenParameter(each); }).count();
+        const countParams = values(param.params).where((each: go.Parameter) => { return !go.isResumeTokenParameter(each) && !go.isNextLinkParameter(each); }).count();
         if (countParams === 0) {
           // if the options param is empty or only contains the resume token param just pass nil
           params.push('nil');

--- a/packages/codegen.go/src/helpers.ts
+++ b/packages/codegen.go/src/helpers.ts
@@ -104,8 +104,8 @@ export function getCreateRequestParametersSig(method: go.Method | go.NextPageMet
   for (const methodParam of values(methodParams)) {
     let paramName = uncapitalize(methodParam.name);
     // when creating the method sig for fooCreateRequest, if the options type is empty
-    // or only contains the ResumeToken param use _ for the param name to quiet the linter
-    if (isParameterGroup(methodParam) && (methodParam.params.length === 0 || (methodParam.params.length === 1 && go.isResumeTokenParameter(methodParam.params[0])))) {
+    // or only contains the ResumeToken or NextLink param use _ for the param name to quiet the linter
+    if (isParameterGroup(methodParam) && (methodParam.params.length === 0 || (methodParam.params.length === 1 && (go.isResumeTokenParameter(methodParam.params[0]) || go.isNextLinkParameter(methodParam.params[0]))))) {
       paramName = '_';
     }
     params.push(`${paramName} ${formatParameterTypeName(methodParam)}`);

--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -358,8 +358,11 @@ function emitPagerDefinition(client: go.Client, method: go.PageableMethod, impor
     if (!go.isLROMethod(method)) {
       text += '\t\t\tnextLink := ""\n';
       nextLinkVar = 'nextLink';
-      text += '\t\t\tif page != nil {\n';
-      text += `\t\t\t\tnextLink = *page.${method.nextLinkName}\n\t\t\t}\n`;
+      text += `\t\t\tif page != nil && page.${method.nextLinkName} != nil {\n`;
+      text += `\t\t\t\tnextLink = *page.${method.nextLinkName}\n`;
+      text += `\t\t\t} else if options != nil && options.NextLink != "" {\n`;
+      text += `\t\t\t\tnextLink = options.NextLink\n`;
+      text += `\t\t\t}\n`;
     } else {
       nextLinkVar = `*page.${method.nextLinkName}`;
     }
@@ -1234,7 +1237,7 @@ function generateLROBeginMethod(client: go.Client, method: go.LROMethod, imports
   let pollerType = 'nil';
   let pollerTypeParam = `[${method.responseEnvelope.name}]`;
   if (go.isPageableMethod(method)) {
-    // for paged LROs, we construct a pager and pass it to the LRO ctor.
+    // for paged LROs, we construct a pager and pass it to the LRO actor.
     pollerTypeParam = `[*runtime.Pager${pollerTypeParam}]`;
     pollerType = '&pager';
     text += '\tpager := ';

--- a/packages/codemodel.go/src/param.ts
+++ b/packages/codemodel.go/src/param.ts
@@ -181,6 +181,10 @@ export interface ResumeTokenParameter extends Parameter {
   isResumeToken: true;
 }
 
+export interface NextLinkParameter extends Parameter {
+  isNextLink: true;
+}
+
 export function isBodyParameter(param: Parameter): param is BodyParameter {
   return (<BodyParameter>param).bodyFormat !== undefined;
 }
@@ -235,6 +239,10 @@ export function isURIParameter(param: Parameter): param is URIParameter {
 
 export function isResumeTokenParameter(param: Parameter): param is ResumeTokenParameter {
   return (<ResumeTokenParameter>param).isResumeToken !== undefined;
+}
+
+export function isNextLinkParameter(param: Parameter): param is NextLinkParameter {
+  return (<NextLinkParameter>param).isNextLink !== undefined;
 }
 
 export function isRequiredParameter(param: Parameter): boolean {
@@ -377,6 +385,14 @@ export class ResumeTokenParameter extends Parameter implements ResumeTokenParame
     super('ResumeToken', new type.PrimitiveType('string'), 'optional', true, 'method');
     this.isResumeToken = true;
     this.docs.summary = 'Resumes the long-running operation from the provided token.';
+  }
+}
+
+export class NextLinkParameter extends Parameter implements NextLinkParameter {
+  constructor() {
+    super('NextLink', new type.PrimitiveType('string'), 'optional', true, 'method');
+    this.isNextLink = true;
+    this.docs.summary = 'Resumes the paging operation from the provided link.';
   }
 }
 

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -303,6 +303,9 @@ export class clientAdapter {
       if (go.isLROMethod(method)) {
         optionalGroup.params.push(new go.ResumeTokenParameter());
       }
+      if (go.isPageableMethod(method)) {
+        optionalGroup.params.push(new go.NextLinkParameter());
+      }
     }
 
     // stuff all of the operation parameters into one array for easy traversal

--- a/packages/typespec-go/test/azure-http-specs/azure/core/azurepagegroup/zz_options.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/core/azurepagegroup/zz_options.go
@@ -7,16 +7,21 @@ package azurepagegroup
 // PageClientListWithCustomPageModelOptions contains the optional parameters for the PageClient.NewListWithCustomPageModelPager
 // method.
 type PageClientListWithCustomPageModelOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PageClientListWithPageOptions contains the optional parameters for the PageClient.NewListWithPagePager method.
 type PageClientListWithPageOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PageClientListWithParametersOptions contains the optional parameters for the PageClient.NewListWithParametersPager method.
 type PageClientListWithParametersOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Another query parameter.
 	Another *ListItemInputExtensibleEnum
 }
@@ -24,11 +29,13 @@ type PageClientListWithParametersOptions struct {
 // PageTwoModelsAsPageItemClientListFirstItemOptions contains the optional parameters for the PageTwoModelsAsPageItemClient.NewListFirstItemPager
 // method.
 type PageTwoModelsAsPageItemClientListFirstItemOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PageTwoModelsAsPageItemClientListSecondItemOptions contains the optional parameters for the PageTwoModelsAsPageItemClient.NewListSecondItemPager
 // method.
 type PageTwoModelsAsPageItemClientListSecondItemOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/typespec-go/test/azure-http-specs/azure/core/azurepagegroup/zz_page_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/core/azurepagegroup/zz_page_client.go
@@ -38,8 +38,10 @@ func (client *PageClient) NewListWithCustomPageModelPager(options *PageClientLis
 		Fetcher: func(ctx context.Context, page *PageClientListWithCustomPageModelResponse) (PageClientListWithCustomPageModelResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PageClient.NewListWithCustomPageModelPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listWithCustomPageModelCreateRequest(ctx, options)
@@ -88,8 +90,10 @@ func (client *PageClient) NewListWithPagePager(options *PageClientListWithPageOp
 		Fetcher: func(ctx context.Context, page *PageClientListWithPageResponse) (PageClientListWithPageResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PageClient.NewListWithPagePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listWithPageCreateRequest(ctx, options)
@@ -140,8 +144,10 @@ func (client *PageClient) NewListWithParametersPager(bodyInput ListItemInputBody
 		Fetcher: func(ctx context.Context, page *PageClientListWithParametersResponse) (PageClientListWithParametersResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PageClient.NewListWithParametersPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listWithParametersCreateRequest(ctx, bodyInput, options)

--- a/packages/typespec-go/test/azure-http-specs/azure/core/azurepagegroup/zz_pagetwomodelsaspageitem_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/core/azurepagegroup/zz_pagetwomodelsaspageitem_client.go
@@ -32,8 +32,10 @@ func (client *PageTwoModelsAsPageItemClient) NewListFirstItemPager(options *Page
 		Fetcher: func(ctx context.Context, page *PageTwoModelsAsPageItemClientListFirstItemResponse) (PageTwoModelsAsPageItemClientListFirstItemResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PageTwoModelsAsPageItemClient.NewListFirstItemPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listFirstItemCreateRequest(ctx, options)
@@ -84,8 +86,10 @@ func (client *PageTwoModelsAsPageItemClient) NewListSecondItemPager(options *Pag
 		Fetcher: func(ctx context.Context, page *PageTwoModelsAsPageItemClientListSecondItemResponse) (PageTwoModelsAsPageItemClientListSecondItemResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PageTwoModelsAsPageItemClient.NewListSecondItemPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listSecondItemCreateRequest(ctx, options)

--- a/packages/typespec-go/test/azure-http-specs/azure/core/basicgroup/zz_basic_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/core/basicgroup/zz_basic_client.go
@@ -361,8 +361,10 @@ func (client *BasicClient) NewListPager(options *BasicClientListOptions) *runtim
 		Fetcher: func(ctx context.Context, page *BasicClientListResponse) (BasicClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "BasicClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/typespec-go/test/azure-http-specs/azure/core/basicgroup/zz_options.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/core/basicgroup/zz_options.go
@@ -36,6 +36,9 @@ type BasicClientGetOptions struct {
 
 // BasicClientListOptions contains the optional parameters for the BasicClient.NewListPager method.
 type BasicClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Expand the indicated resources into the response.
 	Expand []string
 

--- a/packages/typespec-go/test/azure-http-specs/azure/payload/pageablegroup/zz_options.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/payload/pageablegroup/zz_options.go
@@ -6,6 +6,9 @@ package pageablegroup
 
 // PageableClientListOptions contains the optional parameters for the PageableClient.NewListPager method.
 type PageableClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// The maximum number of result items per page.
 	Maxpagesize *int32
 }

--- a/packages/typespec-go/test/azure-http-specs/azure/payload/pageablegroup/zz_pageable_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/payload/pageablegroup/zz_pageable_client.go
@@ -29,8 +29,10 @@ func (client *PageableClient) NewListPager(options *PageableClientListOptions) *
 		Fetcher: func(ctx context.Context, page *PageableClientListResponse) (PageableClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PageableClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_extensionsresources_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_extensionsresources_client.go
@@ -230,8 +230,10 @@ func (client *ExtensionsResourcesClient) NewListByScopePager(resourceURI string,
 		Fetcher: func(ctx context.Context, page *ExtensionsResourcesClientListByScopeResponse) (ExtensionsResourcesClientListByScopeResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ExtensionsResourcesClient.NewListByScopePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByScopeCreateRequest(ctx, resourceURI, options)

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_locationresources_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_locationresources_client.go
@@ -242,8 +242,10 @@ func (client *LocationResourcesClient) NewListByLocationPager(location string, o
 		Fetcher: func(ctx context.Context, page *LocationResourcesClientListByLocationResponse) (LocationResourcesClientListByLocationResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LocationResourcesClient.NewListByLocationPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByLocationCreateRequest(ctx, location, options)

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_nested_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_nested_client.go
@@ -289,8 +289,10 @@ func (client *NestedClient) NewListByTopLevelTrackedResourcePager(resourceGroupN
 		Fetcher: func(ctx context.Context, page *NestedClientListByTopLevelTrackedResourceResponse) (NestedClientListByTopLevelTrackedResourceResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "NestedClient.NewListByTopLevelTrackedResourcePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByTopLevelTrackedResourceCreateRequest(ctx, resourceGroupName, topLevelTrackedResourceName, options)

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_options.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_options.go
@@ -24,7 +24,8 @@ type ExtensionsResourcesClientGetOptions struct {
 // ExtensionsResourcesClientListByScopeOptions contains the optional parameters for the ExtensionsResourcesClient.NewListByScopePager
 // method.
 type ExtensionsResourcesClientListByScopeOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ExtensionsResourcesClientUpdateOptions contains the optional parameters for the ExtensionsResourcesClient.Update method.
@@ -51,7 +52,8 @@ type LocationResourcesClientGetOptions struct {
 // LocationResourcesClientListByLocationOptions contains the optional parameters for the LocationResourcesClient.NewListByLocationPager
 // method.
 type LocationResourcesClientListByLocationOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LocationResourcesClientUpdateOptions contains the optional parameters for the LocationResourcesClient.Update method.
@@ -85,7 +87,8 @@ type NestedClientGetOptions struct {
 // NestedClientListByTopLevelTrackedResourceOptions contains the optional parameters for the NestedClient.NewListByTopLevelTrackedResourcePager
 // method.
 type NestedClientListByTopLevelTrackedResourceOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SingletonClientBeginCreateOrUpdateOptions contains the optional parameters for the SingletonClient.BeginCreateOrUpdate
@@ -103,7 +106,8 @@ type SingletonClientGetByResourceGroupOptions struct {
 // SingletonClientListByResourceGroupOptions contains the optional parameters for the SingletonClient.NewListByResourceGroupPager
 // method.
 type SingletonClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SingletonClientUpdateOptions contains the optional parameters for the SingletonClient.Update method.
@@ -143,11 +147,13 @@ type TopLevelClientGetOptions struct {
 // TopLevelClientListByResourceGroupOptions contains the optional parameters for the TopLevelClient.NewListByResourceGroupPager
 // method.
 type TopLevelClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // TopLevelClientListBySubscriptionOptions contains the optional parameters for the TopLevelClient.NewListBySubscriptionPager
 // method.
 type TopLevelClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_singleton_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_singleton_client.go
@@ -189,8 +189,10 @@ func (client *SingletonClient) NewListByResourceGroupPager(resourceGroupName str
 		Fetcher: func(ctx context.Context, page *SingletonClientListByResourceGroupResponse) (SingletonClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SingletonClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_toplevel_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_toplevel_client.go
@@ -332,8 +332,10 @@ func (client *TopLevelClient) NewListByResourceGroupPager(resourceGroupName stri
 		Fetcher: func(ctx context.Context, page *TopLevelClientListByResourceGroupResponse) (TopLevelClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "TopLevelClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -391,8 +393,10 @@ func (client *TopLevelClient) NewListBySubscriptionPager(options *TopLevelClient
 		Fetcher: func(ctx context.Context, page *TopLevelClientListBySubscriptionResponse) (TopLevelClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "TopLevelClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/typespec-go/test/http-specs/payload/pageablegroup/zz_options.go
+++ b/packages/typespec-go/test/http-specs/payload/pageablegroup/zz_options.go
@@ -7,5 +7,6 @@ package pageablegroup
 // PageableServerDrivenPaginationClientLinkOptions contains the optional parameters for the PageableServerDrivenPaginationClient.NewLinkPager
 // method.
 type PageableServerDrivenPaginationClientLinkOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/typespec-go/test/http-specs/payload/pageablegroup/zz_pageableserverdrivenpagination_client.go
+++ b/packages/typespec-go/test/http-specs/payload/pageablegroup/zz_pageableserverdrivenpagination_client.go
@@ -28,8 +28,10 @@ func (client *PageableServerDrivenPaginationClient) NewLinkPager(options *Pageab
 		Fetcher: func(ctx context.Context, page *PageableServerDrivenPaginationClientLinkResponse) (PageableServerDrivenPaginationClientLinkResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PageableServerDrivenPaginationClient.NewLinkPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.Next != nil {
 				nextLink = *page.Next
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.linkCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armapicenter/zz_apidefinitions_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_apidefinitions_client.go
@@ -580,8 +580,10 @@ func (client *APIDefinitionsClient) NewListPager(resourceGroupName string, servi
 		Fetcher: func(ctx context.Context, page *APIDefinitionsClientListResponse) (APIDefinitionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "APIDefinitionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, serviceName, workspaceName, apiName, versionName, options)

--- a/packages/typespec-go/test/local/armapicenter/zz_apis_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_apis_client.go
@@ -340,8 +340,10 @@ func (client *ApisClient) NewListPager(resourceGroupName string, serviceName str
 		Fetcher: func(ctx context.Context, page *ApisClientListResponse) (ApisClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ApisClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, serviceName, workspaceName, options)

--- a/packages/typespec-go/test/local/armapicenter/zz_apiversions_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_apiversions_client.go
@@ -362,8 +362,10 @@ func (client *APIVersionsClient) NewListPager(resourceGroupName string, serviceN
 		Fetcher: func(ctx context.Context, page *APIVersionsClientListResponse) (APIVersionsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "APIVersionsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, serviceName, workspaceName, apiName, options)

--- a/packages/typespec-go/test/local/armapicenter/zz_deletedservices_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_deletedservices_client.go
@@ -174,8 +174,10 @@ func (client *DeletedServicesClient) NewListPager(resourceGroupName string, opti
 		Fetcher: func(ctx context.Context, page *DeletedServicesClientListResponse) (DeletedServicesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DeletedServicesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, options)
@@ -236,8 +238,10 @@ func (client *DeletedServicesClient) NewListBySubscriptionPager(options *Deleted
 		Fetcher: func(ctx context.Context, page *DeletedServicesClientListBySubscriptionResponse) (DeletedServicesClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DeletedServicesClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armapicenter/zz_deployments_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_deployments_client.go
@@ -362,8 +362,10 @@ func (client *DeploymentsClient) NewListPager(resourceGroupName string, serviceN
 		Fetcher: func(ctx context.Context, page *DeploymentsClientListResponse) (DeploymentsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "DeploymentsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, serviceName, workspaceName, apiName, options)

--- a/packages/typespec-go/test/local/armapicenter/zz_environments_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_environments_client.go
@@ -341,8 +341,10 @@ func (client *EnvironmentsClient) NewListPager(resourceGroupName string, service
 		Fetcher: func(ctx context.Context, page *EnvironmentsClientListResponse) (EnvironmentsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "EnvironmentsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, serviceName, workspaceName, options)

--- a/packages/typespec-go/test/local/armapicenter/zz_metadataschemas_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_metadataschemas_client.go
@@ -321,8 +321,10 @@ func (client *MetadataSchemasClient) NewListPager(resourceGroupName string, serv
 		Fetcher: func(ctx context.Context, page *MetadataSchemasClientListResponse) (MetadataSchemasClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "MetadataSchemasClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, serviceName, options)

--- a/packages/typespec-go/test/local/armapicenter/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_operations_client.go
@@ -45,8 +45,10 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 		Fetcher: func(ctx context.Context, page *OperationsClientListResponse) (OperationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "OperationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armapicenter/zz_options.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_options.go
@@ -41,6 +41,9 @@ type APIDefinitionsClientHeadOptions struct {
 
 // APIDefinitionsClientListOptions contains the optional parameters for the APIDefinitionsClient.NewListPager method.
 type APIDefinitionsClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// OData filter parameter.
 	Filter *string
 }
@@ -67,6 +70,9 @@ type APIVersionsClientHeadOptions struct {
 
 // APIVersionsClientListOptions contains the optional parameters for the APIVersionsClient.NewListPager method.
 type APIVersionsClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// OData filter parameter.
 	Filter *string
 }
@@ -93,6 +99,9 @@ type ApisClientHeadOptions struct {
 
 // ApisClientListOptions contains the optional parameters for the ApisClient.NewListPager method.
 type ApisClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// OData filter parameter.
 	Filter *string
 }
@@ -110,11 +119,15 @@ type DeletedServicesClientGetOptions struct {
 // DeletedServicesClientListBySubscriptionOptions contains the optional parameters for the DeletedServicesClient.NewListBySubscriptionPager
 // method.
 type DeletedServicesClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // DeletedServicesClientListOptions contains the optional parameters for the DeletedServicesClient.NewListPager method.
 type DeletedServicesClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// OData filter parameter.
 	Filter *string
 }
@@ -141,6 +154,9 @@ type DeploymentsClientHeadOptions struct {
 
 // DeploymentsClientListOptions contains the optional parameters for the DeploymentsClient.NewListPager method.
 type DeploymentsClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// OData filter parameter.
 	Filter *string
 }
@@ -167,6 +183,9 @@ type EnvironmentsClientHeadOptions struct {
 
 // EnvironmentsClientListOptions contains the optional parameters for the EnvironmentsClient.NewListPager method.
 type EnvironmentsClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// OData filter parameter.
 	Filter *string
 }
@@ -194,13 +213,17 @@ type MetadataSchemasClientHeadOptions struct {
 
 // MetadataSchemasClientListOptions contains the optional parameters for the MetadataSchemasClient.NewListPager method.
 type MetadataSchemasClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// OData filter parameter.
 	Filter *string
 }
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 type OperationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ServicesClientBeginExportMetadataSchemaOptions contains the optional parameters for the ServicesClient.BeginExportMetadataSchema
@@ -228,13 +251,15 @@ type ServicesClientGetOptions struct {
 // ServicesClientListByResourceGroupOptions contains the optional parameters for the ServicesClient.NewListByResourceGroupPager
 // method.
 type ServicesClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ServicesClientListBySubscriptionOptions contains the optional parameters for the ServicesClient.NewListBySubscriptionPager
 // method.
 type ServicesClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ServicesClientUpdateOptions contains the optional parameters for the ServicesClient.Update method.
@@ -264,6 +289,9 @@ type WorkspacesClientHeadOptions struct {
 
 // WorkspacesClientListOptions contains the optional parameters for the WorkspacesClient.NewListPager method.
 type WorkspacesClientListOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// OData filter parameter.
 	Filter *string
 }

--- a/packages/typespec-go/test/local/armapicenter/zz_services_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_services_client.go
@@ -321,8 +321,10 @@ func (client *ServicesClient) NewListByResourceGroupPager(resourceGroupName stri
 		Fetcher: func(ctx context.Context, page *ServicesClientListByResourceGroupResponse) (ServicesClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ServicesClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -380,8 +382,10 @@ func (client *ServicesClient) NewListBySubscriptionPager(options *ServicesClient
 		Fetcher: func(ctx context.Context, page *ServicesClientListBySubscriptionResponse) (ServicesClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ServicesClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armapicenter/zz_workspaces_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_workspaces_client.go
@@ -320,8 +320,10 @@ func (client *WorkspacesClient) NewListPager(resourceGroupName string, serviceNa
 		Fetcher: func(ctx context.Context, page *WorkspacesClientListResponse) (WorkspacesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "WorkspacesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceGroupName, serviceName, options)

--- a/packages/typespec-go/test/local/armcodesigning/zz_accounts_client.go
+++ b/packages/typespec-go/test/local/armcodesigning/zz_accounts_client.go
@@ -333,8 +333,10 @@ func (client *AccountsClient) NewListByResourceGroupPager(resourceGroupName stri
 		Fetcher: func(ctx context.Context, page *AccountsClientListByResourceGroupResponse) (AccountsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AccountsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -392,8 +394,10 @@ func (client *AccountsClient) NewListBySubscriptionPager(options *AccountsClient
 		Fetcher: func(ctx context.Context, page *AccountsClientListBySubscriptionResponse) (AccountsClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AccountsClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armcodesigning/zz_certificateprofiles_client.go
+++ b/packages/typespec-go/test/local/armcodesigning/zz_certificateprofiles_client.go
@@ -291,8 +291,10 @@ func (client *CertificateProfilesClient) NewListByCodeSigningAccountPager(resour
 		Fetcher: func(ctx context.Context, page *CertificateProfilesClientListByCodeSigningAccountResponse) (CertificateProfilesClientListByCodeSigningAccountResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "CertificateProfilesClient.NewListByCodeSigningAccountPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByCodeSigningAccountCreateRequest(ctx, resourceGroupName, accountName, options)

--- a/packages/typespec-go/test/local/armcodesigning/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armcodesigning/zz_operations_client.go
@@ -45,8 +45,10 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 		Fetcher: func(ctx context.Context, page *OperationsClientListResponse) (OperationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "OperationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armcodesigning/zz_options.go
+++ b/packages/typespec-go/test/local/armcodesigning/zz_options.go
@@ -36,13 +36,15 @@ type AccountsClientGetOptions struct {
 // AccountsClientListByResourceGroupOptions contains the optional parameters for the AccountsClient.NewListByResourceGroupPager
 // method.
 type AccountsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AccountsClientListBySubscriptionOptions contains the optional parameters for the AccountsClient.NewListBySubscriptionPager
 // method.
 type AccountsClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // CertificateProfilesClientBeginCreateOptions contains the optional parameters for the CertificateProfilesClient.BeginCreate
@@ -67,7 +69,8 @@ type CertificateProfilesClientGetOptions struct {
 // CertificateProfilesClientListByCodeSigningAccountOptions contains the optional parameters for the CertificateProfilesClient.NewListByCodeSigningAccountPager
 // method.
 type CertificateProfilesClientListByCodeSigningAccountOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // CertificateProfilesClientRevokeCertificateOptions contains the optional parameters for the CertificateProfilesClient.RevokeCertificate
@@ -78,5 +81,6 @@ type CertificateProfilesClientRevokeCertificateOptions struct {
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 type OperationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/typespec-go/test/local/armcommunitymanagement/zz_communitytrainings_client.go
+++ b/packages/typespec-go/test/local/armcommunitymanagement/zz_communitytrainings_client.go
@@ -275,8 +275,10 @@ func (client *CommunityTrainingsClient) NewListByResourceGroupPager(resourceGrou
 		Fetcher: func(ctx context.Context, page *CommunityTrainingsClientListByResourceGroupResponse) (CommunityTrainingsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "CommunityTrainingsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -334,8 +336,10 @@ func (client *CommunityTrainingsClient) NewListBySubscriptionPager(options *Comm
 		Fetcher: func(ctx context.Context, page *CommunityTrainingsClientListBySubscriptionResponse) (CommunityTrainingsClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "CommunityTrainingsClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armcommunitymanagement/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armcommunitymanagement/zz_operations_client.go
@@ -45,8 +45,10 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 		Fetcher: func(ctx context.Context, page *OperationsClientListResponse) (OperationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "OperationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armcommunitymanagement/zz_options.go
+++ b/packages/typespec-go/test/local/armcommunitymanagement/zz_options.go
@@ -33,16 +33,19 @@ type CommunityTrainingsClientGetOptions struct {
 // CommunityTrainingsClientListByResourceGroupOptions contains the optional parameters for the CommunityTrainingsClient.NewListByResourceGroupPager
 // method.
 type CommunityTrainingsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // CommunityTrainingsClientListBySubscriptionOptions contains the optional parameters for the CommunityTrainingsClient.NewListBySubscriptionPager
 // method.
 type CommunityTrainingsClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 type OperationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_bgppeers_client.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_bgppeers_client.go
@@ -228,8 +228,10 @@ func (client *BgpPeersClient) NewListPager(resourceURI string, options *BgpPeers
 		Fetcher: func(ctx context.Context, page *BgpPeersClientListResponse) (BgpPeersClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "BgpPeersClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceURI, options)

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_loadbalancers_client.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_loadbalancers_client.go
@@ -228,8 +228,10 @@ func (client *LoadBalancersClient) NewListPager(resourceURI string, options *Loa
 		Fetcher: func(ctx context.Context, page *LoadBalancersClientListResponse) (LoadBalancersClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LoadBalancersClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceURI, options)

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_operations_client.go
@@ -45,8 +45,10 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 		Fetcher: func(ctx context.Context, page *OperationsClientListResponse) (OperationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "OperationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_options.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_options.go
@@ -22,7 +22,8 @@ type BgpPeersClientGetOptions struct {
 
 // BgpPeersClientListOptions contains the optional parameters for the BgpPeersClient.NewListPager method.
 type BgpPeersClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LoadBalancersClientBeginCreateOrUpdateOptions contains the optional parameters for the LoadBalancersClient.BeginCreateOrUpdate
@@ -44,12 +45,14 @@ type LoadBalancersClientGetOptions struct {
 
 // LoadBalancersClientListOptions contains the optional parameters for the LoadBalancersClient.NewListPager method.
 type LoadBalancersClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 type OperationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ServicesClientCreateOrUpdateOptions contains the optional parameters for the ServicesClient.CreateOrUpdate method.
@@ -69,7 +72,8 @@ type ServicesClientGetOptions struct {
 
 // ServicesClientListOptions contains the optional parameters for the ServicesClient.NewListPager method.
 type ServicesClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // StorageClassClientBeginCreateOrUpdateOptions contains the optional parameters for the StorageClassClient.BeginCreateOrUpdate
@@ -98,5 +102,6 @@ type StorageClassClientGetOptions struct {
 
 // StorageClassClientListOptions contains the optional parameters for the StorageClassClient.NewListPager method.
 type StorageClassClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_services_client.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_services_client.go
@@ -215,8 +215,10 @@ func (client *ServicesClient) NewListPager(resourceURI string, options *Services
 		Fetcher: func(ctx context.Context, page *ServicesClientListResponse) (ServicesClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ServicesClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceURI, options)

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_storageclass_client.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_storageclass_client.go
@@ -250,8 +250,10 @@ func (client *StorageClassClient) NewListPager(resourceURI string, options *Stor
 		Fetcher: func(ctx context.Context, page *StorageClassClientListResponse) (StorageClassClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "StorageClassClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceURI, options)

--- a/packages/typespec-go/test/local/armdatabasewatcher/zz_alertruleresources_client.go
+++ b/packages/typespec-go/test/local/armdatabasewatcher/zz_alertruleresources_client.go
@@ -258,8 +258,10 @@ func (client *AlertRuleResourcesClient) NewListByParentPager(resourceGroupName s
 		Fetcher: func(ctx context.Context, page *AlertRuleResourcesClientListByParentResponse) (AlertRuleResourcesClientListByParentResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AlertRuleResourcesClient.NewListByParentPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByParentCreateRequest(ctx, resourceGroupName, watcherName, options)

--- a/packages/typespec-go/test/local/armdatabasewatcher/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armdatabasewatcher/zz_operations_client.go
@@ -45,8 +45,10 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 		Fetcher: func(ctx context.Context, page *OperationsClientListResponse) (OperationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "OperationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armdatabasewatcher/zz_options.go
+++ b/packages/typespec-go/test/local/armdatabasewatcher/zz_options.go
@@ -23,12 +23,14 @@ type AlertRuleResourcesClientGetOptions struct {
 // AlertRuleResourcesClientListByParentOptions contains the optional parameters for the AlertRuleResourcesClient.NewListByParentPager
 // method.
 type AlertRuleResourcesClientListByParentOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 type OperationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SharedPrivateLinkResourcesClientBeginCreateOptions contains the optional parameters for the SharedPrivateLinkResourcesClient.BeginCreate
@@ -54,7 +56,8 @@ type SharedPrivateLinkResourcesClientGetOptions struct {
 // SharedPrivateLinkResourcesClientListByWatcherOptions contains the optional parameters for the SharedPrivateLinkResourcesClient.NewListByWatcherPager
 // method.
 type SharedPrivateLinkResourcesClientListByWatcherOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // TargetsClientCreateOrUpdateOptions contains the optional parameters for the TargetsClient.CreateOrUpdate method.
@@ -74,7 +77,8 @@ type TargetsClientGetOptions struct {
 
 // TargetsClientListByWatcherOptions contains the optional parameters for the TargetsClient.NewListByWatcherPager method.
 type TargetsClientListByWatcherOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // WatchersClientBeginCreateOrUpdateOptions contains the optional parameters for the WatchersClient.BeginCreateOrUpdate method.
@@ -115,11 +119,13 @@ type WatchersClientGetOptions struct {
 // WatchersClientListByResourceGroupOptions contains the optional parameters for the WatchersClient.NewListByResourceGroupPager
 // method.
 type WatchersClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // WatchersClientListBySubscriptionOptions contains the optional parameters for the WatchersClient.NewListBySubscriptionPager
 // method.
 type WatchersClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/typespec-go/test/local/armdatabasewatcher/zz_sharedprivatelinkresources_client.go
+++ b/packages/typespec-go/test/local/armdatabasewatcher/zz_sharedprivatelinkresources_client.go
@@ -292,8 +292,10 @@ func (client *SharedPrivateLinkResourcesClient) NewListByWatcherPager(resourceGr
 		Fetcher: func(ctx context.Context, page *SharedPrivateLinkResourcesClientListByWatcherResponse) (SharedPrivateLinkResourcesClientListByWatcherResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SharedPrivateLinkResourcesClient.NewListByWatcherPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByWatcherCreateRequest(ctx, resourceGroupName, watcherName, options)

--- a/packages/typespec-go/test/local/armdatabasewatcher/zz_targets_client.go
+++ b/packages/typespec-go/test/local/armdatabasewatcher/zz_targets_client.go
@@ -256,8 +256,10 @@ func (client *TargetsClient) NewListByWatcherPager(resourceGroupName string, wat
 		Fetcher: func(ctx context.Context, page *TargetsClientListByWatcherResponse) (TargetsClientListByWatcherResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "TargetsClient.NewListByWatcherPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByWatcherCreateRequest(ctx, resourceGroupName, watcherName, options)

--- a/packages/typespec-go/test/local/armdatabasewatcher/zz_watchers_client.go
+++ b/packages/typespec-go/test/local/armdatabasewatcher/zz_watchers_client.go
@@ -274,8 +274,10 @@ func (client *WatchersClient) NewListByResourceGroupPager(resourceGroupName stri
 		Fetcher: func(ctx context.Context, page *WatchersClientListByResourceGroupResponse) (WatchersClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "WatchersClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -333,8 +335,10 @@ func (client *WatchersClient) NewListBySubscriptionPager(options *WatchersClient
 		Fetcher: func(ctx context.Context, page *WatchersClientListBySubscriptionResponse) (WatchersClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "WatchersClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armdevopsinfrastructure/zz_imageversions_client.go
+++ b/packages/typespec-go/test/local/armdevopsinfrastructure/zz_imageversions_client.go
@@ -54,8 +54,10 @@ func (client *ImageVersionsClient) NewListByImagePager(resourceGroupName string,
 		Fetcher: func(ctx context.Context, page *ImageVersionsClientListByImageResponse) (ImageVersionsClientListByImageResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ImageVersionsClient.NewListByImagePager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByImageCreateRequest(ctx, resourceGroupName, imageName, options)

--- a/packages/typespec-go/test/local/armdevopsinfrastructure/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armdevopsinfrastructure/zz_operations_client.go
@@ -45,8 +45,10 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 		Fetcher: func(ctx context.Context, page *OperationsClientListResponse) (OperationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "OperationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armdevopsinfrastructure/zz_options.go
+++ b/packages/typespec-go/test/local/armdevopsinfrastructure/zz_options.go
@@ -7,12 +7,14 @@ package armdevopsinfrastructure
 // ImageVersionsClientListByImageOptions contains the optional parameters for the ImageVersionsClient.NewListByImagePager
 // method.
 type ImageVersionsClientListByImageOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 type OperationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PoolsClientBeginCreateOrUpdateOptions contains the optional parameters for the PoolsClient.BeginCreateOrUpdate method.
@@ -41,27 +43,32 @@ type PoolsClientGetOptions struct {
 // PoolsClientListByResourceGroupOptions contains the optional parameters for the PoolsClient.NewListByResourceGroupPager
 // method.
 type PoolsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PoolsClientListBySubscriptionOptions contains the optional parameters for the PoolsClient.NewListBySubscriptionPager method.
 type PoolsClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ResourceDetailsClientListByPoolOptions contains the optional parameters for the ResourceDetailsClient.NewListByPoolPager
 // method.
 type ResourceDetailsClientListByPoolOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SKUClientListByLocationOptions contains the optional parameters for the SKUClient.NewListByLocationPager method.
 type SKUClientListByLocationOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // SubscriptionUsagesClientUsagesOptions contains the optional parameters for the SubscriptionUsagesClient.NewUsagesPager
 // method.
 type SubscriptionUsagesClientUsagesOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/typespec-go/test/local/armdevopsinfrastructure/zz_pools_client.go
+++ b/packages/typespec-go/test/local/armdevopsinfrastructure/zz_pools_client.go
@@ -274,8 +274,10 @@ func (client *PoolsClient) NewListByResourceGroupPager(resourceGroupName string,
 		Fetcher: func(ctx context.Context, page *PoolsClientListByResourceGroupResponse) (PoolsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PoolsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -333,8 +335,10 @@ func (client *PoolsClient) NewListBySubscriptionPager(options *PoolsClientListBy
 		Fetcher: func(ctx context.Context, page *PoolsClientListBySubscriptionResponse) (PoolsClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PoolsClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armdevopsinfrastructure/zz_resourcedetails_client.go
+++ b/packages/typespec-go/test/local/armdevopsinfrastructure/zz_resourcedetails_client.go
@@ -54,8 +54,10 @@ func (client *ResourceDetailsClient) NewListByPoolPager(resourceGroupName string
 		Fetcher: func(ctx context.Context, page *ResourceDetailsClientListByPoolResponse) (ResourceDetailsClientListByPoolResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ResourceDetailsClient.NewListByPoolPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByPoolCreateRequest(ctx, resourceGroupName, poolName, options)

--- a/packages/typespec-go/test/local/armdevopsinfrastructure/zz_sku_client.go
+++ b/packages/typespec-go/test/local/armdevopsinfrastructure/zz_sku_client.go
@@ -52,8 +52,10 @@ func (client *SKUClient) NewListByLocationPager(locationName string, options *SK
 		Fetcher: func(ctx context.Context, page *SKUClientListByLocationResponse) (SKUClientListByLocationResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SKUClient.NewListByLocationPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByLocationCreateRequest(ctx, locationName, options)

--- a/packages/typespec-go/test/local/armdevopsinfrastructure/zz_subscriptionusages_client.go
+++ b/packages/typespec-go/test/local/armdevopsinfrastructure/zz_subscriptionusages_client.go
@@ -53,8 +53,10 @@ func (client *SubscriptionUsagesClient) NewUsagesPager(location string, options 
 		Fetcher: func(ctx context.Context, page *SubscriptionUsagesClientUsagesResponse) (SubscriptionUsagesClientUsagesResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SubscriptionUsagesClient.NewUsagesPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.usagesCreateRequest(ctx, location, options)

--- a/packages/typespec-go/test/local/armlargeinstance/zz_azurelargeinstance_client.go
+++ b/packages/typespec-go/test/local/armlargeinstance/zz_azurelargeinstance_client.go
@@ -246,8 +246,10 @@ func (client *AzureLargeInstanceClient) NewListByResourceGroupPager(resourceGrou
 		Fetcher: func(ctx context.Context, page *AzureLargeInstanceClientListByResourceGroupResponse) (AzureLargeInstanceClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AzureLargeInstanceClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -306,8 +308,10 @@ func (client *AzureLargeInstanceClient) NewListBySubscriptionPager(options *Azur
 		Fetcher: func(ctx context.Context, page *AzureLargeInstanceClientListBySubscriptionResponse) (AzureLargeInstanceClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AzureLargeInstanceClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armlargeinstance/zz_azurelargestorageinstance_client.go
+++ b/packages/typespec-go/test/local/armlargeinstance/zz_azurelargestorageinstance_client.go
@@ -248,8 +248,10 @@ func (client *AzureLargeStorageInstanceClient) NewListByResourceGroupPager(resou
 		Fetcher: func(ctx context.Context, page *AzureLargeStorageInstanceClientListByResourceGroupResponse) (AzureLargeStorageInstanceClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AzureLargeStorageInstanceClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -308,8 +310,10 @@ func (client *AzureLargeStorageInstanceClient) NewListBySubscriptionPager(option
 		Fetcher: func(ctx context.Context, page *AzureLargeStorageInstanceClientListBySubscriptionResponse) (AzureLargeStorageInstanceClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "AzureLargeStorageInstanceClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armlargeinstance/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armlargeinstance/zz_operations_client.go
@@ -45,8 +45,10 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 		Fetcher: func(ctx context.Context, page *OperationsClientListResponse) (OperationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "OperationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armlargeinstance/zz_options.go
+++ b/packages/typespec-go/test/local/armlargeinstance/zz_options.go
@@ -47,13 +47,15 @@ type AzureLargeInstanceClientGetOptions struct {
 // AzureLargeInstanceClientListByResourceGroupOptions contains the optional parameters for the AzureLargeInstanceClient.NewListByResourceGroupPager
 // method.
 type AzureLargeInstanceClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AzureLargeInstanceClientListBySubscriptionOptions contains the optional parameters for the AzureLargeInstanceClient.NewListBySubscriptionPager
 // method.
 type AzureLargeInstanceClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AzureLargeInstanceClientUpdateOptions contains the optional parameters for the AzureLargeInstanceClient.Update method.
@@ -82,13 +84,15 @@ type AzureLargeStorageInstanceClientGetOptions struct {
 // AzureLargeStorageInstanceClientListByResourceGroupOptions contains the optional parameters for the AzureLargeStorageInstanceClient.NewListByResourceGroupPager
 // method.
 type AzureLargeStorageInstanceClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AzureLargeStorageInstanceClientListBySubscriptionOptions contains the optional parameters for the AzureLargeStorageInstanceClient.NewListBySubscriptionPager
 // method.
 type AzureLargeStorageInstanceClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // AzureLargeStorageInstanceClientUpdateOptions contains the optional parameters for the AzureLargeStorageInstanceClient.Update
@@ -99,5 +103,6 @@ type AzureLargeStorageInstanceClientUpdateOptions struct {
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 type OperationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/typespec-go/test/local/armloadtestservice/zz_loadtestmappings_client.go
+++ b/packages/typespec-go/test/local/armloadtestservice/zz_loadtestmappings_client.go
@@ -217,8 +217,10 @@ func (client *LoadTestMappingsClient) NewListPager(resourceURI string, options *
 		Fetcher: func(ctx context.Context, page *LoadTestMappingsClientListResponse) (LoadTestMappingsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LoadTestMappingsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceURI, options)

--- a/packages/typespec-go/test/local/armloadtestservice/zz_loadtestprofilemappings_client.go
+++ b/packages/typespec-go/test/local/armloadtestservice/zz_loadtestprofilemappings_client.go
@@ -219,8 +219,10 @@ func (client *LoadTestProfileMappingsClient) NewListPager(resourceURI string, op
 		Fetcher: func(ctx context.Context, page *LoadTestProfileMappingsClientListResponse) (LoadTestProfileMappingsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LoadTestProfileMappingsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, resourceURI, options)

--- a/packages/typespec-go/test/local/armloadtestservice/zz_loadtests_client.go
+++ b/packages/typespec-go/test/local/armloadtestservice/zz_loadtests_client.go
@@ -273,8 +273,10 @@ func (client *LoadTestsClient) NewListByResourceGroupPager(resourceGroupName str
 		Fetcher: func(ctx context.Context, page *LoadTestsClientListByResourceGroupResponse) (LoadTestsClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LoadTestsClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)
@@ -332,8 +334,10 @@ func (client *LoadTestsClient) NewListBySubscriptionPager(options *LoadTestsClie
 		Fetcher: func(ctx context.Context, page *LoadTestsClientListBySubscriptionResponse) (LoadTestsClientListBySubscriptionResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LoadTestsClient.NewListBySubscriptionPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listBySubscriptionCreateRequest(ctx, options)
@@ -389,8 +393,10 @@ func (client *LoadTestsClient) NewOutboundNetworkDependenciesEndpointsPager(reso
 		Fetcher: func(ctx context.Context, page *LoadTestsClientOutboundNetworkDependenciesEndpointsResponse) (LoadTestsClientOutboundNetworkDependenciesEndpointsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "LoadTestsClient.NewOutboundNetworkDependenciesEndpointsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.outboundNetworkDependenciesEndpointsCreateRequest(ctx, resourceGroupName, loadTestName, options)

--- a/packages/typespec-go/test/local/armloadtestservice/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armloadtestservice/zz_operations_client.go
@@ -45,8 +45,10 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 		Fetcher: func(ctx context.Context, page *OperationsClientListResponse) (OperationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "OperationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armloadtestservice/zz_options.go
+++ b/packages/typespec-go/test/local/armloadtestservice/zz_options.go
@@ -22,7 +22,8 @@ type LoadTestMappingsClientGetOptions struct {
 
 // LoadTestMappingsClientListOptions contains the optional parameters for the LoadTestMappingsClient.NewListPager method.
 type LoadTestMappingsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LoadTestMappingsClientUpdateOptions contains the optional parameters for the LoadTestMappingsClient.Update method.
@@ -50,7 +51,8 @@ type LoadTestProfileMappingsClientGetOptions struct {
 // LoadTestProfileMappingsClientListOptions contains the optional parameters for the LoadTestProfileMappingsClient.NewListPager
 // method.
 type LoadTestProfileMappingsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LoadTestProfileMappingsClientUpdateOptions contains the optional parameters for the LoadTestProfileMappingsClient.Update
@@ -86,24 +88,28 @@ type LoadTestsClientGetOptions struct {
 // LoadTestsClientListByResourceGroupOptions contains the optional parameters for the LoadTestsClient.NewListByResourceGroupPager
 // method.
 type LoadTestsClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LoadTestsClientListBySubscriptionOptions contains the optional parameters for the LoadTestsClient.NewListBySubscriptionPager
 // method.
 type LoadTestsClientListBySubscriptionOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // LoadTestsClientOutboundNetworkDependenciesEndpointsOptions contains the optional parameters for the LoadTestsClient.NewOutboundNetworkDependenciesEndpointsPager
 // method.
 type LoadTestsClientOutboundNetworkDependenciesEndpointsOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 type OperationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // QuotasClientCheckAvailabilityOptions contains the optional parameters for the QuotasClient.CheckAvailability method.
@@ -118,5 +124,6 @@ type QuotasClientGetOptions struct {
 
 // QuotasClientListOptions contains the optional parameters for the QuotasClient.NewListPager method.
 type QuotasClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/typespec-go/test/local/armloadtestservice/zz_quotas_client.go
+++ b/packages/typespec-go/test/local/armloadtestservice/zz_quotas_client.go
@@ -186,8 +186,10 @@ func (client *QuotasClient) NewListPager(location string, options *QuotasClientL
 		Fetcher: func(ctx context.Context, page *QuotasClientListResponse) (QuotasClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "QuotasClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, location, options)

--- a/packages/typespec-go/test/local/armmongocluster/zz_firewallrules_client.go
+++ b/packages/typespec-go/test/local/armmongocluster/zz_firewallrules_client.go
@@ -291,8 +291,10 @@ func (client *FirewallRulesClient) NewListByMongoClusterPager(resourceGroupName 
 		Fetcher: func(ctx context.Context, page *FirewallRulesClientListByMongoClusterResponse) (FirewallRulesClientListByMongoClusterResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "FirewallRulesClient.NewListByMongoClusterPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByMongoClusterCreateRequest(ctx, resourceGroupName, mongoClusterName, options)

--- a/packages/typespec-go/test/local/armmongocluster/zz_mongoclusters_client.go
+++ b/packages/typespec-go/test/local/armmongocluster/zz_mongoclusters_client.go
@@ -340,8 +340,10 @@ func (client *MongoClustersClient) NewListPager(options *MongoClustersClientList
 		Fetcher: func(ctx context.Context, page *MongoClustersClientListResponse) (MongoClustersClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "MongoClustersClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)
@@ -396,8 +398,10 @@ func (client *MongoClustersClient) NewListByResourceGroupPager(resourceGroupName
 		Fetcher: func(ctx context.Context, page *MongoClustersClientListByResourceGroupResponse) (MongoClustersClientListByResourceGroupResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "MongoClustersClient.NewListByResourceGroupPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByResourceGroupCreateRequest(ctx, resourceGroupName, options)

--- a/packages/typespec-go/test/local/armmongocluster/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armmongocluster/zz_operations_client.go
@@ -45,8 +45,10 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 		Fetcher: func(ctx context.Context, page *OperationsClientListResponse) (OperationsClientListResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "OperationsClient.NewListPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/armmongocluster/zz_options.go
+++ b/packages/typespec-go/test/local/armmongocluster/zz_options.go
@@ -25,7 +25,8 @@ type FirewallRulesClientGetOptions struct {
 // FirewallRulesClientListByMongoClusterOptions contains the optional parameters for the FirewallRulesClient.NewListByMongoClusterPager
 // method.
 type FirewallRulesClientListByMongoClusterOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // MongoClustersClientBeginCreateOrUpdateOptions contains the optional parameters for the MongoClustersClient.BeginCreateOrUpdate
@@ -67,7 +68,8 @@ type MongoClustersClientGetOptions struct {
 // MongoClustersClientListByResourceGroupOptions contains the optional parameters for the MongoClustersClient.NewListByResourceGroupPager
 // method.
 type MongoClustersClientListByResourceGroupOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // MongoClustersClientListConnectionStringsOptions contains the optional parameters for the MongoClustersClient.ListConnectionStrings
@@ -78,12 +80,14 @@ type MongoClustersClientListConnectionStringsOptions struct {
 
 // MongoClustersClientListOptions contains the optional parameters for the MongoClustersClient.NewListPager method.
 type MongoClustersClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 type OperationsClientListOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PrivateEndpointConnectionsClientBeginCreateOptions contains the optional parameters for the PrivateEndpointConnectionsClient.BeginCreate
@@ -109,16 +113,19 @@ type PrivateEndpointConnectionsClientGetOptions struct {
 // PrivateEndpointConnectionsClientListByMongoClusterOptions contains the optional parameters for the PrivateEndpointConnectionsClient.NewListByMongoClusterPager
 // method.
 type PrivateEndpointConnectionsClientListByMongoClusterOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // PrivateLinksClientListByMongoClusterOptions contains the optional parameters for the PrivateLinksClient.NewListByMongoClusterPager
 // method.
 type PrivateLinksClientListByMongoClusterOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }
 
 // ReplicasClientListByParentOptions contains the optional parameters for the ReplicasClient.NewListByParentPager method.
 type ReplicasClientListByParentOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/typespec-go/test/local/armmongocluster/zz_privateendpointconnections_client.go
+++ b/packages/typespec-go/test/local/armmongocluster/zz_privateendpointconnections_client.go
@@ -292,8 +292,10 @@ func (client *PrivateEndpointConnectionsClient) NewListByMongoClusterPager(resou
 		Fetcher: func(ctx context.Context, page *PrivateEndpointConnectionsClientListByMongoClusterResponse) (PrivateEndpointConnectionsClientListByMongoClusterResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PrivateEndpointConnectionsClient.NewListByMongoClusterPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByMongoClusterCreateRequest(ctx, resourceGroupName, mongoClusterName, options)

--- a/packages/typespec-go/test/local/armmongocluster/zz_privatelinks_client.go
+++ b/packages/typespec-go/test/local/armmongocluster/zz_privatelinks_client.go
@@ -54,8 +54,10 @@ func (client *PrivateLinksClient) NewListByMongoClusterPager(resourceGroupName s
 		Fetcher: func(ctx context.Context, page *PrivateLinksClientListByMongoClusterResponse) (PrivateLinksClientListByMongoClusterResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "PrivateLinksClient.NewListByMongoClusterPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByMongoClusterCreateRequest(ctx, resourceGroupName, mongoClusterName, options)

--- a/packages/typespec-go/test/local/armmongocluster/zz_replicas_client.go
+++ b/packages/typespec-go/test/local/armmongocluster/zz_replicas_client.go
@@ -54,8 +54,10 @@ func (client *ReplicasClient) NewListByParentPager(resourceGroupName string, mon
 		Fetcher: func(ctx context.Context, page *ReplicasClientListByParentResponse) (ReplicasClientListByParentResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ReplicasClient.NewListByParentPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listByParentCreateRequest(ctx, resourceGroupName, mongoClusterName, options)

--- a/packages/typespec-go/test/local/armrandom/zz_options.go
+++ b/packages/typespec-go/test/local/armrandom/zz_options.go
@@ -6,5 +6,6 @@ package armrandom
 
 // SomeServiceClientListThingsOptions contains the optional parameters for the SomeServiceClient.NewListThingsPager method.
 type SomeServiceClientListThingsOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }

--- a/packages/typespec-go/test/local/armrandom/zz_someservice_client.go
+++ b/packages/typespec-go/test/local/armrandom/zz_someservice_client.go
@@ -46,8 +46,10 @@ func (client *SomeServiceClient) NewListThingsPager(options *SomeServiceClientLi
 		Fetcher: func(ctx context.Context, page *SomeServiceClientListThingsResponse) (SomeServiceClientListThingsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "SomeServiceClient.NewListThingsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listThingsCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/azkeys/zz_keyvault_client.go
+++ b/packages/typespec-go/test/local/azkeys/zz_keyvault_client.go
@@ -466,8 +466,10 @@ func (client *KeyVaultClient) NewGetDeletedKeysPager(options *KeyVaultClientGetD
 		Fetcher: func(ctx context.Context, page *KeyVaultClientGetDeletedKeysResponse) (KeyVaultClientGetDeletedKeysResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "KeyVaultClient.NewGetDeletedKeysPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getDeletedKeysCreateRequest(ctx, options)
@@ -655,8 +657,10 @@ func (client *KeyVaultClient) NewGetKeyVersionsPager(keyName string, options *Ke
 		Fetcher: func(ctx context.Context, page *KeyVaultClientGetKeyVersionsResponse) (KeyVaultClientGetKeyVersionsResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "KeyVaultClient.NewGetKeyVersionsPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getKeyVersionsCreateRequest(ctx, keyName, options)
@@ -720,8 +724,10 @@ func (client *KeyVaultClient) NewGetKeysPager(options *KeyVaultClientGetKeysOpti
 		Fetcher: func(ctx context.Context, page *KeyVaultClientGetKeysResponse) (KeyVaultClientGetKeysResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "KeyVaultClient.NewGetKeysPager")
 			nextLink := ""
-			if page != nil {
+			if page != nil && page.NextLink != nil {
 				nextLink = *page.NextLink
+			} else if options != nil && options.NextLink != "" {
+				nextLink = options.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.getKeysCreateRequest(ctx, options)

--- a/packages/typespec-go/test/local/azkeys/zz_options.go
+++ b/packages/typespec-go/test/local/azkeys/zz_options.go
@@ -36,6 +36,9 @@ type KeyVaultClientGetDeletedKeyOptions struct {
 
 // KeyVaultClientGetDeletedKeysOptions contains the optional parameters for the KeyVaultClient.NewGetDeletedKeysPager method.
 type KeyVaultClientGetDeletedKeysOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Maximum number of results to return in a page. If not specified the service
 	// will return up to 25 results.
 	Maxresults *int32
@@ -54,6 +57,9 @@ type KeyVaultClientGetKeyRotationPolicyOptions struct {
 
 // KeyVaultClientGetKeyVersionsOptions contains the optional parameters for the KeyVaultClient.NewGetKeyVersionsPager method.
 type KeyVaultClientGetKeyVersionsOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Maximum number of results to return in a page. If not specified the service
 	// will return up to 25 results.
 	Maxresults *int32
@@ -61,6 +67,9 @@ type KeyVaultClientGetKeyVersionsOptions struct {
 
 // KeyVaultClientGetKeysOptions contains the optional parameters for the KeyVaultClient.NewGetKeysPager method.
 type KeyVaultClientGetKeysOptions struct {
+	// Resumes the paging operation from the provided link.
+	NextLink string
+
 	// Maximum number of results to return in a page. If not specified the service
 	// will return up to 25 results.
 	Maxresults *int32

--- a/packages/typespec-go/test/local/internalpager/zz_options.go
+++ b/packages/typespec-go/test/local/internalpager/zz_options.go
@@ -6,5 +6,6 @@ package internalpager
 
 // pagerWidgetsClientlistMethodOptions contains the optional parameters for the PagerWidgetsClient.NewlistMethodPager method.
 type pagerWidgetsClientlistMethodOptions struct {
-	// placeholder for future optional parameters
+	// Resumes the paging operation from the provided link.
+	NextLink string
 }


### PR DESCRIPTION
If a user wishes to resume paging from a particular link, they may pass a parameter to the list operation method on their client. This next link will be used for the first paging operation.