### PR TITLE
[docs] remove reference to rush

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -24,7 +24,7 @@ This guide outlines the getting started steps to contributing to these generator
 ## Prerequisites
 
 - Install [Node.js](https://nodejs.org/download/)
-- Install [rush](https://rushjs.io/pages/intro/get_started/)
+- Install [pnpm](https://pnpm.io/installation/)
 - Install [Go](https://go.dev/doc/install)
 
 ## Step 1: Clone the repo
@@ -42,13 +42,19 @@ Once you have the code locally, you can build it.
 First, update all dependencies.
 
 ```terminal
-rush update
+pnpm update
 ```
 
 Then, build the code.
 
 ```terminal
-rush build
+pnpm build
+```
+
+To rebuild the entire codebase, run this from the root of the repo:
+
+```terminal
+pnpm -r build
 ```
 
 ## Step 3: Regenerate tests and samples
@@ -58,25 +64,25 @@ After making changes, build the code again, then run a regeneration command to s
 ### For autorest.go
 
 ```terminal
-rush regenerate
+pnpm regenerate
 ```
 
 To regenerate a specific test:
 
 ```terminal
-rush regenerate --filter TestName
+pnpm regenerate --filter TestName
 ```
 
 ### For typespec-go
 
 ```terminal
-rush tspcompile
+pnpm tspcompile
 ```
 
 To regenerate a specific test:
 
 ```terminal
-rush tspcompile --filter TestName
+pnpm tspcompile --filter TestName
 ```
 
 ## Step 4: Test your changes
@@ -86,9 +92,9 @@ Verify changes made result in the output you expect.
 For typespec-go, you can run tests using spector.
 
 ```terminal
-rush spector --start
+pnpm spector --start
 ~ run tests~
-rush spector --stop
+pnpm spector --stop
 ```
 
 ### Debug
@@ -100,18 +106,18 @@ To debug the code generator:
 
 ### Built in commands
 
-There are a number of custom rush commands to help with development. See the `.scripts` folder for more.
+There are a number of custom pnpm commands to help with development. See the `.scripts` folder for more.
 
 To run `go build` and `go vet` on every generated module:
 
 ```terminal
-rush buildvet
+pnpm buildvet
 ```
 
 To run `go mod tidy` on every generated module:
 
 ```terminal
-rush modtidy
+pnpm modtidy
 ```
 
 ## Step 5: Make a PR

--- a/docs/development.md
+++ b/docs/development.md
@@ -106,7 +106,9 @@ To debug the code generator:
 
 ### Built in commands
 
-There are a number of custom pnpm commands to help with development. See the `.scripts` folder for more. Add the `-w` switch for the script to apply to every package.
+There are a number of custom pnpm commands to help with development. See the `.scripts` folder for more. Add the -w switch when executing the script from a directory other than the repo root.
+
+NOTE: by default, the script will run against the entire repo. To limit its scope, pass a directory argument. E.g. when working from the /packages/autorest.go directory, to execute modtidy for only go.mod files under /packages/autorest.go, execute pnpm -w modtidy $pwd
 
 To run `go build` and `go vet` on every generated module:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -106,18 +106,18 @@ To debug the code generator:
 
 ### Built in commands
 
-There are a number of custom pnpm commands to help with development. See the `.scripts` folder for more.
+There are a number of custom pnpm commands to help with development. See the `.scripts` folder for more. Add the `-r` switch for the script to apply to every package.
 
 To run `go build` and `go vet` on every generated module:
 
 ```terminal
-pnpm buildvet
+pnpm -r buildvet
 ```
 
 To run `go mod tidy` on every generated module:
 
 ```terminal
-pnpm modtidy
+pnpm -r modtidy
 ```
 
 ## Step 5: Make a PR

--- a/docs/development.md
+++ b/docs/development.md
@@ -47,14 +47,10 @@ pnpm install
 
 Then, build the code.
 
+To build a specific package, navigate to that directory and run the command from there.
+
 ```terminal
 pnpm build
-```
-
-To rebuild the entire codebase, run this from the root of the repo:
-
-```terminal
-pnpm -r build
 ```
 
 ## Step 3: Regenerate tests and samples
@@ -62,6 +58,8 @@ pnpm -r build
 After making changes, build the code again, then run a regeneration command to see how your change has affected client code generation.
 
 ### For autorest.go
+
+From the `autorest.go/packages/autorest.go` directory, run the following command:
 
 ```terminal
 pnpm regenerate
@@ -74,6 +72,8 @@ pnpm regenerate --filter=TestName
 ```
 
 ### For typespec-go
+
+From the `autorest.go/packages/typespec-go` directory, run the following command:
 
 ```terminal
 pnpm tspcompile
@@ -106,18 +106,18 @@ To debug the code generator:
 
 ### Built in commands
 
-There are a number of custom pnpm commands to help with development. See the `.scripts` folder for more. Add the `-r` switch for the script to apply to every package.
+There are a number of custom pnpm commands to help with development. See the `.scripts` folder for more. Add the `-w` switch for the script to apply to every package.
 
 To run `go build` and `go vet` on every generated module:
 
 ```terminal
-pnpm -r buildvet
+pnpm -w buildvet
 ```
 
 To run `go mod tidy` on every generated module:
 
 ```terminal
-pnpm -r modtidy
+pnpm -w modtidy
 ```
 
 ## Step 5: Make a PR

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,10 +39,10 @@ git clone https://github.com/<your-github-username>/autorest.go.git
 
 Once you have the code locally, you can build it.
 
-First, update all dependencies.
+First, install all dependencies.
 
 ```terminal
-pnpm update
+pnpm install
 ```
 
 Then, build the code.
@@ -70,7 +70,7 @@ pnpm regenerate
 To regenerate a specific test:
 
 ```terminal
-pnpm regenerate --filter TestName
+pnpm regenerate --filter=TestName
 ```
 
 ### For typespec-go
@@ -82,7 +82,7 @@ pnpm tspcompile
 To regenerate a specific test:
 
 ```terminal
-pnpm tspcompile --filter TestName
+pnpm tspcompile --filter=TestName
 ```
 
 ## Step 4: Test your changes


### PR DESCRIPTION
Update getting started docs to reference `pnpm` instead of `rush`