### PR TITLE
Fix monomorphic response field name

### DIFF
--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.4.0 (2025-03-11)
+## 0.4.0 (2025-03-12)
 
 ### Breaking Changes
 

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.4.0 (2025-03-11)
+
+### Breaking Changes
+
+* The monomorphic response field will no longer have the name `Value` in some cases. This is to preserve compatibility with the behavior of the `autorest.go` code generator.
+
 ## 0.3.11 (2025-03-07)
 
 ### Other Changes

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-go",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "description": "TypeSpec emitter for Go SDKs",
   "type": "module",
   "main": "dist/typespec-go/src/index.js",

--- a/packages/typespec-go/test/http-specs/type/arraygroup/arraygroup_test.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/arraygroup_test.go
@@ -21,7 +21,7 @@ func TestBooleanValueClientGet(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.NewArrayBooleanValueClient().Get(context.Background(), nil)
 	require.NoError(t, err)
-	require.Equal(t, []bool{true, false}, resp.Value)
+	require.Equal(t, []bool{true, false}, resp.BoolArray)
 }
 
 func TestBooleanValueClientPut(t *testing.T) {
@@ -37,7 +37,7 @@ func TestDatetimeValueClientGet(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.NewArrayDatetimeValueClient().Get(context.Background(), nil)
 	require.NoError(t, err)
-	require.EqualValues(t, []time.Time{time.Date(2022, time.August, 26, 18, 38, 0, 0, time.UTC)}, resp.Value)
+	require.EqualValues(t, []time.Time{time.Date(2022, time.August, 26, 18, 38, 0, 0, time.UTC)}, resp.TimeArray)
 }
 
 func TestDatetimeValueClientPut(t *testing.T) {
@@ -53,7 +53,7 @@ func TestDurationValueClientGet(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.NewArrayDurationValueClient().Get(context.Background(), nil)
 	require.NoError(t, err)
-	require.EqualValues(t, []string{"P123DT22H14M12.011S"}, resp.Value)
+	require.EqualValues(t, []string{"P123DT22H14M12.011S"}, resp.StringArray)
 }
 
 func TestDurationValueClientPut(t *testing.T) {
@@ -69,7 +69,7 @@ func TestFloat32ValueClientGet(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.NewArrayFloat32ValueClient().Get(context.Background(), nil)
 	require.NoError(t, err)
-	require.EqualValues(t, []float32{43.125}, resp.Value)
+	require.EqualValues(t, []float32{43.125}, resp.Float32Array)
 }
 
 func TestFloat32ValueClientPut(t *testing.T) {
@@ -85,7 +85,7 @@ func TestInt32ValueClientGet(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.NewArrayInt32ValueClient().Get(context.Background(), nil)
 	require.NoError(t, err)
-	require.EqualValues(t, []int32{1, 2}, resp.Value)
+	require.EqualValues(t, []int32{1, 2}, resp.Int32Array)
 }
 
 func TestInt32ValueClientPut(t *testing.T) {
@@ -101,7 +101,7 @@ func TestInt64ValueClientGet(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.NewArrayInt64ValueClient().Get(context.Background(), nil)
 	require.NoError(t, err)
-	require.EqualValues(t, []int64{9007199254740991, -9007199254740991}, resp.Value)
+	require.EqualValues(t, []int64{9007199254740991, -9007199254740991}, resp.Int64Array)
 }
 
 func TestInt64ValueClientPut(t *testing.T) {
@@ -124,7 +124,7 @@ func TestModelValueClientGet(t *testing.T) {
 		{
 			Property: to.Ptr("world"),
 		},
-	}, resp.Value)
+	}, resp.InnerModelArray)
 }
 
 func TestModelValueClientPut(t *testing.T) {
@@ -147,7 +147,7 @@ func TestNullableFloatValueClientGet(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.NewArrayNullableFloatValueClient().Get(context.Background(), nil)
 	require.NoError(t, err)
-	require.EqualValues(t, []*float32{to.Ptr[float32](1.25), nil, to.Ptr[float32](3)}, resp.Value)
+	require.EqualValues(t, []*float32{to.Ptr[float32](1.25), nil, to.Ptr[float32](3)}, resp.Float32Array)
 }
 
 func TestNullableFloatValueClientPut(t *testing.T) {
@@ -163,7 +163,7 @@ func TestStringValueClientGet(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.NewArrayStringValueClient().Get(context.Background(), nil)
 	require.NoError(t, err)
-	require.EqualValues(t, []string{"hello", ""}, resp.Value)
+	require.EqualValues(t, []string{"hello", ""}, resp.StringArray)
 }
 
 func TestStringValueClientPut(t *testing.T) {
@@ -179,7 +179,7 @@ func TestUnknownValueClientGet(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.NewArrayUnknownValueClient().Get(context.Background(), nil)
 	require.NoError(t, err)
-	require.EqualValues(t, []any{float64(1), "hello", nil}, resp.Value)
+	require.EqualValues(t, []any{float64(1), "hello", nil}, resp.InterfaceArray)
 }
 
 func TestUnknownValueClientPut(t *testing.T) {

--- a/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraybooleanvalue_server.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraybooleanvalue_server.go
@@ -97,7 +97,7 @@ func (a *ArrayBooleanValueServerTransport) dispatchGet(req *http.Request) (*http
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).BoolArray, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraydatetimevalue_server.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraydatetimevalue_server.go
@@ -98,7 +98,7 @@ func (a *ArrayDatetimeValueServerTransport) dispatchGet(req *http.Request) (*htt
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).TimeArray, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraydurationvalue_server.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraydurationvalue_server.go
@@ -97,7 +97,7 @@ func (a *ArrayDurationValueServerTransport) dispatchGet(req *http.Request) (*htt
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).StringArray, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arrayfloat32value_server.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arrayfloat32value_server.go
@@ -97,7 +97,7 @@ func (a *ArrayFloat32ValueServerTransport) dispatchGet(req *http.Request) (*http
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Float32Array, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arrayint32value_server.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arrayint32value_server.go
@@ -97,7 +97,7 @@ func (a *ArrayInt32ValueServerTransport) dispatchGet(req *http.Request) (*http.R
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Int32Array, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arrayint64value_server.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arrayint64value_server.go
@@ -97,7 +97,7 @@ func (a *ArrayInt64ValueServerTransport) dispatchGet(req *http.Request) (*http.R
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Int64Array, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraymodelvalue_server.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraymodelvalue_server.go
@@ -97,7 +97,7 @@ func (a *ArrayModelValueServerTransport) dispatchGet(req *http.Request) (*http.R
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).InnerModelArray, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraynullablebooleanvalue_server.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraynullablebooleanvalue_server.go
@@ -97,7 +97,7 @@ func (a *ArrayNullableBooleanValueServerTransport) dispatchGet(req *http.Request
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).BoolArray, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraynullablefloatvalue_server.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraynullablefloatvalue_server.go
@@ -97,7 +97,7 @@ func (a *ArrayNullableFloatValueServerTransport) dispatchGet(req *http.Request) 
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Float32Array, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraynullableint32value_server.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraynullableint32value_server.go
@@ -97,7 +97,7 @@ func (a *ArrayNullableInt32ValueServerTransport) dispatchGet(req *http.Request) 
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Int32Array, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraynullablemodelvalue_server.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraynullablemodelvalue_server.go
@@ -97,7 +97,7 @@ func (a *ArrayNullableModelValueServerTransport) dispatchGet(req *http.Request) 
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).InnerModelArray, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraynullablestringvalue_server.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraynullablestringvalue_server.go
@@ -97,7 +97,7 @@ func (a *ArrayNullableStringValueServerTransport) dispatchGet(req *http.Request)
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).StringArray, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraystringvalue_server.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arraystringvalue_server.go
@@ -97,7 +97,7 @@ func (a *ArrayStringValueServerTransport) dispatchGet(req *http.Request) (*http.
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).StringArray, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arrayunknownvalue_server.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/fake/zz_arrayunknownvalue_server.go
@@ -97,7 +97,7 @@ func (a *ArrayUnknownValueServerTransport) dispatchGet(req *http.Request) (*http
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).InterfaceArray, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraybooleanvalue_client.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraybooleanvalue_client.go
@@ -57,7 +57,7 @@ func (client *ArrayBooleanValueClient) getCreateRequest(ctx context.Context, _ *
 // getHandleResponse handles the Get response.
 func (client *ArrayBooleanValueClient) getHandleResponse(resp *http.Response) (ArrayBooleanValueClientGetResponse, error) {
 	result := ArrayBooleanValueClientGetResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.BoolArray); err != nil {
 		return ArrayBooleanValueClientGetResponse{}, err
 	}
 	return result, nil

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraydatetimevalue_client.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraydatetimevalue_client.go
@@ -66,7 +66,7 @@ func (client *ArrayDatetimeValueClient) getHandleResponse(resp *http.Response) (
 	for i := 0; i < len(aux); i++ {
 		cp[i] = (time.Time)(aux[i])
 	}
-	result.Value = cp
+	result.TimeArray = cp
 	return result, nil
 }
 

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraydurationvalue_client.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraydurationvalue_client.go
@@ -57,7 +57,7 @@ func (client *ArrayDurationValueClient) getCreateRequest(ctx context.Context, _ 
 // getHandleResponse handles the Get response.
 func (client *ArrayDurationValueClient) getHandleResponse(resp *http.Response) (ArrayDurationValueClientGetResponse, error) {
 	result := ArrayDurationValueClientGetResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
 		return ArrayDurationValueClientGetResponse{}, err
 	}
 	return result, nil

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_arrayfloat32value_client.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_arrayfloat32value_client.go
@@ -57,7 +57,7 @@ func (client *ArrayFloat32ValueClient) getCreateRequest(ctx context.Context, _ *
 // getHandleResponse handles the Get response.
 func (client *ArrayFloat32ValueClient) getHandleResponse(resp *http.Response) (ArrayFloat32ValueClientGetResponse, error) {
 	result := ArrayFloat32ValueClientGetResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Float32Array); err != nil {
 		return ArrayFloat32ValueClientGetResponse{}, err
 	}
 	return result, nil

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_arrayint32value_client.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_arrayint32value_client.go
@@ -57,7 +57,7 @@ func (client *ArrayInt32ValueClient) getCreateRequest(ctx context.Context, _ *Ar
 // getHandleResponse handles the Get response.
 func (client *ArrayInt32ValueClient) getHandleResponse(resp *http.Response) (ArrayInt32ValueClientGetResponse, error) {
 	result := ArrayInt32ValueClientGetResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Int32Array); err != nil {
 		return ArrayInt32ValueClientGetResponse{}, err
 	}
 	return result, nil

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_arrayint64value_client.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_arrayint64value_client.go
@@ -57,7 +57,7 @@ func (client *ArrayInt64ValueClient) getCreateRequest(ctx context.Context, _ *Ar
 // getHandleResponse handles the Get response.
 func (client *ArrayInt64ValueClient) getHandleResponse(resp *http.Response) (ArrayInt64ValueClientGetResponse, error) {
 	result := ArrayInt64ValueClientGetResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Int64Array); err != nil {
 		return ArrayInt64ValueClientGetResponse{}, err
 	}
 	return result, nil

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraymodelvalue_client.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraymodelvalue_client.go
@@ -57,7 +57,7 @@ func (client *ArrayModelValueClient) getCreateRequest(ctx context.Context, _ *Ar
 // getHandleResponse handles the Get response.
 func (client *ArrayModelValueClient) getHandleResponse(resp *http.Response) (ArrayModelValueClientGetResponse, error) {
 	result := ArrayModelValueClientGetResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.InnerModelArray); err != nil {
 		return ArrayModelValueClientGetResponse{}, err
 	}
 	return result, nil

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraynullablebooleanvalue_client.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraynullablebooleanvalue_client.go
@@ -58,7 +58,7 @@ func (client *ArrayNullableBooleanValueClient) getCreateRequest(ctx context.Cont
 // getHandleResponse handles the Get response.
 func (client *ArrayNullableBooleanValueClient) getHandleResponse(resp *http.Response) (ArrayNullableBooleanValueClientGetResponse, error) {
 	result := ArrayNullableBooleanValueClientGetResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.BoolArray); err != nil {
 		return ArrayNullableBooleanValueClientGetResponse{}, err
 	}
 	return result, nil

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraynullablefloatvalue_client.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraynullablefloatvalue_client.go
@@ -58,7 +58,7 @@ func (client *ArrayNullableFloatValueClient) getCreateRequest(ctx context.Contex
 // getHandleResponse handles the Get response.
 func (client *ArrayNullableFloatValueClient) getHandleResponse(resp *http.Response) (ArrayNullableFloatValueClientGetResponse, error) {
 	result := ArrayNullableFloatValueClientGetResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Float32Array); err != nil {
 		return ArrayNullableFloatValueClientGetResponse{}, err
 	}
 	return result, nil

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraynullableint32value_client.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraynullableint32value_client.go
@@ -58,7 +58,7 @@ func (client *ArrayNullableInt32ValueClient) getCreateRequest(ctx context.Contex
 // getHandleResponse handles the Get response.
 func (client *ArrayNullableInt32ValueClient) getHandleResponse(resp *http.Response) (ArrayNullableInt32ValueClientGetResponse, error) {
 	result := ArrayNullableInt32ValueClientGetResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Int32Array); err != nil {
 		return ArrayNullableInt32ValueClientGetResponse{}, err
 	}
 	return result, nil

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraynullablemodelvalue_client.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraynullablemodelvalue_client.go
@@ -58,7 +58,7 @@ func (client *ArrayNullableModelValueClient) getCreateRequest(ctx context.Contex
 // getHandleResponse handles the Get response.
 func (client *ArrayNullableModelValueClient) getHandleResponse(resp *http.Response) (ArrayNullableModelValueClientGetResponse, error) {
 	result := ArrayNullableModelValueClientGetResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.InnerModelArray); err != nil {
 		return ArrayNullableModelValueClientGetResponse{}, err
 	}
 	return result, nil

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraynullablestringvalue_client.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraynullablestringvalue_client.go
@@ -58,7 +58,7 @@ func (client *ArrayNullableStringValueClient) getCreateRequest(ctx context.Conte
 // getHandleResponse handles the Get response.
 func (client *ArrayNullableStringValueClient) getHandleResponse(resp *http.Response) (ArrayNullableStringValueClientGetResponse, error) {
 	result := ArrayNullableStringValueClientGetResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
 		return ArrayNullableStringValueClientGetResponse{}, err
 	}
 	return result, nil

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraystringvalue_client.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_arraystringvalue_client.go
@@ -57,7 +57,7 @@ func (client *ArrayStringValueClient) getCreateRequest(ctx context.Context, _ *A
 // getHandleResponse handles the Get response.
 func (client *ArrayStringValueClient) getHandleResponse(resp *http.Response) (ArrayStringValueClientGetResponse, error) {
 	result := ArrayStringValueClientGetResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
 		return ArrayStringValueClientGetResponse{}, err
 	}
 	return result, nil

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_arrayunknownvalue_client.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_arrayunknownvalue_client.go
@@ -57,7 +57,7 @@ func (client *ArrayUnknownValueClient) getCreateRequest(ctx context.Context, _ *
 // getHandleResponse handles the Get response.
 func (client *ArrayUnknownValueClient) getHandleResponse(resp *http.Response) (ArrayUnknownValueClientGetResponse, error) {
 	result := ArrayUnknownValueClientGetResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.InterfaceArray); err != nil {
 		return ArrayUnknownValueClientGetResponse{}, err
 	}
 	return result, nil

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_responses.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_responses.go
@@ -8,7 +8,7 @@ import "time"
 
 // ArrayBooleanValueClientGetResponse contains the response from method ArrayBooleanValueClient.Get.
 type ArrayBooleanValueClientGetResponse struct {
-	Value []bool
+	BoolArray []bool
 }
 
 // ArrayBooleanValueClientPutResponse contains the response from method ArrayBooleanValueClient.Put.
@@ -18,7 +18,7 @@ type ArrayBooleanValueClientPutResponse struct {
 
 // ArrayDatetimeValueClientGetResponse contains the response from method ArrayDatetimeValueClient.Get.
 type ArrayDatetimeValueClientGetResponse struct {
-	Value []time.Time
+	TimeArray []time.Time
 }
 
 // ArrayDatetimeValueClientPutResponse contains the response from method ArrayDatetimeValueClient.Put.
@@ -28,7 +28,7 @@ type ArrayDatetimeValueClientPutResponse struct {
 
 // ArrayDurationValueClientGetResponse contains the response from method ArrayDurationValueClient.Get.
 type ArrayDurationValueClientGetResponse struct {
-	Value []string
+	StringArray []string
 }
 
 // ArrayDurationValueClientPutResponse contains the response from method ArrayDurationValueClient.Put.
@@ -38,7 +38,7 @@ type ArrayDurationValueClientPutResponse struct {
 
 // ArrayFloat32ValueClientGetResponse contains the response from method ArrayFloat32ValueClient.Get.
 type ArrayFloat32ValueClientGetResponse struct {
-	Value []float32
+	Float32Array []float32
 }
 
 // ArrayFloat32ValueClientPutResponse contains the response from method ArrayFloat32ValueClient.Put.
@@ -48,7 +48,7 @@ type ArrayFloat32ValueClientPutResponse struct {
 
 // ArrayInt32ValueClientGetResponse contains the response from method ArrayInt32ValueClient.Get.
 type ArrayInt32ValueClientGetResponse struct {
-	Value []int32
+	Int32Array []int32
 }
 
 // ArrayInt32ValueClientPutResponse contains the response from method ArrayInt32ValueClient.Put.
@@ -58,7 +58,7 @@ type ArrayInt32ValueClientPutResponse struct {
 
 // ArrayInt64ValueClientGetResponse contains the response from method ArrayInt64ValueClient.Get.
 type ArrayInt64ValueClientGetResponse struct {
-	Value []int64
+	Int64Array []int64
 }
 
 // ArrayInt64ValueClientPutResponse contains the response from method ArrayInt64ValueClient.Put.
@@ -68,7 +68,7 @@ type ArrayInt64ValueClientPutResponse struct {
 
 // ArrayModelValueClientGetResponse contains the response from method ArrayModelValueClient.Get.
 type ArrayModelValueClientGetResponse struct {
-	Value []InnerModel
+	InnerModelArray []InnerModel
 }
 
 // ArrayModelValueClientPutResponse contains the response from method ArrayModelValueClient.Put.
@@ -78,7 +78,7 @@ type ArrayModelValueClientPutResponse struct {
 
 // ArrayNullableBooleanValueClientGetResponse contains the response from method ArrayNullableBooleanValueClient.Get.
 type ArrayNullableBooleanValueClientGetResponse struct {
-	Value []*bool
+	BoolArray []*bool
 }
 
 // ArrayNullableBooleanValueClientPutResponse contains the response from method ArrayNullableBooleanValueClient.Put.
@@ -88,7 +88,7 @@ type ArrayNullableBooleanValueClientPutResponse struct {
 
 // ArrayNullableFloatValueClientGetResponse contains the response from method ArrayNullableFloatValueClient.Get.
 type ArrayNullableFloatValueClientGetResponse struct {
-	Value []*float32
+	Float32Array []*float32
 }
 
 // ArrayNullableFloatValueClientPutResponse contains the response from method ArrayNullableFloatValueClient.Put.
@@ -98,7 +98,7 @@ type ArrayNullableFloatValueClientPutResponse struct {
 
 // ArrayNullableInt32ValueClientGetResponse contains the response from method ArrayNullableInt32ValueClient.Get.
 type ArrayNullableInt32ValueClientGetResponse struct {
-	Value []*int32
+	Int32Array []*int32
 }
 
 // ArrayNullableInt32ValueClientPutResponse contains the response from method ArrayNullableInt32ValueClient.Put.
@@ -108,7 +108,7 @@ type ArrayNullableInt32ValueClientPutResponse struct {
 
 // ArrayNullableModelValueClientGetResponse contains the response from method ArrayNullableModelValueClient.Get.
 type ArrayNullableModelValueClientGetResponse struct {
-	Value []*InnerModel
+	InnerModelArray []*InnerModel
 }
 
 // ArrayNullableModelValueClientPutResponse contains the response from method ArrayNullableModelValueClient.Put.
@@ -118,7 +118,7 @@ type ArrayNullableModelValueClientPutResponse struct {
 
 // ArrayNullableStringValueClientGetResponse contains the response from method ArrayNullableStringValueClient.Get.
 type ArrayNullableStringValueClientGetResponse struct {
-	Value []*string
+	StringArray []*string
 }
 
 // ArrayNullableStringValueClientPutResponse contains the response from method ArrayNullableStringValueClient.Put.
@@ -128,7 +128,7 @@ type ArrayNullableStringValueClientPutResponse struct {
 
 // ArrayStringValueClientGetResponse contains the response from method ArrayStringValueClient.Get.
 type ArrayStringValueClientGetResponse struct {
-	Value []string
+	StringArray []string
 }
 
 // ArrayStringValueClientPutResponse contains the response from method ArrayStringValueClient.Put.
@@ -138,7 +138,7 @@ type ArrayStringValueClientPutResponse struct {
 
 // ArrayUnknownValueClientGetResponse contains the response from method ArrayUnknownValueClient.Get.
 type ArrayUnknownValueClientGetResponse struct {
-	Value []any
+	InterfaceArray []any
 }
 
 // ArrayUnknownValueClientPutResponse contains the response from method ArrayUnknownValueClient.Put.

--- a/packages/typespec-go/test/http-specs/type/scalargroup/decimal128verify_client_test.go
+++ b/packages/typespec-go/test/http-specs/type/scalargroup/decimal128verify_client_test.go
@@ -19,7 +19,7 @@ func TestDecimal128VerifyClient_PrepareVerify(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.NewScalarDecimal128VerifyClient().PrepareVerify(context.Background(), nil)
 	require.NoError(t, err)
-	require.EqualValues(t, []float64{0.1, 0.1, 0.1}, resp.Value)
+	require.EqualValues(t, []float64{0.1, 0.1, 0.1}, resp.Float64Array)
 }
 
 func TestDecimal128VerifyClient_Verify(t *testing.T) {

--- a/packages/typespec-go/test/http-specs/type/scalargroup/decimalverify_client_test.go
+++ b/packages/typespec-go/test/http-specs/type/scalargroup/decimalverify_client_test.go
@@ -19,7 +19,7 @@ func TestDecimalVerifyClient_PrepareVerify(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.NewScalarDecimalVerifyClient().PrepareVerify(context.Background(), nil)
 	require.NoError(t, err)
-	require.EqualValues(t, []float64{0.1, 0.1, 0.1}, resp.Value)
+	require.EqualValues(t, []float64{0.1, 0.1, 0.1}, resp.Float64Array)
 }
 
 func TestDecimalVerifyClient_Verify(t *testing.T) {

--- a/packages/typespec-go/test/http-specs/type/scalargroup/fake/zz_scalardecimal128verify_server.go
+++ b/packages/typespec-go/test/http-specs/type/scalargroup/fake/zz_scalardecimal128verify_server.go
@@ -97,7 +97,7 @@ func (s *ScalarDecimal128VerifyServerTransport) dispatchPrepareVerify(req *http.
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Float64Array, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/scalargroup/fake/zz_scalardecimalverify_server.go
+++ b/packages/typespec-go/test/http-specs/type/scalargroup/fake/zz_scalardecimalverify_server.go
@@ -97,7 +97,7 @@ func (s *ScalarDecimalVerifyServerTransport) dispatchPrepareVerify(req *http.Req
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Float64Array, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/scalargroup/fake/zz_scalarunknown_server.go
+++ b/packages/typespec-go/test/http-specs/type/scalargroup/fake/zz_scalarunknown_server.go
@@ -97,7 +97,7 @@ func (s *ScalarUnknownServerTransport) dispatchGet(req *http.Request) (*http.Res
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Interface, req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/type/scalargroup/unknown_client_test.go
+++ b/packages/typespec-go/test/http-specs/type/scalargroup/unknown_client_test.go
@@ -19,7 +19,7 @@ func TestUnknownClient_Get(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.NewScalarUnknownClient().Get(context.Background(), nil)
 	require.NoError(t, err)
-	require.EqualValues(t, "test", resp.Value)
+	require.EqualValues(t, "test", resp.Interface)
 }
 
 func TestUnknownClient_Put(t *testing.T) {

--- a/packages/typespec-go/test/http-specs/type/scalargroup/zz_responses.go
+++ b/packages/typespec-go/test/http-specs/type/scalargroup/zz_responses.go
@@ -31,7 +31,7 @@ type ScalarDecimal128TypeClientResponseBodyResponse struct {
 
 // ScalarDecimal128VerifyClientPrepareVerifyResponse contains the response from method ScalarDecimal128VerifyClient.PrepareVerify.
 type ScalarDecimal128VerifyClientPrepareVerifyResponse struct {
-	Value []float64
+	Float64Array []float64
 }
 
 // ScalarDecimal128VerifyClientVerifyResponse contains the response from method ScalarDecimal128VerifyClient.Verify.
@@ -56,7 +56,7 @@ type ScalarDecimalTypeClientResponseBodyResponse struct {
 
 // ScalarDecimalVerifyClientPrepareVerifyResponse contains the response from method ScalarDecimalVerifyClient.PrepareVerify.
 type ScalarDecimalVerifyClientPrepareVerifyResponse struct {
-	Value []float64
+	Float64Array []float64
 }
 
 // ScalarDecimalVerifyClientVerifyResponse contains the response from method ScalarDecimalVerifyClient.Verify.
@@ -76,7 +76,7 @@ type ScalarStringClientPutResponse struct {
 
 // ScalarUnknownClientGetResponse contains the response from method ScalarUnknownClient.Get.
 type ScalarUnknownClientGetResponse struct {
-	Value any
+	Interface any
 }
 
 // ScalarUnknownClientPutResponse contains the response from method ScalarUnknownClient.Put.

--- a/packages/typespec-go/test/http-specs/type/scalargroup/zz_scalardecimal128verify_client.go
+++ b/packages/typespec-go/test/http-specs/type/scalargroup/zz_scalardecimal128verify_client.go
@@ -58,7 +58,7 @@ func (client *ScalarDecimal128VerifyClient) prepareVerifyCreateRequest(ctx conte
 // prepareVerifyHandleResponse handles the PrepareVerify response.
 func (client *ScalarDecimal128VerifyClient) prepareVerifyHandleResponse(resp *http.Response) (ScalarDecimal128VerifyClientPrepareVerifyResponse, error) {
 	result := ScalarDecimal128VerifyClientPrepareVerifyResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Float64Array); err != nil {
 		return ScalarDecimal128VerifyClientPrepareVerifyResponse{}, err
 	}
 	return result, nil

--- a/packages/typespec-go/test/http-specs/type/scalargroup/zz_scalardecimalverify_client.go
+++ b/packages/typespec-go/test/http-specs/type/scalargroup/zz_scalardecimalverify_client.go
@@ -58,7 +58,7 @@ func (client *ScalarDecimalVerifyClient) prepareVerifyCreateRequest(ctx context.
 // prepareVerifyHandleResponse handles the PrepareVerify response.
 func (client *ScalarDecimalVerifyClient) prepareVerifyHandleResponse(resp *http.Response) (ScalarDecimalVerifyClientPrepareVerifyResponse, error) {
 	result := ScalarDecimalVerifyClientPrepareVerifyResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Float64Array); err != nil {
 		return ScalarDecimalVerifyClientPrepareVerifyResponse{}, err
 	}
 	return result, nil

--- a/packages/typespec-go/test/http-specs/type/scalargroup/zz_scalarunknown_client.go
+++ b/packages/typespec-go/test/http-specs/type/scalargroup/zz_scalarunknown_client.go
@@ -57,7 +57,7 @@ func (client *ScalarUnknownClient) getCreateRequest(ctx context.Context, _ *Scal
 // getHandleResponse handles the Get response.
 func (client *ScalarUnknownClient) getHandleResponse(resp *http.Response) (ScalarUnknownClientGetResponse, error) {
 	result := ScalarUnknownClientGetResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.Interface); err != nil {
 		return ScalarUnknownClientGetResponse{}, err
 	}
 	return result, nil


### PR DESCRIPTION
The hard-coded name Value introduced some breaking changes for services migrating to tsp. In addition, as some tsp-based SDKs have shipped with this name, we cannot simply revert to the autorest.go behavior.

The recursiveTypeName implementation is essentially a hybrid of the autorest.go and typespec-go implementations. See the function's doc comments for an explanation of the naming algorithm. This result is based on an analysis of released SDKs and a pending release which is inadvertently being held up due to the result field being renamed.

Fixes https://github.com/Azure/autorest.go/issues/1515