### PR TITLE
fix `Upload TypeSpec Spector Test Coverage` pipeline step

### DIFF
--- a/eng/pipelines/cadl-ranch-typespec.yml
+++ b/eng/pipelines/cadl-ranch-typespec.yml
@@ -24,4 +24,5 @@ steps:
       azureSubscription: "TypeSpec Storage"
       scriptType: "bash"
       scriptLocation: "inlineScript"
+      workingDirectory: $(Build.SourcesDirectory)/packages/typespec-go
       inlineScript: npx tsp-spector upload-coverage --containerName=coverages --generatorName @azure-tools/typespec-go --storageAccountName typespec --generatorVersion $(node -p -e "require('$(System.DefaultWorkingDirectory)/packages/typespec-go/package.json').version") --generatorMode azure


### PR DESCRIPTION
Pipeline step failing after switching from rush to pnpm, need to add `workingDirectory`