### PR TITLE
Centralize test version definitions and test go latest + previous

### DIFF
--- a/eng/pipelines/ci-go.yml
+++ b/eng/pipelines/ci-go.yml
@@ -30,7 +30,7 @@ extends:
       - stage: "AutoRest_Go_CI"
         jobs:
           - job: "AutoRest_Go_CI"
-            displayName: "Run AutoRest CI Checks - $(GoVersion)"
+            displayName: "Run AutoRest CI Checks - "
 
             variables:
               - template: /eng/pipelines/templates/variables/globals.yml

--- a/eng/pipelines/ci-go.yml
+++ b/eng/pipelines/ci-go.yml
@@ -30,15 +30,23 @@ extends:
       - stage: "AutoRest_Go_CI"
         jobs:
           - job: "AutoRest_Go_CI"
-            displayName: "Run AutoRest CI Checks"
+            displayName: "Run AutoRest CI Checks - $(GoVersion)"
 
             variables:
+              - template: /eng/pipelines/templates/variables/globals.yml
               - template: /eng/pipelines/templates/variables/image.yml
 
             pool:
               name: "$(LINUXNEXTPOOL)"
               image: "$(LINUXNEXTVMIMAGE)"
               os: linux
+
+            strategy:
+              matrix:
+                GoVersionLatest:
+                  GoVersion: $(GoVersionLatest)
+                GoVersionPrevious:
+                  GoVersion: $(GoVersionPrevious)
 
             steps:
               - template: /eng/pipelines/templates/steps/set-env.yaml

--- a/eng/pipelines/ci-gotest.yml
+++ b/eng/pipelines/ci-gotest.yml
@@ -36,7 +36,7 @@ extends:
       - stage: "AutoRest_Go_CI"
         jobs:
           - job: "AutoRest_Go_CI"
-            displayName: "Run AutoRest CI Checks - $(GoVersion)"
+            displayName: "Run AutoRest CI Checks - "
 
             variables:
               - template: /eng/pipelines/templates/variables/globals.yml

--- a/eng/pipelines/ci-gotest.yml
+++ b/eng/pipelines/ci-gotest.yml
@@ -36,15 +36,23 @@ extends:
       - stage: "AutoRest_Go_CI"
         jobs:
           - job: "AutoRest_Go_CI"
-            displayName: "Run AutoRest CI Checks"
+            displayName: "Run AutoRest CI Checks - $(GoVersion)"
 
             variables:
+              - template: /eng/pipelines/templates/variables/globals.yml
               - template: /eng/pipelines/templates/variables/image.yml
 
             pool:
               name: "$(LINUXNEXTPOOL)"
               image: "$(LINUXNEXTVMIMAGE)"
               os: linux
+
+            strategy:
+              matrix:
+                GoVersionLatest:
+                  GoVersion: $(GoVersionLatest)
+                GoVersionPrevious:
+                  GoVersion: $(GoVersionPrevious)
 
             steps:
               - template: /eng/pipelines/templates/steps/set-env.yaml

--- a/eng/pipelines/ci-typespec-nightly.yml
+++ b/eng/pipelines/ci-typespec-nightly.yml
@@ -11,6 +11,7 @@ pr: none
 
 jobs:
 - job: Go_Nightly_Build
+  displayName: "Run TypeSpec Go CI Checks - "
 
   variables:
     - template: /eng/pipelines/templates/variables/globals.yml

--- a/eng/pipelines/ci-typespec-nightly.yml
+++ b/eng/pipelines/ci-typespec-nightly.yml
@@ -11,13 +11,25 @@ pr: none
 
 jobs:
 - job: Go_Nightly_Build
-  timeoutInMinutes: 120
+
   variables:
+    - template: /eng/pipelines/templates/variables/globals.yml
     - template: /eng/pipelines/templates/variables/image.yml
+
   pool:
     name: "$(LINUXNEXTPOOL)"
     image: "$(LINUXNEXTVMIMAGE)"
     os: linux
+
+  strategy:
+    matrix:
+      GoVersionLatest:
+        GoVersion: $(GoVersionLatest)
+      GoVersionPrevious:
+        GoVersion: $(GoVersionPrevious)
+
+  timeoutInMinutes: 120
+
   steps:
     - template: /eng/pipelines/templates/steps/set-env.yaml
     - script: |

--- a/eng/pipelines/ci-typespec.yml
+++ b/eng/pipelines/ci-typespec.yml
@@ -32,15 +32,23 @@ extends:
       - stage: "TypeSpec_Go_CI"
         jobs:
           - job: "TypeSpec_Go_CI"
-            displayName: "Run TypeSpec Go CI Checks"
+            displayName: "Run TypeSpec Go CI Checks - $(GoVersion)"
 
             variables:
+              - template: /eng/pipelines/templates/variables/globals.yml
               - template: /eng/pipelines/templates/variables/image.yml
 
             pool:
               name: "$(LINUXNEXTPOOL)"
               image: "$(LINUXNEXTVMIMAGE)"
               os: linux
+
+            strategy:
+              matrix:
+                GoVersionLatest:
+                  GoVersion: $(GoVersionLatest)
+                GoVersionPrevious:
+                  GoVersion: $(GoVersionPrevious)
 
             steps:
               - template: /eng/pipelines/templates/steps/set-env.yaml

--- a/eng/pipelines/ci-typespec.yml
+++ b/eng/pipelines/ci-typespec.yml
@@ -32,7 +32,7 @@ extends:
       - stage: "TypeSpec_Go_CI"
         jobs:
           - job: "TypeSpec_Go_CI"
-            displayName: "Run TypeSpec Go CI Checks - $(GoVersion)"
+            displayName: "Run TypeSpec Go CI Checks - "
 
             variables:
               - template: /eng/pipelines/templates/variables/globals.yml

--- a/eng/pipelines/templates/steps/build-test-go.yaml
+++ b/eng/pipelines/templates/steps/build-test-go.yaml
@@ -49,7 +49,7 @@ steps:
         }
       }
       exit $exit
-    displayName: "Build"
+    displayName: "Build - go$(GoVersion)"
 
   - pwsh: |
       $modDirs = (./eng/scripts/get_module_dirs.ps1 -serviceDir ${{ parameters.GoTestPath }})
@@ -116,11 +116,11 @@ steps:
       pushd ./packages/autorest.go/node_modules/@microsoft.azure/autorest.testserver
       npm stop
       popd
-    displayName: "Run Acceptance Tests"
+    displayName: "Run Acceptance Tests - go$(GoVersion)"
     timeoutInMinutes: 10
 
   - pwsh: npm test
-    displayName: "Run Unit Tests"
+    displayName: "Run Unit Tests - go$(GoVersion)"
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.go
 
   - task: PublishTestResults@2

--- a/eng/pipelines/templates/steps/build-test-gotest.yaml
+++ b/eng/pipelines/templates/steps/build-test-gotest.yaml
@@ -12,7 +12,7 @@ steps:
   - script: |
       export PATH=$PATH:$HOME/go/bin
       npm test
-    displayName: "Run Tests"
+    displayName: "Run Tests - go$(GoVersion)"
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.gotest
 
   - task: PublishTestResults@2

--- a/eng/pipelines/templates/steps/build-test-typespec.yaml
+++ b/eng/pipelines/templates/steps/build-test-typespec.yaml
@@ -65,7 +65,7 @@ steps:
         popd
       }
       rush spector --stop
-    displayName: "Run All Tests"
+    displayName: "Run All Tests - go$(GoVersion)"
     timeoutInMinutes: 10
 
   - task: PublishTestResults@2

--- a/eng/pipelines/templates/steps/set-env.yaml
+++ b/eng/pipelines/templates/steps/set-env.yaml
@@ -1,7 +1,7 @@
 parameters:
-  NodeVersion: "20.x"
-  GoVersion: "1.24.1"
-  GoLintCLIVersion: 'v1.64.6'
+  NodeVersion: "$(NodeVersion)"
+  GoVersion: "$(GoVersion)"
+  GoLintCLIVersion: "$(GoLintCLIVersion)"
 
 steps:
   - task: NodeTool@0

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,0 +1,9 @@
+variables:
+  - name: GoVersionLatest
+    value: "1.24.1"
+  - name: GoVersionPrevious
+    value: "1.23.7"
+  - name: NodeVersion
+    value: "20.x"
+  - name: GoLintCLIVersion
+    value: "v1.64.6"


### PR DESCRIPTION
@jhendrixMSFT this updates the pipeline configs to test go latest and N-1 versions. Wasn't sure if you wanted all or some of the pipelines to test both versions, so just let me know which ones (and also if you want a variable naming change).