### PR TITLE
add globals.yaml for cadl-ranch-typespec and release pipeline

### DIFF
--- a/eng/pipelines/cadl-ranch-typespec.yml
+++ b/eng/pipelines/cadl-ranch-typespec.yml
@@ -13,6 +13,13 @@ variables:
     value: $(System.DefaultWorkingDirectory)/packages/typespec-go/node_modules/@typespec/spector/node_modules/.bin/tsp-spector
   - template: /eng/pipelines/templates/variables/globals.yml
 
+strategy:
+  matrix:
+    GoVersionLatest:
+      GoVersion: $(GoVersionLatest)
+    GoVersionPrevious:
+      GoVersion: $(GoVersionPrevious)
+
 steps:
   - template: /eng/pipelines/templates/steps/set-env.yaml
 

--- a/eng/pipelines/cadl-ranch-typespec.yml
+++ b/eng/pipelines/cadl-ranch-typespec.yml
@@ -11,6 +11,7 @@ pr: none
 variables:
   - name: spector
     value: $(System.DefaultWorkingDirectory)/packages/typespec-go/node_modules/@typespec/spector/node_modules/.bin/tsp-spector
+  - template: /eng/pipelines/templates/variables/globals.yml
 
 steps:
   - template: /eng/pipelines/templates/steps/set-env.yaml

--- a/eng/pipelines/cadl-ranch-typespec.yml
+++ b/eng/pipelines/cadl-ranch-typespec.yml
@@ -13,15 +13,10 @@ variables:
     value: $(System.DefaultWorkingDirectory)/packages/typespec-go/node_modules/@typespec/spector/node_modules/.bin/tsp-spector
   - template: /eng/pipelines/templates/variables/globals.yml
 
-strategy:
-  matrix:
-    GoVersionLatest:
-      GoVersion: $(GoVersionLatest)
-    GoVersionPrevious:
-      GoVersion: $(GoVersionPrevious)
-
 steps:
   - template: /eng/pipelines/templates/steps/set-env.yaml
+    parameters:
+      GoVersion: $(GoVersionLatest)
 
   - template: /eng/pipelines/templates/steps/build-test-typespec.yaml
 

--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -27,6 +27,7 @@ extends:
 
       variables: 
         - template: /eng/pipelines/templates/variables/image.yml
+        - template: /eng/pipelines/templates/variables/globals.yml
 
       jobs:
         - job: Release 
@@ -37,6 +38,8 @@ extends:
 
           steps:
             - template: /eng/pipelines/templates/steps/set-env.yaml
+              parameters:
+                GoVersion: $(GoVersionLatest)
 
             - ${{ if eq(parameters.release_autorestgo, true) }}:
               - template: /eng/pipelines/templates/steps/build-test-go.yaml


### PR DESCRIPTION
resolve: 
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4718215&view=results
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4718337&view=results

They caused by lack of global parameters for those pipelines.