### PR TITLE
upgrade version and key vault test

### DIFF
--- a/packages/typespec-go/.scripts/tspcompile.js
+++ b/packages/typespec-go/.scripts/tspcompile.js
@@ -165,8 +165,8 @@ generate('armcontainerorchestratorruntime', armcontainerorchestratorruntime, 'te
 const azmodelsonly = pkgRoot + 'test/tsp/ModelsOnlyWithBaseTypes';
 generate('azmodelsonly', azmodelsonly, 'test/local/azmodelsonly');
 
-const azkeys = pkgRoot + 'test/tsp/KeyVault.Keys';
-generate('azkeys', azkeys, 'test/local/azkeys');
+const azkeys = pkgRoot + 'test/tsp/KeyVault.Keys/client.tsp';
+generate('azkeys', azkeys, 'test/local/azkeys', ['single-client=true']);
 
 const armtest = pkgRoot + 'test/tsp/Test.Management';
 generate('armtest', armtest, 'test/local/armtest');

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.4.11 (2025-06-09)
+
+### Other Changes
+
+* Updated to latest tcgc.
+
 ## 0.4.10 (2025-05-29)
 
 ### Bugs Fixed

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -53,11 +53,11 @@
     "@azure-tools/typespec-autorest": "0.56.0",
     "@azure-tools/typespec-azure-core": "0.56.0",
     "@azure-tools/typespec-azure-resource-manager": "0.56.2",
-    "@azure-tools/typespec-client-generator-core": "0.56.2",
+    "@azure-tools/typespec-client-generator-core": "0.56.4",
     "@types/node": "catalog:",
     "@typespec/compiler": "1.0.0",
     "@typespec/events": "0.70.0",
-    "@typespec/http": "1.0.0",
+    "@typespec/http": "1.0.1",
     "@typespec/http-specs": "0.1.0-alpha.22",
     "@typespec/openapi": "1.0.0",
     "@typespec/rest": "0.70.0",
@@ -77,7 +77,7 @@
   "peerDependencies": {
     "@azure-tools/typespec-client-generator-core": "0.56.2",
     "@typespec/compiler": "^1.0.0",
-    "@typespec/http": "^1.0.0"
+    "@typespec/http": "^1.0.1"
   },
   "dependencies": {
     "@azure-tools/codegen": "catalog:",

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-go",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "TypeSpec emitter for Go SDKs",
   "type": "module",
   "exports": {
@@ -75,7 +75,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@azure-tools/typespec-client-generator-core": "0.56.2",
+    "@azure-tools/typespec-client-generator-core": "0.56.4",
     "@typespec/compiler": "^1.0.0",
     "@typespec/http": "^1.0.1"
   },

--- a/packages/typespec-go/test/local/azkeys/custom_client.go
+++ b/packages/typespec-go/test/local/azkeys/custom_client.go
@@ -8,12 +8,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
-func NewKeyVaultClient(vaultURL string, options *azcore.ClientOptions) (*KeyVaultClient, error) {
+func NewClient(vaultURL string, options *azcore.ClientOptions) (*Client, error) {
 	client, err := azcore.NewClient("azkeys", "v0.1.0", runtime.PipelineOptions{}, options)
 	if err != nil {
 		return nil, err
 	}
-	return &KeyVaultClient{
+	return &Client{
 		internal:     client,
 		vaultBaseUrl: vaultURL,
 	}, nil

--- a/packages/typespec-go/test/local/azkeys/fake/zz_internal.go
+++ b/packages/typespec-go/test/local/azkeys/fake/zz_internal.go
@@ -32,17 +32,6 @@ func contains[T comparable](s []T, v T) bool {
 	return false
 }
 
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
 func newTracker[T any]() *tracker[T] {
 	return &tracker[T]{
 		items: map[string]*T{},

--- a/packages/typespec-go/test/local/azkeys/fake/zz_server.go
+++ b/packages/typespec-go/test/local/azkeys/fake/zz_server.go
@@ -16,200 +16,199 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"strconv"
 )
 
-// KeyVaultServer is a fake server for instances of the azkeys.KeyVaultClient type.
-type KeyVaultServer struct {
-	// BackupKey is the fake for method KeyVaultClient.BackupKey
+// Server is a fake server for instances of the azkeys.Client type.
+type Server struct {
+	// BackupKey is the fake for method Client.BackupKey
 	// HTTP status codes to indicate success: http.StatusOK
-	BackupKey func(ctx context.Context, keyName string, options *azkeys.KeyVaultClientBackupKeyOptions) (resp azfake.Responder[azkeys.KeyVaultClientBackupKeyResponse], errResp azfake.ErrorResponder)
+	BackupKey func(ctx context.Context, keyName string, options *azkeys.BackupKeyOptions) (resp azfake.Responder[azkeys.BackupKeyResponse], errResp azfake.ErrorResponder)
 
-	// CreateKey is the fake for method KeyVaultClient.CreateKey
+	// CreateKey is the fake for method Client.CreateKey
 	// HTTP status codes to indicate success: http.StatusOK
-	CreateKey func(ctx context.Context, keyName string, parameters azkeys.KeyCreateParameters, options *azkeys.KeyVaultClientCreateKeyOptions) (resp azfake.Responder[azkeys.KeyVaultClientCreateKeyResponse], errResp azfake.ErrorResponder)
+	CreateKey func(ctx context.Context, keyName string, parameters azkeys.CreateKeyParameters, options *azkeys.CreateKeyOptions) (resp azfake.Responder[azkeys.CreateKeyResponse], errResp azfake.ErrorResponder)
 
-	// Decrypt is the fake for method KeyVaultClient.Decrypt
+	// Decrypt is the fake for method Client.Decrypt
 	// HTTP status codes to indicate success: http.StatusOK
-	Decrypt func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeyOperationsParameters, options *azkeys.KeyVaultClientDecryptOptions) (resp azfake.Responder[azkeys.KeyVaultClientDecryptResponse], errResp azfake.ErrorResponder)
+	Decrypt func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeyOperationParameters, options *azkeys.DecryptOptions) (resp azfake.Responder[azkeys.DecryptResponse], errResp azfake.ErrorResponder)
 
-	// DeleteKey is the fake for method KeyVaultClient.DeleteKey
+	// DeleteKey is the fake for method Client.DeleteKey
 	// HTTP status codes to indicate success: http.StatusOK
-	DeleteKey func(ctx context.Context, keyName string, options *azkeys.KeyVaultClientDeleteKeyOptions) (resp azfake.Responder[azkeys.KeyVaultClientDeleteKeyResponse], errResp azfake.ErrorResponder)
+	DeleteKey func(ctx context.Context, keyName string, options *azkeys.DeleteKeyOptions) (resp azfake.Responder[azkeys.DeleteKeyResponse], errResp azfake.ErrorResponder)
 
-	// Encrypt is the fake for method KeyVaultClient.Encrypt
+	// Encrypt is the fake for method Client.Encrypt
 	// HTTP status codes to indicate success: http.StatusOK
-	Encrypt func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeyOperationsParameters, options *azkeys.KeyVaultClientEncryptOptions) (resp azfake.Responder[azkeys.KeyVaultClientEncryptResponse], errResp azfake.ErrorResponder)
+	Encrypt func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeyOperationParameters, options *azkeys.EncryptOptions) (resp azfake.Responder[azkeys.EncryptResponse], errResp azfake.ErrorResponder)
 
-	// GetDeletedKey is the fake for method KeyVaultClient.GetDeletedKey
+	// GetDeletedKey is the fake for method Client.GetDeletedKey
 	// HTTP status codes to indicate success: http.StatusOK
-	GetDeletedKey func(ctx context.Context, keyName string, options *azkeys.KeyVaultClientGetDeletedKeyOptions) (resp azfake.Responder[azkeys.KeyVaultClientGetDeletedKeyResponse], errResp azfake.ErrorResponder)
+	GetDeletedKey func(ctx context.Context, keyName string, options *azkeys.GetDeletedKeyOptions) (resp azfake.Responder[azkeys.GetDeletedKeyResponse], errResp azfake.ErrorResponder)
 
-	// NewGetDeletedKeysPager is the fake for method KeyVaultClient.NewGetDeletedKeysPager
+	// GetKey is the fake for method Client.GetKey
 	// HTTP status codes to indicate success: http.StatusOK
-	NewGetDeletedKeysPager func(options *azkeys.KeyVaultClientGetDeletedKeysOptions) (resp azfake.PagerResponder[azkeys.KeyVaultClientGetDeletedKeysResponse])
+	GetKey func(ctx context.Context, keyName string, keyVersion string, options *azkeys.GetKeyOptions) (resp azfake.Responder[azkeys.GetKeyResponse], errResp azfake.ErrorResponder)
 
-	// GetKey is the fake for method KeyVaultClient.GetKey
+	// GetKeyRotationPolicy is the fake for method Client.GetKeyRotationPolicy
 	// HTTP status codes to indicate success: http.StatusOK
-	GetKey func(ctx context.Context, keyName string, keyVersion string, options *azkeys.KeyVaultClientGetKeyOptions) (resp azfake.Responder[azkeys.KeyVaultClientGetKeyResponse], errResp azfake.ErrorResponder)
+	GetKeyRotationPolicy func(ctx context.Context, keyName string, options *azkeys.GetKeyRotationPolicyOptions) (resp azfake.Responder[azkeys.GetKeyRotationPolicyResponse], errResp azfake.ErrorResponder)
 
-	// GetKeyRotationPolicy is the fake for method KeyVaultClient.GetKeyRotationPolicy
+	// GetRandomBytes is the fake for method Client.GetRandomBytes
 	// HTTP status codes to indicate success: http.StatusOK
-	GetKeyRotationPolicy func(ctx context.Context, keyName string, options *azkeys.KeyVaultClientGetKeyRotationPolicyOptions) (resp azfake.Responder[azkeys.KeyVaultClientGetKeyRotationPolicyResponse], errResp azfake.ErrorResponder)
+	GetRandomBytes func(ctx context.Context, parameters azkeys.GetRandomBytesParameters, options *azkeys.GetRandomBytesOptions) (resp azfake.Responder[azkeys.GetRandomBytesResponse], errResp azfake.ErrorResponder)
 
-	// NewGetKeyVersionsPager is the fake for method KeyVaultClient.NewGetKeyVersionsPager
+	// ImportKey is the fake for method Client.ImportKey
 	// HTTP status codes to indicate success: http.StatusOK
-	NewGetKeyVersionsPager func(keyName string, options *azkeys.KeyVaultClientGetKeyVersionsOptions) (resp azfake.PagerResponder[azkeys.KeyVaultClientGetKeyVersionsResponse])
+	ImportKey func(ctx context.Context, keyName string, parameters azkeys.ImportKeyParameters, options *azkeys.ImportKeyOptions) (resp azfake.Responder[azkeys.ImportKeyResponse], errResp azfake.ErrorResponder)
 
-	// NewGetKeysPager is the fake for method KeyVaultClient.NewGetKeysPager
+	// NewListDeletedKeyPropertiesPager is the fake for method Client.NewListDeletedKeyPropertiesPager
 	// HTTP status codes to indicate success: http.StatusOK
-	NewGetKeysPager func(options *azkeys.KeyVaultClientGetKeysOptions) (resp azfake.PagerResponder[azkeys.KeyVaultClientGetKeysResponse])
+	NewListDeletedKeyPropertiesPager func(options *azkeys.ListDeletedKeyPropertiesOptions) (resp azfake.PagerResponder[azkeys.ListDeletedKeyPropertiesResponse])
 
-	// GetRandomBytes is the fake for method KeyVaultClient.GetRandomBytes
+	// NewListKeyPropertiesPager is the fake for method Client.NewListKeyPropertiesPager
 	// HTTP status codes to indicate success: http.StatusOK
-	GetRandomBytes func(ctx context.Context, parameters azkeys.GetRandomBytesRequest, options *azkeys.KeyVaultClientGetRandomBytesOptions) (resp azfake.Responder[azkeys.KeyVaultClientGetRandomBytesResponse], errResp azfake.ErrorResponder)
+	NewListKeyPropertiesPager func(options *azkeys.ListKeyPropertiesOptions) (resp azfake.PagerResponder[azkeys.ListKeyPropertiesResponse])
 
-	// ImportKey is the fake for method KeyVaultClient.ImportKey
+	// NewListKeyPropertiesVersionsPager is the fake for method Client.NewListKeyPropertiesVersionsPager
 	// HTTP status codes to indicate success: http.StatusOK
-	ImportKey func(ctx context.Context, keyName string, parameters azkeys.KeyImportParameters, options *azkeys.KeyVaultClientImportKeyOptions) (resp azfake.Responder[azkeys.KeyVaultClientImportKeyResponse], errResp azfake.ErrorResponder)
+	NewListKeyPropertiesVersionsPager func(keyName string, options *azkeys.ListKeyPropertiesVersionsOptions) (resp azfake.PagerResponder[azkeys.ListKeyPropertiesVersionsResponse])
 
-	// PurgeDeletedKey is the fake for method KeyVaultClient.PurgeDeletedKey
+	// PurgeDeletedKey is the fake for method Client.PurgeDeletedKey
 	// HTTP status codes to indicate success: http.StatusNoContent
-	PurgeDeletedKey func(ctx context.Context, keyName string, options *azkeys.KeyVaultClientPurgeDeletedKeyOptions) (resp azfake.Responder[azkeys.KeyVaultClientPurgeDeletedKeyResponse], errResp azfake.ErrorResponder)
+	PurgeDeletedKey func(ctx context.Context, keyName string, options *azkeys.PurgeDeletedKeyOptions) (resp azfake.Responder[azkeys.PurgeDeletedKeyResponse], errResp azfake.ErrorResponder)
 
-	// RecoverDeletedKey is the fake for method KeyVaultClient.RecoverDeletedKey
+	// RecoverDeletedKey is the fake for method Client.RecoverDeletedKey
 	// HTTP status codes to indicate success: http.StatusOK
-	RecoverDeletedKey func(ctx context.Context, keyName string, options *azkeys.KeyVaultClientRecoverDeletedKeyOptions) (resp azfake.Responder[azkeys.KeyVaultClientRecoverDeletedKeyResponse], errResp azfake.ErrorResponder)
+	RecoverDeletedKey func(ctx context.Context, keyName string, options *azkeys.RecoverDeletedKeyOptions) (resp azfake.Responder[azkeys.RecoverDeletedKeyResponse], errResp azfake.ErrorResponder)
 
-	// Release is the fake for method KeyVaultClient.Release
+	// Release is the fake for method Client.Release
 	// HTTP status codes to indicate success: http.StatusOK
-	Release func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeyReleaseParameters, options *azkeys.KeyVaultClientReleaseOptions) (resp azfake.Responder[azkeys.KeyVaultClientReleaseResponse], errResp azfake.ErrorResponder)
+	Release func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.ReleaseParameters, options *azkeys.ReleaseOptions) (resp azfake.Responder[azkeys.ReleaseResponse], errResp azfake.ErrorResponder)
 
-	// RestoreKey is the fake for method KeyVaultClient.RestoreKey
+	// RestoreKey is the fake for method Client.RestoreKey
 	// HTTP status codes to indicate success: http.StatusOK
-	RestoreKey func(ctx context.Context, parameters azkeys.KeyRestoreParameters, options *azkeys.KeyVaultClientRestoreKeyOptions) (resp azfake.Responder[azkeys.KeyVaultClientRestoreKeyResponse], errResp azfake.ErrorResponder)
+	RestoreKey func(ctx context.Context, parameters azkeys.RestoreKeyParameters, options *azkeys.RestoreKeyOptions) (resp azfake.Responder[azkeys.RestoreKeyResponse], errResp azfake.ErrorResponder)
 
-	// RotateKey is the fake for method KeyVaultClient.RotateKey
+	// RotateKey is the fake for method Client.RotateKey
 	// HTTP status codes to indicate success: http.StatusOK
-	RotateKey func(ctx context.Context, keyName string, options *azkeys.KeyVaultClientRotateKeyOptions) (resp azfake.Responder[azkeys.KeyVaultClientRotateKeyResponse], errResp azfake.ErrorResponder)
+	RotateKey func(ctx context.Context, keyName string, options *azkeys.RotateKeyOptions) (resp azfake.Responder[azkeys.RotateKeyResponse], errResp azfake.ErrorResponder)
 
-	// Sign is the fake for method KeyVaultClient.Sign
+	// Sign is the fake for method Client.Sign
 	// HTTP status codes to indicate success: http.StatusOK
-	Sign func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeySignParameters, options *azkeys.KeyVaultClientSignOptions) (resp azfake.Responder[azkeys.KeyVaultClientSignResponse], errResp azfake.ErrorResponder)
+	Sign func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.SignParameters, options *azkeys.SignOptions) (resp azfake.Responder[azkeys.SignResponse], errResp azfake.ErrorResponder)
 
-	// UnwrapKey is the fake for method KeyVaultClient.UnwrapKey
+	// UnwrapKey is the fake for method Client.UnwrapKey
 	// HTTP status codes to indicate success: http.StatusOK
-	UnwrapKey func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeyOperationsParameters, options *azkeys.KeyVaultClientUnwrapKeyOptions) (resp azfake.Responder[azkeys.KeyVaultClientUnwrapKeyResponse], errResp azfake.ErrorResponder)
+	UnwrapKey func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeyOperationParameters, options *azkeys.UnwrapKeyOptions) (resp azfake.Responder[azkeys.UnwrapKeyResponse], errResp azfake.ErrorResponder)
 
-	// UpdateKey is the fake for method KeyVaultClient.UpdateKey
+	// UpdateKey is the fake for method Client.UpdateKey
 	// HTTP status codes to indicate success: http.StatusOK
-	UpdateKey func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeyUpdateParameters, options *azkeys.KeyVaultClientUpdateKeyOptions) (resp azfake.Responder[azkeys.KeyVaultClientUpdateKeyResponse], errResp azfake.ErrorResponder)
+	UpdateKey func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.UpdateKeyParameters, options *azkeys.UpdateKeyOptions) (resp azfake.Responder[azkeys.UpdateKeyResponse], errResp azfake.ErrorResponder)
 
-	// UpdateKeyRotationPolicy is the fake for method KeyVaultClient.UpdateKeyRotationPolicy
+	// UpdateKeyRotationPolicy is the fake for method Client.UpdateKeyRotationPolicy
 	// HTTP status codes to indicate success: http.StatusOK
-	UpdateKeyRotationPolicy func(ctx context.Context, keyName string, keyRotationPolicy azkeys.KeyRotationPolicy, options *azkeys.KeyVaultClientUpdateKeyRotationPolicyOptions) (resp azfake.Responder[azkeys.KeyVaultClientUpdateKeyRotationPolicyResponse], errResp azfake.ErrorResponder)
+	UpdateKeyRotationPolicy func(ctx context.Context, keyName string, keyRotationPolicy azkeys.KeyRotationPolicy, options *azkeys.UpdateKeyRotationPolicyOptions) (resp azfake.Responder[azkeys.UpdateKeyRotationPolicyResponse], errResp azfake.ErrorResponder)
 
-	// Verify is the fake for method KeyVaultClient.Verify
+	// Verify is the fake for method Client.Verify
 	// HTTP status codes to indicate success: http.StatusOK
-	Verify func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeyVerifyParameters, options *azkeys.KeyVaultClientVerifyOptions) (resp azfake.Responder[azkeys.KeyVaultClientVerifyResponse], errResp azfake.ErrorResponder)
+	Verify func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.VerifyParameters, options *azkeys.VerifyOptions) (resp azfake.Responder[azkeys.VerifyResponse], errResp azfake.ErrorResponder)
 
-	// WrapKey is the fake for method KeyVaultClient.WrapKey
+	// WrapKey is the fake for method Client.WrapKey
 	// HTTP status codes to indicate success: http.StatusOK
-	WrapKey func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeyOperationsParameters, options *azkeys.KeyVaultClientWrapKeyOptions) (resp azfake.Responder[azkeys.KeyVaultClientWrapKeyResponse], errResp azfake.ErrorResponder)
+	WrapKey func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeyOperationParameters, options *azkeys.WrapKeyOptions) (resp azfake.Responder[azkeys.WrapKeyResponse], errResp azfake.ErrorResponder)
 }
 
-// NewKeyVaultServerTransport creates a new instance of KeyVaultServerTransport with the provided implementation.
-// The returned KeyVaultServerTransport instance is connected to an instance of azkeys.KeyVaultClient via the
+// NewServerTransport creates a new instance of ServerTransport with the provided implementation.
+// The returned ServerTransport instance is connected to an instance of azkeys.Client via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
-func NewKeyVaultServerTransport(srv *KeyVaultServer) *KeyVaultServerTransport {
-	return &KeyVaultServerTransport{
-		srv:                    srv,
-		newGetDeletedKeysPager: newTracker[azfake.PagerResponder[azkeys.KeyVaultClientGetDeletedKeysResponse]](),
-		newGetKeyVersionsPager: newTracker[azfake.PagerResponder[azkeys.KeyVaultClientGetKeyVersionsResponse]](),
-		newGetKeysPager:        newTracker[azfake.PagerResponder[azkeys.KeyVaultClientGetKeysResponse]](),
+func NewServerTransport(srv *Server) *ServerTransport {
+	return &ServerTransport{
+		srv:                               srv,
+		newListDeletedKeyPropertiesPager:  newTracker[azfake.PagerResponder[azkeys.ListDeletedKeyPropertiesResponse]](),
+		newListKeyPropertiesPager:         newTracker[azfake.PagerResponder[azkeys.ListKeyPropertiesResponse]](),
+		newListKeyPropertiesVersionsPager: newTracker[azfake.PagerResponder[azkeys.ListKeyPropertiesVersionsResponse]](),
 	}
 }
 
-// KeyVaultServerTransport connects instances of azkeys.KeyVaultClient to instances of KeyVaultServer.
-// Don't use this type directly, use NewKeyVaultServerTransport instead.
-type KeyVaultServerTransport struct {
-	srv                    *KeyVaultServer
-	newGetDeletedKeysPager *tracker[azfake.PagerResponder[azkeys.KeyVaultClientGetDeletedKeysResponse]]
-	newGetKeyVersionsPager *tracker[azfake.PagerResponder[azkeys.KeyVaultClientGetKeyVersionsResponse]]
-	newGetKeysPager        *tracker[azfake.PagerResponder[azkeys.KeyVaultClientGetKeysResponse]]
+// ServerTransport connects instances of azkeys.Client to instances of Server.
+// Don't use this type directly, use NewServerTransport instead.
+type ServerTransport struct {
+	srv                               *Server
+	newListDeletedKeyPropertiesPager  *tracker[azfake.PagerResponder[azkeys.ListDeletedKeyPropertiesResponse]]
+	newListKeyPropertiesPager         *tracker[azfake.PagerResponder[azkeys.ListKeyPropertiesResponse]]
+	newListKeyPropertiesVersionsPager *tracker[azfake.PagerResponder[azkeys.ListKeyPropertiesVersionsResponse]]
 }
 
-// Do implements the policy.Transporter interface for KeyVaultServerTransport.
-func (k *KeyVaultServerTransport) Do(req *http.Request) (*http.Response, error) {
+// Do implements the policy.Transporter interface for ServerTransport.
+func (s *ServerTransport) Do(req *http.Request) (*http.Response, error) {
 	rawMethod := req.Context().Value(runtime.CtxAPINameKey{})
 	method, ok := rawMethod.(string)
 	if !ok {
 		return nil, nonRetriableError{errors.New("unable to dispatch request, missing value for CtxAPINameKey")}
 	}
 
-	return k.dispatchToMethodFake(req, method)
+	return s.dispatchToMethodFake(req, method)
 }
 
-func (k *KeyVaultServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
+func (s *ServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
 	resultChan := make(chan result)
 	defer close(resultChan)
 
 	go func() {
 		var intercepted bool
 		var res result
-		if keyVaultServerTransportInterceptor != nil {
-			res.resp, res.err, intercepted = keyVaultServerTransportInterceptor.Do(req)
+		if serverTransportInterceptor != nil {
+			res.resp, res.err, intercepted = serverTransportInterceptor.Do(req)
 		}
 		if !intercepted {
 			switch method {
-			case "KeyVaultClient.BackupKey":
-				res.resp, res.err = k.dispatchBackupKey(req)
-			case "KeyVaultClient.CreateKey":
-				res.resp, res.err = k.dispatchCreateKey(req)
-			case "KeyVaultClient.Decrypt":
-				res.resp, res.err = k.dispatchDecrypt(req)
-			case "KeyVaultClient.DeleteKey":
-				res.resp, res.err = k.dispatchDeleteKey(req)
-			case "KeyVaultClient.Encrypt":
-				res.resp, res.err = k.dispatchEncrypt(req)
-			case "KeyVaultClient.GetDeletedKey":
-				res.resp, res.err = k.dispatchGetDeletedKey(req)
-			case "KeyVaultClient.NewGetDeletedKeysPager":
-				res.resp, res.err = k.dispatchNewGetDeletedKeysPager(req)
-			case "KeyVaultClient.GetKey":
-				res.resp, res.err = k.dispatchGetKey(req)
-			case "KeyVaultClient.GetKeyRotationPolicy":
-				res.resp, res.err = k.dispatchGetKeyRotationPolicy(req)
-			case "KeyVaultClient.NewGetKeyVersionsPager":
-				res.resp, res.err = k.dispatchNewGetKeyVersionsPager(req)
-			case "KeyVaultClient.NewGetKeysPager":
-				res.resp, res.err = k.dispatchNewGetKeysPager(req)
-			case "KeyVaultClient.GetRandomBytes":
-				res.resp, res.err = k.dispatchGetRandomBytes(req)
-			case "KeyVaultClient.ImportKey":
-				res.resp, res.err = k.dispatchImportKey(req)
-			case "KeyVaultClient.PurgeDeletedKey":
-				res.resp, res.err = k.dispatchPurgeDeletedKey(req)
-			case "KeyVaultClient.RecoverDeletedKey":
-				res.resp, res.err = k.dispatchRecoverDeletedKey(req)
-			case "KeyVaultClient.Release":
-				res.resp, res.err = k.dispatchRelease(req)
-			case "KeyVaultClient.RestoreKey":
-				res.resp, res.err = k.dispatchRestoreKey(req)
-			case "KeyVaultClient.RotateKey":
-				res.resp, res.err = k.dispatchRotateKey(req)
-			case "KeyVaultClient.Sign":
-				res.resp, res.err = k.dispatchSign(req)
-			case "KeyVaultClient.UnwrapKey":
-				res.resp, res.err = k.dispatchUnwrapKey(req)
-			case "KeyVaultClient.UpdateKey":
-				res.resp, res.err = k.dispatchUpdateKey(req)
-			case "KeyVaultClient.UpdateKeyRotationPolicy":
-				res.resp, res.err = k.dispatchUpdateKeyRotationPolicy(req)
-			case "KeyVaultClient.Verify":
-				res.resp, res.err = k.dispatchVerify(req)
-			case "KeyVaultClient.WrapKey":
-				res.resp, res.err = k.dispatchWrapKey(req)
+			case "Client.BackupKey":
+				res.resp, res.err = s.dispatchBackupKey(req)
+			case "Client.CreateKey":
+				res.resp, res.err = s.dispatchCreateKey(req)
+			case "Client.Decrypt":
+				res.resp, res.err = s.dispatchDecrypt(req)
+			case "Client.DeleteKey":
+				res.resp, res.err = s.dispatchDeleteKey(req)
+			case "Client.Encrypt":
+				res.resp, res.err = s.dispatchEncrypt(req)
+			case "Client.GetDeletedKey":
+				res.resp, res.err = s.dispatchGetDeletedKey(req)
+			case "Client.GetKey":
+				res.resp, res.err = s.dispatchGetKey(req)
+			case "Client.GetKeyRotationPolicy":
+				res.resp, res.err = s.dispatchGetKeyRotationPolicy(req)
+			case "Client.GetRandomBytes":
+				res.resp, res.err = s.dispatchGetRandomBytes(req)
+			case "Client.ImportKey":
+				res.resp, res.err = s.dispatchImportKey(req)
+			case "Client.NewListDeletedKeyPropertiesPager":
+				res.resp, res.err = s.dispatchNewListDeletedKeyPropertiesPager(req)
+			case "Client.NewListKeyPropertiesPager":
+				res.resp, res.err = s.dispatchNewListKeyPropertiesPager(req)
+			case "Client.NewListKeyPropertiesVersionsPager":
+				res.resp, res.err = s.dispatchNewListKeyPropertiesVersionsPager(req)
+			case "Client.PurgeDeletedKey":
+				res.resp, res.err = s.dispatchPurgeDeletedKey(req)
+			case "Client.RecoverDeletedKey":
+				res.resp, res.err = s.dispatchRecoverDeletedKey(req)
+			case "Client.Release":
+				res.resp, res.err = s.dispatchRelease(req)
+			case "Client.RestoreKey":
+				res.resp, res.err = s.dispatchRestoreKey(req)
+			case "Client.RotateKey":
+				res.resp, res.err = s.dispatchRotateKey(req)
+			case "Client.Sign":
+				res.resp, res.err = s.dispatchSign(req)
+			case "Client.UnwrapKey":
+				res.resp, res.err = s.dispatchUnwrapKey(req)
+			case "Client.UpdateKey":
+				res.resp, res.err = s.dispatchUpdateKey(req)
+			case "Client.UpdateKeyRotationPolicy":
+				res.resp, res.err = s.dispatchUpdateKeyRotationPolicy(req)
+			case "Client.Verify":
+				res.resp, res.err = s.dispatchVerify(req)
+			case "Client.WrapKey":
+				res.resp, res.err = s.dispatchWrapKey(req)
 			default:
 				res.err = fmt.Errorf("unhandled API %s", method)
 			}
@@ -229,8 +228,8 @@ func (k *KeyVaultServerTransport) dispatchToMethodFake(req *http.Request, method
 	}
 }
 
-func (k *KeyVaultServerTransport) dispatchBackupKey(req *http.Request) (*http.Response, error) {
-	if k.srv.BackupKey == nil {
+func (s *ServerTransport) dispatchBackupKey(req *http.Request) (*http.Response, error) {
+	if s.srv.BackupKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BackupKey not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/backup`
@@ -243,7 +242,7 @@ func (k *KeyVaultServerTransport) dispatchBackupKey(req *http.Request) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.BackupKey(req.Context(), keyNameParam, nil)
+	respr, errRespr := s.srv.BackupKey(req.Context(), keyNameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -258,8 +257,8 @@ func (k *KeyVaultServerTransport) dispatchBackupKey(req *http.Request) (*http.Re
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchCreateKey(req *http.Request) (*http.Response, error) {
-	if k.srv.CreateKey == nil {
+func (s *ServerTransport) dispatchCreateKey(req *http.Request) (*http.Response, error) {
+	if s.srv.CreateKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method CreateKey not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/create`
@@ -268,7 +267,7 @@ func (k *KeyVaultServerTransport) dispatchCreateKey(req *http.Request) (*http.Re
 	if len(matches) < 2 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	body, err := server.UnmarshalRequestAsJSON[azkeys.KeyCreateParameters](req)
+	body, err := server.UnmarshalRequestAsJSON[azkeys.CreateKeyParameters](req)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +275,7 @@ func (k *KeyVaultServerTransport) dispatchCreateKey(req *http.Request) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.CreateKey(req.Context(), keyNameParam, body, nil)
+	respr, errRespr := s.srv.CreateKey(req.Context(), keyNameParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -291,8 +290,8 @@ func (k *KeyVaultServerTransport) dispatchCreateKey(req *http.Request) (*http.Re
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchDecrypt(req *http.Request) (*http.Response, error) {
-	if k.srv.Decrypt == nil {
+func (s *ServerTransport) dispatchDecrypt(req *http.Request) (*http.Response, error) {
+	if s.srv.Decrypt == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Decrypt not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/(?P<key_version>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/decrypt`
@@ -301,7 +300,7 @@ func (k *KeyVaultServerTransport) dispatchDecrypt(req *http.Request) (*http.Resp
 	if len(matches) < 3 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	body, err := server.UnmarshalRequestAsJSON[azkeys.KeyOperationsParameters](req)
+	body, err := server.UnmarshalRequestAsJSON[azkeys.KeyOperationParameters](req)
 	if err != nil {
 		return nil, err
 	}
@@ -313,7 +312,7 @@ func (k *KeyVaultServerTransport) dispatchDecrypt(req *http.Request) (*http.Resp
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.Decrypt(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.Decrypt(req.Context(), keyNameParam, keyVersionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -328,8 +327,8 @@ func (k *KeyVaultServerTransport) dispatchDecrypt(req *http.Request) (*http.Resp
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchDeleteKey(req *http.Request) (*http.Response, error) {
-	if k.srv.DeleteKey == nil {
+func (s *ServerTransport) dispatchDeleteKey(req *http.Request) (*http.Response, error) {
+	if s.srv.DeleteKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method DeleteKey not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
@@ -342,7 +341,7 @@ func (k *KeyVaultServerTransport) dispatchDeleteKey(req *http.Request) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.DeleteKey(req.Context(), keyNameParam, nil)
+	respr, errRespr := s.srv.DeleteKey(req.Context(), keyNameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -350,15 +349,15 @@ func (k *KeyVaultServerTransport) dispatchDeleteKey(req *http.Request) (*http.Re
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).DeletedKeyBundle, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).DeletedKey, req)
 	if err != nil {
 		return nil, err
 	}
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchEncrypt(req *http.Request) (*http.Response, error) {
-	if k.srv.Encrypt == nil {
+func (s *ServerTransport) dispatchEncrypt(req *http.Request) (*http.Response, error) {
+	if s.srv.Encrypt == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Encrypt not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/(?P<key_version>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/encrypt`
@@ -367,7 +366,7 @@ func (k *KeyVaultServerTransport) dispatchEncrypt(req *http.Request) (*http.Resp
 	if len(matches) < 3 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	body, err := server.UnmarshalRequestAsJSON[azkeys.KeyOperationsParameters](req)
+	body, err := server.UnmarshalRequestAsJSON[azkeys.KeyOperationParameters](req)
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +378,7 @@ func (k *KeyVaultServerTransport) dispatchEncrypt(req *http.Request) (*http.Resp
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.Encrypt(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.Encrypt(req.Context(), keyNameParam, keyVersionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -394,8 +393,8 @@ func (k *KeyVaultServerTransport) dispatchEncrypt(req *http.Request) (*http.Resp
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchGetDeletedKey(req *http.Request) (*http.Response, error) {
-	if k.srv.GetDeletedKey == nil {
+func (s *ServerTransport) dispatchGetDeletedKey(req *http.Request) (*http.Response, error) {
+	if s.srv.GetDeletedKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method GetDeletedKey not implemented")}
 	}
 	const regexStr = `/deletedkeys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
@@ -408,7 +407,7 @@ func (k *KeyVaultServerTransport) dispatchGetDeletedKey(req *http.Request) (*htt
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.GetDeletedKey(req.Context(), keyNameParam, nil)
+	respr, errRespr := s.srv.GetDeletedKey(req.Context(), keyNameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -416,63 +415,15 @@ func (k *KeyVaultServerTransport) dispatchGetDeletedKey(req *http.Request) (*htt
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).DeletedKeyBundle, req)
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).DeletedKey, req)
 	if err != nil {
 		return nil, err
 	}
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchNewGetDeletedKeysPager(req *http.Request) (*http.Response, error) {
-	if k.srv.NewGetDeletedKeysPager == nil {
-		return nil, &nonRetriableError{errors.New("fake for method NewGetDeletedKeysPager not implemented")}
-	}
-	newGetDeletedKeysPager := k.newGetDeletedKeysPager.get(req)
-	if newGetDeletedKeysPager == nil {
-		qp := req.URL.Query()
-		maxresultsUnescaped, err := url.QueryUnescape(qp.Get("maxresults"))
-		if err != nil {
-			return nil, err
-		}
-		maxresultsParam, err := parseOptional(maxresultsUnescaped, func(v string) (int32, error) {
-			p, parseErr := strconv.ParseInt(v, 10, 32)
-			if parseErr != nil {
-				return 0, parseErr
-			}
-			return int32(p), nil
-		})
-		if err != nil {
-			return nil, err
-		}
-		var options *azkeys.KeyVaultClientGetDeletedKeysOptions
-		if maxresultsParam != nil {
-			options = &azkeys.KeyVaultClientGetDeletedKeysOptions{
-				Maxresults: maxresultsParam,
-			}
-		}
-		resp := k.srv.NewGetDeletedKeysPager(options)
-		newGetDeletedKeysPager = &resp
-		k.newGetDeletedKeysPager.add(req, newGetDeletedKeysPager)
-		server.PagerResponderInjectNextLinks(newGetDeletedKeysPager, req, func(page *azkeys.KeyVaultClientGetDeletedKeysResponse, createLink func() string) {
-			page.NextLink = to.Ptr(createLink())
-		})
-	}
-	resp, err := server.PagerResponderNext(newGetDeletedKeysPager, req)
-	if err != nil {
-		return nil, err
-	}
-	if !contains([]int{http.StatusOK}, resp.StatusCode) {
-		k.newGetDeletedKeysPager.remove(req)
-		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
-	}
-	if !server.PagerResponderMore(newGetDeletedKeysPager) {
-		k.newGetDeletedKeysPager.remove(req)
-	}
-	return resp, nil
-}
-
-func (k *KeyVaultServerTransport) dispatchGetKey(req *http.Request) (*http.Response, error) {
-	if k.srv.GetKey == nil {
+func (s *ServerTransport) dispatchGetKey(req *http.Request) (*http.Response, error) {
+	if s.srv.GetKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method GetKey not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/(?P<key_version>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
@@ -489,7 +440,7 @@ func (k *KeyVaultServerTransport) dispatchGetKey(req *http.Request) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.GetKey(req.Context(), keyNameParam, keyVersionParam, nil)
+	respr, errRespr := s.srv.GetKey(req.Context(), keyNameParam, keyVersionParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -504,8 +455,8 @@ func (k *KeyVaultServerTransport) dispatchGetKey(req *http.Request) (*http.Respo
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchGetKeyRotationPolicy(req *http.Request) (*http.Response, error) {
-	if k.srv.GetKeyRotationPolicy == nil {
+func (s *ServerTransport) dispatchGetKeyRotationPolicy(req *http.Request) (*http.Response, error) {
+	if s.srv.GetKeyRotationPolicy == nil {
 		return nil, &nonRetriableError{errors.New("fake for method GetKeyRotationPolicy not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/rotationpolicy`
@@ -518,7 +469,7 @@ func (k *KeyVaultServerTransport) dispatchGetKeyRotationPolicy(req *http.Request
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.GetKeyRotationPolicy(req.Context(), keyNameParam, nil)
+	respr, errRespr := s.srv.GetKeyRotationPolicy(req.Context(), keyNameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -533,121 +484,15 @@ func (k *KeyVaultServerTransport) dispatchGetKeyRotationPolicy(req *http.Request
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchNewGetKeyVersionsPager(req *http.Request) (*http.Response, error) {
-	if k.srv.NewGetKeyVersionsPager == nil {
-		return nil, &nonRetriableError{errors.New("fake for method NewGetKeyVersionsPager not implemented")}
-	}
-	newGetKeyVersionsPager := k.newGetKeyVersionsPager.get(req)
-	if newGetKeyVersionsPager == nil {
-		const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/versions`
-		regex := regexp.MustCompile(regexStr)
-		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
-		if len(matches) < 2 {
-			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
-		}
-		qp := req.URL.Query()
-		keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
-		if err != nil {
-			return nil, err
-		}
-		maxresultsUnescaped, err := url.QueryUnescape(qp.Get("maxresults"))
-		if err != nil {
-			return nil, err
-		}
-		maxresultsParam, err := parseOptional(maxresultsUnescaped, func(v string) (int32, error) {
-			p, parseErr := strconv.ParseInt(v, 10, 32)
-			if parseErr != nil {
-				return 0, parseErr
-			}
-			return int32(p), nil
-		})
-		if err != nil {
-			return nil, err
-		}
-		var options *azkeys.KeyVaultClientGetKeyVersionsOptions
-		if maxresultsParam != nil {
-			options = &azkeys.KeyVaultClientGetKeyVersionsOptions{
-				Maxresults: maxresultsParam,
-			}
-		}
-		resp := k.srv.NewGetKeyVersionsPager(keyNameParam, options)
-		newGetKeyVersionsPager = &resp
-		k.newGetKeyVersionsPager.add(req, newGetKeyVersionsPager)
-		server.PagerResponderInjectNextLinks(newGetKeyVersionsPager, req, func(page *azkeys.KeyVaultClientGetKeyVersionsResponse, createLink func() string) {
-			page.NextLink = to.Ptr(createLink())
-		})
-	}
-	resp, err := server.PagerResponderNext(newGetKeyVersionsPager, req)
-	if err != nil {
-		return nil, err
-	}
-	if !contains([]int{http.StatusOK}, resp.StatusCode) {
-		k.newGetKeyVersionsPager.remove(req)
-		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
-	}
-	if !server.PagerResponderMore(newGetKeyVersionsPager) {
-		k.newGetKeyVersionsPager.remove(req)
-	}
-	return resp, nil
-}
-
-func (k *KeyVaultServerTransport) dispatchNewGetKeysPager(req *http.Request) (*http.Response, error) {
-	if k.srv.NewGetKeysPager == nil {
-		return nil, &nonRetriableError{errors.New("fake for method NewGetKeysPager not implemented")}
-	}
-	newGetKeysPager := k.newGetKeysPager.get(req)
-	if newGetKeysPager == nil {
-		qp := req.URL.Query()
-		maxresultsUnescaped, err := url.QueryUnescape(qp.Get("maxresults"))
-		if err != nil {
-			return nil, err
-		}
-		maxresultsParam, err := parseOptional(maxresultsUnescaped, func(v string) (int32, error) {
-			p, parseErr := strconv.ParseInt(v, 10, 32)
-			if parseErr != nil {
-				return 0, parseErr
-			}
-			return int32(p), nil
-		})
-		if err != nil {
-			return nil, err
-		}
-		var options *azkeys.KeyVaultClientGetKeysOptions
-		if maxresultsParam != nil {
-			options = &azkeys.KeyVaultClientGetKeysOptions{
-				Maxresults: maxresultsParam,
-			}
-		}
-		resp := k.srv.NewGetKeysPager(options)
-		newGetKeysPager = &resp
-		k.newGetKeysPager.add(req, newGetKeysPager)
-		server.PagerResponderInjectNextLinks(newGetKeysPager, req, func(page *azkeys.KeyVaultClientGetKeysResponse, createLink func() string) {
-			page.NextLink = to.Ptr(createLink())
-		})
-	}
-	resp, err := server.PagerResponderNext(newGetKeysPager, req)
-	if err != nil {
-		return nil, err
-	}
-	if !contains([]int{http.StatusOK}, resp.StatusCode) {
-		k.newGetKeysPager.remove(req)
-		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
-	}
-	if !server.PagerResponderMore(newGetKeysPager) {
-		k.newGetKeysPager.remove(req)
-	}
-	return resp, nil
-}
-
-func (k *KeyVaultServerTransport) dispatchGetRandomBytes(req *http.Request) (*http.Response, error) {
-	if k.srv.GetRandomBytes == nil {
+func (s *ServerTransport) dispatchGetRandomBytes(req *http.Request) (*http.Response, error) {
+	if s.srv.GetRandomBytes == nil {
 		return nil, &nonRetriableError{errors.New("fake for method GetRandomBytes not implemented")}
 	}
-	body, err := server.UnmarshalRequestAsJSON[azkeys.GetRandomBytesRequest](req)
+	body, err := server.UnmarshalRequestAsJSON[azkeys.GetRandomBytesParameters](req)
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.GetRandomBytes(req.Context(), body, nil)
+	respr, errRespr := s.srv.GetRandomBytes(req.Context(), body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -662,8 +507,8 @@ func (k *KeyVaultServerTransport) dispatchGetRandomBytes(req *http.Request) (*ht
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchImportKey(req *http.Request) (*http.Response, error) {
-	if k.srv.ImportKey == nil {
+func (s *ServerTransport) dispatchImportKey(req *http.Request) (*http.Response, error) {
+	if s.srv.ImportKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method ImportKey not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
@@ -672,7 +517,7 @@ func (k *KeyVaultServerTransport) dispatchImportKey(req *http.Request) (*http.Re
 	if len(matches) < 2 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	body, err := server.UnmarshalRequestAsJSON[azkeys.KeyImportParameters](req)
+	body, err := server.UnmarshalRequestAsJSON[azkeys.ImportKeyParameters](req)
 	if err != nil {
 		return nil, err
 	}
@@ -680,7 +525,7 @@ func (k *KeyVaultServerTransport) dispatchImportKey(req *http.Request) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.ImportKey(req.Context(), keyNameParam, body, nil)
+	respr, errRespr := s.srv.ImportKey(req.Context(), keyNameParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -695,8 +540,99 @@ func (k *KeyVaultServerTransport) dispatchImportKey(req *http.Request) (*http.Re
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchPurgeDeletedKey(req *http.Request) (*http.Response, error) {
-	if k.srv.PurgeDeletedKey == nil {
+func (s *ServerTransport) dispatchNewListDeletedKeyPropertiesPager(req *http.Request) (*http.Response, error) {
+	if s.srv.NewListDeletedKeyPropertiesPager == nil {
+		return nil, &nonRetriableError{errors.New("fake for method NewListDeletedKeyPropertiesPager not implemented")}
+	}
+	newListDeletedKeyPropertiesPager := s.newListDeletedKeyPropertiesPager.get(req)
+	if newListDeletedKeyPropertiesPager == nil {
+		resp := s.srv.NewListDeletedKeyPropertiesPager(nil)
+		newListDeletedKeyPropertiesPager = &resp
+		s.newListDeletedKeyPropertiesPager.add(req, newListDeletedKeyPropertiesPager)
+		server.PagerResponderInjectNextLinks(newListDeletedKeyPropertiesPager, req, func(page *azkeys.ListDeletedKeyPropertiesResponse, createLink func() string) {
+			page.NextLink = to.Ptr(createLink())
+		})
+	}
+	resp, err := server.PagerResponderNext(newListDeletedKeyPropertiesPager, req)
+	if err != nil {
+		return nil, err
+	}
+	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListDeletedKeyPropertiesPager.remove(req)
+		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
+	}
+	if !server.PagerResponderMore(newListDeletedKeyPropertiesPager) {
+		s.newListDeletedKeyPropertiesPager.remove(req)
+	}
+	return resp, nil
+}
+
+func (s *ServerTransport) dispatchNewListKeyPropertiesPager(req *http.Request) (*http.Response, error) {
+	if s.srv.NewListKeyPropertiesPager == nil {
+		return nil, &nonRetriableError{errors.New("fake for method NewListKeyPropertiesPager not implemented")}
+	}
+	newListKeyPropertiesPager := s.newListKeyPropertiesPager.get(req)
+	if newListKeyPropertiesPager == nil {
+		resp := s.srv.NewListKeyPropertiesPager(nil)
+		newListKeyPropertiesPager = &resp
+		s.newListKeyPropertiesPager.add(req, newListKeyPropertiesPager)
+		server.PagerResponderInjectNextLinks(newListKeyPropertiesPager, req, func(page *azkeys.ListKeyPropertiesResponse, createLink func() string) {
+			page.NextLink = to.Ptr(createLink())
+		})
+	}
+	resp, err := server.PagerResponderNext(newListKeyPropertiesPager, req)
+	if err != nil {
+		return nil, err
+	}
+	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListKeyPropertiesPager.remove(req)
+		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
+	}
+	if !server.PagerResponderMore(newListKeyPropertiesPager) {
+		s.newListKeyPropertiesPager.remove(req)
+	}
+	return resp, nil
+}
+
+func (s *ServerTransport) dispatchNewListKeyPropertiesVersionsPager(req *http.Request) (*http.Response, error) {
+	if s.srv.NewListKeyPropertiesVersionsPager == nil {
+		return nil, &nonRetriableError{errors.New("fake for method NewListKeyPropertiesVersionsPager not implemented")}
+	}
+	newListKeyPropertiesVersionsPager := s.newListKeyPropertiesVersionsPager.get(req)
+	if newListKeyPropertiesVersionsPager == nil {
+		const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/versions`
+		regex := regexp.MustCompile(regexStr)
+		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
+		if len(matches) < 2 {
+			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
+		}
+		keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+		if err != nil {
+			return nil, err
+		}
+		resp := s.srv.NewListKeyPropertiesVersionsPager(keyNameParam, nil)
+		newListKeyPropertiesVersionsPager = &resp
+		s.newListKeyPropertiesVersionsPager.add(req, newListKeyPropertiesVersionsPager)
+		server.PagerResponderInjectNextLinks(newListKeyPropertiesVersionsPager, req, func(page *azkeys.ListKeyPropertiesVersionsResponse, createLink func() string) {
+			page.NextLink = to.Ptr(createLink())
+		})
+	}
+	resp, err := server.PagerResponderNext(newListKeyPropertiesVersionsPager, req)
+	if err != nil {
+		return nil, err
+	}
+	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListKeyPropertiesVersionsPager.remove(req)
+		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
+	}
+	if !server.PagerResponderMore(newListKeyPropertiesVersionsPager) {
+		s.newListKeyPropertiesVersionsPager.remove(req)
+	}
+	return resp, nil
+}
+
+func (s *ServerTransport) dispatchPurgeDeletedKey(req *http.Request) (*http.Response, error) {
+	if s.srv.PurgeDeletedKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method PurgeDeletedKey not implemented")}
 	}
 	const regexStr = `/deletedkeys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
@@ -709,7 +645,7 @@ func (k *KeyVaultServerTransport) dispatchPurgeDeletedKey(req *http.Request) (*h
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.PurgeDeletedKey(req.Context(), keyNameParam, nil)
+	respr, errRespr := s.srv.PurgeDeletedKey(req.Context(), keyNameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -724,8 +660,8 @@ func (k *KeyVaultServerTransport) dispatchPurgeDeletedKey(req *http.Request) (*h
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchRecoverDeletedKey(req *http.Request) (*http.Response, error) {
-	if k.srv.RecoverDeletedKey == nil {
+func (s *ServerTransport) dispatchRecoverDeletedKey(req *http.Request) (*http.Response, error) {
+	if s.srv.RecoverDeletedKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method RecoverDeletedKey not implemented")}
 	}
 	const regexStr = `/deletedkeys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/recover`
@@ -738,7 +674,7 @@ func (k *KeyVaultServerTransport) dispatchRecoverDeletedKey(req *http.Request) (
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.RecoverDeletedKey(req.Context(), keyNameParam, nil)
+	respr, errRespr := s.srv.RecoverDeletedKey(req.Context(), keyNameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -753,8 +689,8 @@ func (k *KeyVaultServerTransport) dispatchRecoverDeletedKey(req *http.Request) (
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchRelease(req *http.Request) (*http.Response, error) {
-	if k.srv.Release == nil {
+func (s *ServerTransport) dispatchRelease(req *http.Request) (*http.Response, error) {
+	if s.srv.Release == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Release not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/(?P<key_version>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/release`
@@ -763,7 +699,7 @@ func (k *KeyVaultServerTransport) dispatchRelease(req *http.Request) (*http.Resp
 	if len(matches) < 3 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	body, err := server.UnmarshalRequestAsJSON[azkeys.KeyReleaseParameters](req)
+	body, err := server.UnmarshalRequestAsJSON[azkeys.ReleaseParameters](req)
 	if err != nil {
 		return nil, err
 	}
@@ -775,7 +711,7 @@ func (k *KeyVaultServerTransport) dispatchRelease(req *http.Request) (*http.Resp
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.Release(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.Release(req.Context(), keyNameParam, keyVersionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -790,15 +726,15 @@ func (k *KeyVaultServerTransport) dispatchRelease(req *http.Request) (*http.Resp
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchRestoreKey(req *http.Request) (*http.Response, error) {
-	if k.srv.RestoreKey == nil {
+func (s *ServerTransport) dispatchRestoreKey(req *http.Request) (*http.Response, error) {
+	if s.srv.RestoreKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method RestoreKey not implemented")}
 	}
-	body, err := server.UnmarshalRequestAsJSON[azkeys.KeyRestoreParameters](req)
+	body, err := server.UnmarshalRequestAsJSON[azkeys.RestoreKeyParameters](req)
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.RestoreKey(req.Context(), body, nil)
+	respr, errRespr := s.srv.RestoreKey(req.Context(), body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -813,8 +749,8 @@ func (k *KeyVaultServerTransport) dispatchRestoreKey(req *http.Request) (*http.R
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchRotateKey(req *http.Request) (*http.Response, error) {
-	if k.srv.RotateKey == nil {
+func (s *ServerTransport) dispatchRotateKey(req *http.Request) (*http.Response, error) {
+	if s.srv.RotateKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method RotateKey not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/rotate`
@@ -827,7 +763,7 @@ func (k *KeyVaultServerTransport) dispatchRotateKey(req *http.Request) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.RotateKey(req.Context(), keyNameParam, nil)
+	respr, errRespr := s.srv.RotateKey(req.Context(), keyNameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -842,8 +778,8 @@ func (k *KeyVaultServerTransport) dispatchRotateKey(req *http.Request) (*http.Re
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchSign(req *http.Request) (*http.Response, error) {
-	if k.srv.Sign == nil {
+func (s *ServerTransport) dispatchSign(req *http.Request) (*http.Response, error) {
+	if s.srv.Sign == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Sign not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/(?P<key_version>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/sign`
@@ -852,7 +788,7 @@ func (k *KeyVaultServerTransport) dispatchSign(req *http.Request) (*http.Respons
 	if len(matches) < 3 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	body, err := server.UnmarshalRequestAsJSON[azkeys.KeySignParameters](req)
+	body, err := server.UnmarshalRequestAsJSON[azkeys.SignParameters](req)
 	if err != nil {
 		return nil, err
 	}
@@ -864,7 +800,7 @@ func (k *KeyVaultServerTransport) dispatchSign(req *http.Request) (*http.Respons
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.Sign(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.Sign(req.Context(), keyNameParam, keyVersionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -879,8 +815,8 @@ func (k *KeyVaultServerTransport) dispatchSign(req *http.Request) (*http.Respons
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchUnwrapKey(req *http.Request) (*http.Response, error) {
-	if k.srv.UnwrapKey == nil {
+func (s *ServerTransport) dispatchUnwrapKey(req *http.Request) (*http.Response, error) {
+	if s.srv.UnwrapKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method UnwrapKey not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/(?P<key_version>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/unwrapkey`
@@ -889,7 +825,7 @@ func (k *KeyVaultServerTransport) dispatchUnwrapKey(req *http.Request) (*http.Re
 	if len(matches) < 3 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	body, err := server.UnmarshalRequestAsJSON[azkeys.KeyOperationsParameters](req)
+	body, err := server.UnmarshalRequestAsJSON[azkeys.KeyOperationParameters](req)
 	if err != nil {
 		return nil, err
 	}
@@ -901,7 +837,7 @@ func (k *KeyVaultServerTransport) dispatchUnwrapKey(req *http.Request) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.UnwrapKey(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.UnwrapKey(req.Context(), keyNameParam, keyVersionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -916,8 +852,8 @@ func (k *KeyVaultServerTransport) dispatchUnwrapKey(req *http.Request) (*http.Re
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchUpdateKey(req *http.Request) (*http.Response, error) {
-	if k.srv.UpdateKey == nil {
+func (s *ServerTransport) dispatchUpdateKey(req *http.Request) (*http.Response, error) {
+	if s.srv.UpdateKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method UpdateKey not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/(?P<key_version>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
@@ -926,7 +862,7 @@ func (k *KeyVaultServerTransport) dispatchUpdateKey(req *http.Request) (*http.Re
 	if len(matches) < 3 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	body, err := server.UnmarshalRequestAsJSON[azkeys.KeyUpdateParameters](req)
+	body, err := server.UnmarshalRequestAsJSON[azkeys.UpdateKeyParameters](req)
 	if err != nil {
 		return nil, err
 	}
@@ -938,7 +874,7 @@ func (k *KeyVaultServerTransport) dispatchUpdateKey(req *http.Request) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.UpdateKey(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.UpdateKey(req.Context(), keyNameParam, keyVersionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -953,8 +889,8 @@ func (k *KeyVaultServerTransport) dispatchUpdateKey(req *http.Request) (*http.Re
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchUpdateKeyRotationPolicy(req *http.Request) (*http.Response, error) {
-	if k.srv.UpdateKeyRotationPolicy == nil {
+func (s *ServerTransport) dispatchUpdateKeyRotationPolicy(req *http.Request) (*http.Response, error) {
+	if s.srv.UpdateKeyRotationPolicy == nil {
 		return nil, &nonRetriableError{errors.New("fake for method UpdateKeyRotationPolicy not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/rotationpolicy`
@@ -971,7 +907,7 @@ func (k *KeyVaultServerTransport) dispatchUpdateKeyRotationPolicy(req *http.Requ
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.UpdateKeyRotationPolicy(req.Context(), keyNameParam, body, nil)
+	respr, errRespr := s.srv.UpdateKeyRotationPolicy(req.Context(), keyNameParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -986,8 +922,8 @@ func (k *KeyVaultServerTransport) dispatchUpdateKeyRotationPolicy(req *http.Requ
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchVerify(req *http.Request) (*http.Response, error) {
-	if k.srv.Verify == nil {
+func (s *ServerTransport) dispatchVerify(req *http.Request) (*http.Response, error) {
+	if s.srv.Verify == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Verify not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/(?P<key_version>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/verify`
@@ -996,7 +932,7 @@ func (k *KeyVaultServerTransport) dispatchVerify(req *http.Request) (*http.Respo
 	if len(matches) < 3 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	body, err := server.UnmarshalRequestAsJSON[azkeys.KeyVerifyParameters](req)
+	body, err := server.UnmarshalRequestAsJSON[azkeys.VerifyParameters](req)
 	if err != nil {
 		return nil, err
 	}
@@ -1008,7 +944,7 @@ func (k *KeyVaultServerTransport) dispatchVerify(req *http.Request) (*http.Respo
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.Verify(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.Verify(req.Context(), keyNameParam, keyVersionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -1023,8 +959,8 @@ func (k *KeyVaultServerTransport) dispatchVerify(req *http.Request) (*http.Respo
 	return resp, nil
 }
 
-func (k *KeyVaultServerTransport) dispatchWrapKey(req *http.Request) (*http.Response, error) {
-	if k.srv.WrapKey == nil {
+func (s *ServerTransport) dispatchWrapKey(req *http.Request) (*http.Response, error) {
+	if s.srv.WrapKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method WrapKey not implemented")}
 	}
 	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/(?P<key_version>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/wrapkey`
@@ -1033,7 +969,7 @@ func (k *KeyVaultServerTransport) dispatchWrapKey(req *http.Request) (*http.Resp
 	if len(matches) < 3 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	body, err := server.UnmarshalRequestAsJSON[azkeys.KeyOperationsParameters](req)
+	body, err := server.UnmarshalRequestAsJSON[azkeys.KeyOperationParameters](req)
 	if err != nil {
 		return nil, err
 	}
@@ -1045,7 +981,7 @@ func (k *KeyVaultServerTransport) dispatchWrapKey(req *http.Request) (*http.Resp
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := k.srv.WrapKey(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.WrapKey(req.Context(), keyNameParam, keyVersionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -1060,8 +996,8 @@ func (k *KeyVaultServerTransport) dispatchWrapKey(req *http.Request) (*http.Resp
 	return resp, nil
 }
 
-// set this to conditionally intercept incoming requests to KeyVaultServerTransport
-var keyVaultServerTransportInterceptor interface {
+// set this to conditionally intercept incoming requests to ServerTransport
+var serverTransportInterceptor interface {
 	// Do returns true if the server transport should use the returned response/error
 	Do(*http.Request) (*http.Response, error, bool)
 }

--- a/packages/typespec-go/test/local/azkeys/fake_test.go
+++ b/packages/typespec-go/test/local/azkeys/fake_test.go
@@ -19,13 +19,13 @@ import (
 func TestFakeBackupKey(t *testing.T) {
 	const fakeKeyName = "fakeKey"
 	fakeKeyBlob := []byte{1, 2, 3}
-	server := fake.KeyVaultServer{
-		BackupKey: func(ctx context.Context, keyName string, options *azkeys.KeyVaultClientBackupKeyOptions) (resp azfake.Responder[azkeys.KeyVaultClientBackupKeyResponse], errResp azfake.ErrorResponder) {
+	server := fake.Server{
+		BackupKey: func(ctx context.Context, keyName string, options *azkeys.BackupKeyOptions) (resp azfake.Responder[azkeys.BackupKeyResponse], errResp azfake.ErrorResponder) {
 			if keyName != fakeKeyName {
 				errResp.SetError(fmt.Errorf("bad fake key name %s", keyName))
 				return
 			}
-			resp.SetResponse(http.StatusOK, azkeys.KeyVaultClientBackupKeyResponse{
+			resp.SetResponse(http.StatusOK, azkeys.BackupKeyResponse{
 				BackupKeyResult: azkeys.BackupKeyResult{
 					Value: fakeKeyBlob,
 				},
@@ -34,8 +34,8 @@ func TestFakeBackupKey(t *testing.T) {
 		},
 	}
 
-	client, err := azkeys.NewKeyVaultClient("https://contoso.com/fake/vault", &azcore.ClientOptions{
-		Transport: fake.NewKeyVaultServerTransport(&server),
+	client, err := azkeys.NewClient("https://contoso.com/fake/vault", &azcore.ClientOptions{
+		Transport: fake.NewServerTransport(&server),
 	})
 	require.NoError(t, err)
 

--- a/packages/typespec-go/test/local/azkeys/zz_client.go
+++ b/packages/typespec-go/test/local/azkeys/zz_client.go
@@ -12,14 +12,13 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 )
 
-// KeyVaultClient - The key vault client performs cryptographic key operations and vault operations
+// Client - The key vault client performs cryptographic key operations and vault operations
 // against the Key Vault service.
 // Don't use this type directly, use a constructor function instead.
-type KeyVaultClient struct {
+type Client struct {
 	internal     *azcore.Client
 	vaultBaseUrl string
 }
@@ -43,31 +42,31 @@ type KeyVaultClient struct {
 //
 // Generated from API version 7.6-preview.1
 //   - keyName - The name of the key.
-//   - options - KeyVaultClientBackupKeyOptions contains the optional parameters for the KeyVaultClient.BackupKey method.
-func (client *KeyVaultClient) BackupKey(ctx context.Context, keyName string, options *KeyVaultClientBackupKeyOptions) (KeyVaultClientBackupKeyResponse, error) {
+//   - options - BackupKeyOptions contains the optional parameters for the Client.BackupKey method.
+func (client *Client) BackupKey(ctx context.Context, keyName string, options *BackupKeyOptions) (BackupKeyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.BackupKey"
+	const operationName = "Client.BackupKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.backupKeyCreateRequest(ctx, keyName, options)
 	if err != nil {
-		return KeyVaultClientBackupKeyResponse{}, err
+		return BackupKeyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientBackupKeyResponse{}, err
+		return BackupKeyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientBackupKeyResponse{}, err
+		return BackupKeyResponse{}, err
 	}
 	resp, err := client.backupKeyHandleResponse(httpResp)
 	return resp, err
 }
 
 // backupKeyCreateRequest creates the BackupKey request.
-func (client *KeyVaultClient) backupKeyCreateRequest(ctx context.Context, keyName string, _ *KeyVaultClientBackupKeyOptions) (*policy.Request, error) {
+func (client *Client) backupKeyCreateRequest(ctx context.Context, keyName string, _ *BackupKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}/backup"
@@ -87,10 +86,10 @@ func (client *KeyVaultClient) backupKeyCreateRequest(ctx context.Context, keyNam
 }
 
 // backupKeyHandleResponse handles the BackupKey response.
-func (client *KeyVaultClient) backupKeyHandleResponse(resp *http.Response) (KeyVaultClientBackupKeyResponse, error) {
-	result := KeyVaultClientBackupKeyResponse{}
+func (client *Client) backupKeyHandleResponse(resp *http.Response) (BackupKeyResponse, error) {
+	result := BackupKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BackupKeyResult); err != nil {
-		return KeyVaultClientBackupKeyResponse{}, err
+		return BackupKeyResponse{}, err
 	}
 	return result, nil
 }
@@ -109,31 +108,31 @@ func (client *KeyVaultClient) backupKeyHandleResponse(resp *http.Response) (KeyV
 //     the service. The value provided should not include personally identifiable or
 //     sensitive information.
 //   - parameters - The parameters to create a key.
-//   - options - KeyVaultClientCreateKeyOptions contains the optional parameters for the KeyVaultClient.CreateKey method.
-func (client *KeyVaultClient) CreateKey(ctx context.Context, keyName string, parameters KeyCreateParameters, options *KeyVaultClientCreateKeyOptions) (KeyVaultClientCreateKeyResponse, error) {
+//   - options - CreateKeyOptions contains the optional parameters for the Client.CreateKey method.
+func (client *Client) CreateKey(ctx context.Context, keyName string, parameters CreateKeyParameters, options *CreateKeyOptions) (CreateKeyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.CreateKey"
+	const operationName = "Client.CreateKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.createKeyCreateRequest(ctx, keyName, parameters, options)
 	if err != nil {
-		return KeyVaultClientCreateKeyResponse{}, err
+		return CreateKeyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientCreateKeyResponse{}, err
+		return CreateKeyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientCreateKeyResponse{}, err
+		return CreateKeyResponse{}, err
 	}
 	resp, err := client.createKeyHandleResponse(httpResp)
 	return resp, err
 }
 
 // createKeyCreateRequest creates the CreateKey request.
-func (client *KeyVaultClient) createKeyCreateRequest(ctx context.Context, keyName string, parameters KeyCreateParameters, _ *KeyVaultClientCreateKeyOptions) (*policy.Request, error) {
+func (client *Client) createKeyCreateRequest(ctx context.Context, keyName string, parameters CreateKeyParameters, _ *CreateKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}/create"
@@ -157,10 +156,10 @@ func (client *KeyVaultClient) createKeyCreateRequest(ctx context.Context, keyNam
 }
 
 // createKeyHandleResponse handles the CreateKey response.
-func (client *KeyVaultClient) createKeyHandleResponse(resp *http.Response) (KeyVaultClientCreateKeyResponse, error) {
-	result := KeyVaultClientCreateKeyResponse{}
+func (client *Client) createKeyHandleResponse(resp *http.Response) (CreateKeyResponse, error) {
+	result := CreateKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
-		return KeyVaultClientCreateKeyResponse{}, err
+		return CreateKeyResponse{}, err
 	}
 	return result, nil
 }
@@ -184,31 +183,31 @@ func (client *KeyVaultClient) createKeyHandleResponse(resp *http.Response) (KeyV
 //   - keyName - The name of the key.
 //   - keyVersion - The version of the key.
 //   - parameters - The parameters for the decryption operation.
-//   - options - KeyVaultClientDecryptOptions contains the optional parameters for the KeyVaultClient.Decrypt method.
-func (client *KeyVaultClient) Decrypt(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientDecryptOptions) (KeyVaultClientDecryptResponse, error) {
+//   - options - DecryptOptions contains the optional parameters for the Client.Decrypt method.
+func (client *Client) Decrypt(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, options *DecryptOptions) (DecryptResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.Decrypt"
+	const operationName = "Client.Decrypt"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.decryptCreateRequest(ctx, keyName, keyVersion, parameters, options)
 	if err != nil {
-		return KeyVaultClientDecryptResponse{}, err
+		return DecryptResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientDecryptResponse{}, err
+		return DecryptResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientDecryptResponse{}, err
+		return DecryptResponse{}, err
 	}
 	resp, err := client.decryptHandleResponse(httpResp)
 	return resp, err
 }
 
 // decryptCreateRequest creates the Decrypt request.
-func (client *KeyVaultClient) decryptCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationsParameters, _ *KeyVaultClientDecryptOptions) (*policy.Request, error) {
+func (client *Client) decryptCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, _ *DecryptOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}/{key-version}/decrypt"
@@ -236,10 +235,10 @@ func (client *KeyVaultClient) decryptCreateRequest(ctx context.Context, keyName 
 }
 
 // decryptHandleResponse handles the Decrypt response.
-func (client *KeyVaultClient) decryptHandleResponse(resp *http.Response) (KeyVaultClientDecryptResponse, error) {
-	result := KeyVaultClientDecryptResponse{}
+func (client *Client) decryptHandleResponse(resp *http.Response) (DecryptResponse, error) {
+	result := DecryptResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
-		return KeyVaultClientDecryptResponse{}, err
+		return DecryptResponse{}, err
 	}
 	return result, nil
 }
@@ -254,31 +253,31 @@ func (client *KeyVaultClient) decryptHandleResponse(resp *http.Response) (KeyVau
 //
 // Generated from API version 7.6-preview.1
 //   - keyName - The name of the key to delete.
-//   - options - KeyVaultClientDeleteKeyOptions contains the optional parameters for the KeyVaultClient.DeleteKey method.
-func (client *KeyVaultClient) DeleteKey(ctx context.Context, keyName string, options *KeyVaultClientDeleteKeyOptions) (KeyVaultClientDeleteKeyResponse, error) {
+//   - options - DeleteKeyOptions contains the optional parameters for the Client.DeleteKey method.
+func (client *Client) DeleteKey(ctx context.Context, keyName string, options *DeleteKeyOptions) (DeleteKeyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.DeleteKey"
+	const operationName = "Client.DeleteKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.deleteKeyCreateRequest(ctx, keyName, options)
 	if err != nil {
-		return KeyVaultClientDeleteKeyResponse{}, err
+		return DeleteKeyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientDeleteKeyResponse{}, err
+		return DeleteKeyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientDeleteKeyResponse{}, err
+		return DeleteKeyResponse{}, err
 	}
 	resp, err := client.deleteKeyHandleResponse(httpResp)
 	return resp, err
 }
 
 // deleteKeyCreateRequest creates the DeleteKey request.
-func (client *KeyVaultClient) deleteKeyCreateRequest(ctx context.Context, keyName string, _ *KeyVaultClientDeleteKeyOptions) (*policy.Request, error) {
+func (client *Client) deleteKeyCreateRequest(ctx context.Context, keyName string, _ *DeleteKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}"
@@ -298,10 +297,10 @@ func (client *KeyVaultClient) deleteKeyCreateRequest(ctx context.Context, keyNam
 }
 
 // deleteKeyHandleResponse handles the DeleteKey response.
-func (client *KeyVaultClient) deleteKeyHandleResponse(resp *http.Response) (KeyVaultClientDeleteKeyResponse, error) {
-	result := KeyVaultClientDeleteKeyResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedKeyBundle); err != nil {
-		return KeyVaultClientDeleteKeyResponse{}, err
+func (client *Client) deleteKeyHandleResponse(resp *http.Response) (DeleteKeyResponse, error) {
+	result := DeleteKeyResponse{}
+	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedKey); err != nil {
+		return DeleteKeyResponse{}, err
 	}
 	return result, nil
 }
@@ -324,31 +323,31 @@ func (client *KeyVaultClient) deleteKeyHandleResponse(resp *http.Response) (KeyV
 //   - keyName - The name of the key.
 //   - keyVersion - The version of the key.
 //   - parameters - The parameters for the encryption operation.
-//   - options - KeyVaultClientEncryptOptions contains the optional parameters for the KeyVaultClient.Encrypt method.
-func (client *KeyVaultClient) Encrypt(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientEncryptOptions) (KeyVaultClientEncryptResponse, error) {
+//   - options - EncryptOptions contains the optional parameters for the Client.Encrypt method.
+func (client *Client) Encrypt(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, options *EncryptOptions) (EncryptResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.Encrypt"
+	const operationName = "Client.Encrypt"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.encryptCreateRequest(ctx, keyName, keyVersion, parameters, options)
 	if err != nil {
-		return KeyVaultClientEncryptResponse{}, err
+		return EncryptResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientEncryptResponse{}, err
+		return EncryptResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientEncryptResponse{}, err
+		return EncryptResponse{}, err
 	}
 	resp, err := client.encryptHandleResponse(httpResp)
 	return resp, err
 }
 
 // encryptCreateRequest creates the Encrypt request.
-func (client *KeyVaultClient) encryptCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationsParameters, _ *KeyVaultClientEncryptOptions) (*policy.Request, error) {
+func (client *Client) encryptCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, _ *EncryptOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}/{key-version}/encrypt"
@@ -376,10 +375,10 @@ func (client *KeyVaultClient) encryptCreateRequest(ctx context.Context, keyName 
 }
 
 // encryptHandleResponse handles the Encrypt response.
-func (client *KeyVaultClient) encryptHandleResponse(resp *http.Response) (KeyVaultClientEncryptResponse, error) {
-	result := KeyVaultClientEncryptResponse{}
+func (client *Client) encryptHandleResponse(resp *http.Response) (EncryptResponse, error) {
+	result := EncryptResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
-		return KeyVaultClientEncryptResponse{}, err
+		return EncryptResponse{}, err
 	}
 	return result, nil
 }
@@ -394,31 +393,31 @@ func (client *KeyVaultClient) encryptHandleResponse(resp *http.Response) (KeyVau
 //
 // Generated from API version 7.6-preview.1
 //   - keyName - The name of the key.
-//   - options - KeyVaultClientGetDeletedKeyOptions contains the optional parameters for the KeyVaultClient.GetDeletedKey method.
-func (client *KeyVaultClient) GetDeletedKey(ctx context.Context, keyName string, options *KeyVaultClientGetDeletedKeyOptions) (KeyVaultClientGetDeletedKeyResponse, error) {
+//   - options - GetDeletedKeyOptions contains the optional parameters for the Client.GetDeletedKey method.
+func (client *Client) GetDeletedKey(ctx context.Context, keyName string, options *GetDeletedKeyOptions) (GetDeletedKeyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.GetDeletedKey"
+	const operationName = "Client.GetDeletedKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.getDeletedKeyCreateRequest(ctx, keyName, options)
 	if err != nil {
-		return KeyVaultClientGetDeletedKeyResponse{}, err
+		return GetDeletedKeyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientGetDeletedKeyResponse{}, err
+		return GetDeletedKeyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientGetDeletedKeyResponse{}, err
+		return GetDeletedKeyResponse{}, err
 	}
 	resp, err := client.getDeletedKeyHandleResponse(httpResp)
 	return resp, err
 }
 
 // getDeletedKeyCreateRequest creates the GetDeletedKey request.
-func (client *KeyVaultClient) getDeletedKeyCreateRequest(ctx context.Context, keyName string, _ *KeyVaultClientGetDeletedKeyOptions) (*policy.Request, error) {
+func (client *Client) getDeletedKeyCreateRequest(ctx context.Context, keyName string, _ *GetDeletedKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/deletedkeys/{key-name}"
@@ -438,73 +437,10 @@ func (client *KeyVaultClient) getDeletedKeyCreateRequest(ctx context.Context, ke
 }
 
 // getDeletedKeyHandleResponse handles the GetDeletedKey response.
-func (client *KeyVaultClient) getDeletedKeyHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedKeyResponse, error) {
-	result := KeyVaultClientGetDeletedKeyResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedKeyBundle); err != nil {
-		return KeyVaultClientGetDeletedKeyResponse{}, err
-	}
-	return result, nil
-}
-
-// NewGetDeletedKeysPager - Lists the deleted keys in the specified vault.
-//
-// Retrieves a list of the keys in the Key Vault as JSON Web Key structures that
-// contain the public part of a deleted key. This operation includes
-// deletion-specific information. The Get Deleted Keys operation is applicable for
-// vaults enabled for soft-delete. While the operation can be invoked on any
-// vault, it will return an error if invoked on a non soft-delete enabled vault.
-// This operation requires the keys/list permission.
-//
-// Generated from API version 7.6-preview.1
-//   - options - KeyVaultClientGetDeletedKeysOptions contains the optional parameters for the KeyVaultClient.NewGetDeletedKeysPager
-//     method.
-func (client *KeyVaultClient) NewGetDeletedKeysPager(options *KeyVaultClientGetDeletedKeysOptions) *runtime.Pager[KeyVaultClientGetDeletedKeysResponse] {
-	return runtime.NewPager(runtime.PagingHandler[KeyVaultClientGetDeletedKeysResponse]{
-		More: func(page KeyVaultClientGetDeletedKeysResponse) bool {
-			return page.NextLink != nil && len(*page.NextLink) > 0
-		},
-		Fetcher: func(ctx context.Context, page *KeyVaultClientGetDeletedKeysResponse) (KeyVaultClientGetDeletedKeysResponse, error) {
-			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "KeyVaultClient.NewGetDeletedKeysPager")
-			nextLink := ""
-			if page != nil {
-				nextLink = *page.NextLink
-			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.getDeletedKeysCreateRequest(ctx, options)
-			}, nil)
-			if err != nil {
-				return KeyVaultClientGetDeletedKeysResponse{}, err
-			}
-			return client.getDeletedKeysHandleResponse(resp)
-		},
-		Tracer: client.internal.Tracer(),
-	})
-}
-
-// getDeletedKeysCreateRequest creates the GetDeletedKeys request.
-func (client *KeyVaultClient) getDeletedKeysCreateRequest(ctx context.Context, options *KeyVaultClientGetDeletedKeysOptions) (*policy.Request, error) {
-	host := "{vaultBaseUrl}"
-	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
-	urlPath := "/deletedkeys"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
-	if err != nil {
-		return nil, err
-	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
-	if options != nil && options.Maxresults != nil {
-		reqQP.Set("maxresults", strconv.FormatInt(int64(*options.Maxresults), 10))
-	}
-	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["Accept"] = []string{"application/json"}
-	return req, nil
-}
-
-// getDeletedKeysHandleResponse handles the GetDeletedKeys response.
-func (client *KeyVaultClient) getDeletedKeysHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedKeysResponse, error) {
-	result := KeyVaultClientGetDeletedKeysResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedKeyListResult); err != nil {
-		return KeyVaultClientGetDeletedKeysResponse{}, err
+func (client *Client) getDeletedKeyHandleResponse(resp *http.Response) (GetDeletedKeyResponse, error) {
+	result := GetDeletedKeyResponse{}
+	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedKey); err != nil {
+		return GetDeletedKeyResponse{}, err
 	}
 	return result, nil
 }
@@ -521,31 +457,31 @@ func (client *KeyVaultClient) getDeletedKeysHandleResponse(resp *http.Response) 
 //   - keyVersion - Adding the version parameter retrieves a specific version of a key. This URI
 //     fragment is optional. If not specified, the latest version of the key is
 //     returned.
-//   - options - KeyVaultClientGetKeyOptions contains the optional parameters for the KeyVaultClient.GetKey method.
-func (client *KeyVaultClient) GetKey(ctx context.Context, keyName string, keyVersion string, options *KeyVaultClientGetKeyOptions) (KeyVaultClientGetKeyResponse, error) {
+//   - options - GetKeyOptions contains the optional parameters for the Client.GetKey method.
+func (client *Client) GetKey(ctx context.Context, keyName string, keyVersion string, options *GetKeyOptions) (GetKeyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.GetKey"
+	const operationName = "Client.GetKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.getKeyCreateRequest(ctx, keyName, keyVersion, options)
 	if err != nil {
-		return KeyVaultClientGetKeyResponse{}, err
+		return GetKeyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientGetKeyResponse{}, err
+		return GetKeyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientGetKeyResponse{}, err
+		return GetKeyResponse{}, err
 	}
 	resp, err := client.getKeyHandleResponse(httpResp)
 	return resp, err
 }
 
 // getKeyCreateRequest creates the GetKey request.
-func (client *KeyVaultClient) getKeyCreateRequest(ctx context.Context, keyName string, keyVersion string, _ *KeyVaultClientGetKeyOptions) (*policy.Request, error) {
+func (client *Client) getKeyCreateRequest(ctx context.Context, keyName string, keyVersion string, _ *GetKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}/{key-version}"
@@ -569,10 +505,10 @@ func (client *KeyVaultClient) getKeyCreateRequest(ctx context.Context, keyName s
 }
 
 // getKeyHandleResponse handles the GetKey response.
-func (client *KeyVaultClient) getKeyHandleResponse(resp *http.Response) (KeyVaultClientGetKeyResponse, error) {
-	result := KeyVaultClientGetKeyResponse{}
+func (client *Client) getKeyHandleResponse(resp *http.Response) (GetKeyResponse, error) {
+	result := GetKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
-		return KeyVaultClientGetKeyResponse{}, err
+		return GetKeyResponse{}, err
 	}
 	return result, nil
 }
@@ -585,32 +521,31 @@ func (client *KeyVaultClient) getKeyHandleResponse(resp *http.Response) (KeyVaul
 //
 // Generated from API version 7.6-preview.1
 //   - keyName - The name of the key in a given key vault.
-//   - options - KeyVaultClientGetKeyRotationPolicyOptions contains the optional parameters for the KeyVaultClient.GetKeyRotationPolicy
-//     method.
-func (client *KeyVaultClient) GetKeyRotationPolicy(ctx context.Context, keyName string, options *KeyVaultClientGetKeyRotationPolicyOptions) (KeyVaultClientGetKeyRotationPolicyResponse, error) {
+//   - options - GetKeyRotationPolicyOptions contains the optional parameters for the Client.GetKeyRotationPolicy method.
+func (client *Client) GetKeyRotationPolicy(ctx context.Context, keyName string, options *GetKeyRotationPolicyOptions) (GetKeyRotationPolicyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.GetKeyRotationPolicy"
+	const operationName = "Client.GetKeyRotationPolicy"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.getKeyRotationPolicyCreateRequest(ctx, keyName, options)
 	if err != nil {
-		return KeyVaultClientGetKeyRotationPolicyResponse{}, err
+		return GetKeyRotationPolicyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientGetKeyRotationPolicyResponse{}, err
+		return GetKeyRotationPolicyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientGetKeyRotationPolicyResponse{}, err
+		return GetKeyRotationPolicyResponse{}, err
 	}
 	resp, err := client.getKeyRotationPolicyHandleResponse(httpResp)
 	return resp, err
 }
 
 // getKeyRotationPolicyCreateRequest creates the GetKeyRotationPolicy request.
-func (client *KeyVaultClient) getKeyRotationPolicyCreateRequest(ctx context.Context, keyName string, _ *KeyVaultClientGetKeyRotationPolicyOptions) (*policy.Request, error) {
+func (client *Client) getKeyRotationPolicyCreateRequest(ctx context.Context, keyName string, _ *GetKeyRotationPolicyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}/rotationpolicy"
@@ -630,135 +565,10 @@ func (client *KeyVaultClient) getKeyRotationPolicyCreateRequest(ctx context.Cont
 }
 
 // getKeyRotationPolicyHandleResponse handles the GetKeyRotationPolicy response.
-func (client *KeyVaultClient) getKeyRotationPolicyHandleResponse(resp *http.Response) (KeyVaultClientGetKeyRotationPolicyResponse, error) {
-	result := KeyVaultClientGetKeyRotationPolicyResponse{}
+func (client *Client) getKeyRotationPolicyHandleResponse(resp *http.Response) (GetKeyRotationPolicyResponse, error) {
+	result := GetKeyRotationPolicyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyRotationPolicy); err != nil {
-		return KeyVaultClientGetKeyRotationPolicyResponse{}, err
-	}
-	return result, nil
-}
-
-// NewGetKeyVersionsPager - Retrieves a list of individual key versions with the same key name.
-//
-// The full key identifier, attributes, and tags are provided in the response.
-// This operation requires the keys/list permission.
-//
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key.
-//   - options - KeyVaultClientGetKeyVersionsOptions contains the optional parameters for the KeyVaultClient.NewGetKeyVersionsPager
-//     method.
-func (client *KeyVaultClient) NewGetKeyVersionsPager(keyName string, options *KeyVaultClientGetKeyVersionsOptions) *runtime.Pager[KeyVaultClientGetKeyVersionsResponse] {
-	return runtime.NewPager(runtime.PagingHandler[KeyVaultClientGetKeyVersionsResponse]{
-		More: func(page KeyVaultClientGetKeyVersionsResponse) bool {
-			return page.NextLink != nil && len(*page.NextLink) > 0
-		},
-		Fetcher: func(ctx context.Context, page *KeyVaultClientGetKeyVersionsResponse) (KeyVaultClientGetKeyVersionsResponse, error) {
-			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "KeyVaultClient.NewGetKeyVersionsPager")
-			nextLink := ""
-			if page != nil {
-				nextLink = *page.NextLink
-			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.getKeyVersionsCreateRequest(ctx, keyName, options)
-			}, nil)
-			if err != nil {
-				return KeyVaultClientGetKeyVersionsResponse{}, err
-			}
-			return client.getKeyVersionsHandleResponse(resp)
-		},
-		Tracer: client.internal.Tracer(),
-	})
-}
-
-// getKeyVersionsCreateRequest creates the GetKeyVersions request.
-func (client *KeyVaultClient) getKeyVersionsCreateRequest(ctx context.Context, keyName string, options *KeyVaultClientGetKeyVersionsOptions) (*policy.Request, error) {
-	host := "{vaultBaseUrl}"
-	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
-	urlPath := "/keys/{key-name}/versions"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
-	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
-	if err != nil {
-		return nil, err
-	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
-	if options != nil && options.Maxresults != nil {
-		reqQP.Set("maxresults", strconv.FormatInt(int64(*options.Maxresults), 10))
-	}
-	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["Accept"] = []string{"application/json"}
-	return req, nil
-}
-
-// getKeyVersionsHandleResponse handles the GetKeyVersions response.
-func (client *KeyVaultClient) getKeyVersionsHandleResponse(resp *http.Response) (KeyVaultClientGetKeyVersionsResponse, error) {
-	result := KeyVaultClientGetKeyVersionsResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.KeyListResult); err != nil {
-		return KeyVaultClientGetKeyVersionsResponse{}, err
-	}
-	return result, nil
-}
-
-// NewGetKeysPager - List keys in the specified vault.
-//
-// Retrieves a list of the keys in the Key Vault as JSON Web Key structures that
-// contain the public part of a stored key. The LIST operation is applicable to
-// all key types, however only the base key identifier, attributes, and tags are
-// provided in the response. Individual versions of a key are not listed in the
-// response. This operation requires the keys/list permission.
-//
-// Generated from API version 7.6-preview.1
-//   - options - KeyVaultClientGetKeysOptions contains the optional parameters for the KeyVaultClient.NewGetKeysPager method.
-func (client *KeyVaultClient) NewGetKeysPager(options *KeyVaultClientGetKeysOptions) *runtime.Pager[KeyVaultClientGetKeysResponse] {
-	return runtime.NewPager(runtime.PagingHandler[KeyVaultClientGetKeysResponse]{
-		More: func(page KeyVaultClientGetKeysResponse) bool {
-			return page.NextLink != nil && len(*page.NextLink) > 0
-		},
-		Fetcher: func(ctx context.Context, page *KeyVaultClientGetKeysResponse) (KeyVaultClientGetKeysResponse, error) {
-			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "KeyVaultClient.NewGetKeysPager")
-			nextLink := ""
-			if page != nil {
-				nextLink = *page.NextLink
-			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.getKeysCreateRequest(ctx, options)
-			}, nil)
-			if err != nil {
-				return KeyVaultClientGetKeysResponse{}, err
-			}
-			return client.getKeysHandleResponse(resp)
-		},
-		Tracer: client.internal.Tracer(),
-	})
-}
-
-// getKeysCreateRequest creates the GetKeys request.
-func (client *KeyVaultClient) getKeysCreateRequest(ctx context.Context, options *KeyVaultClientGetKeysOptions) (*policy.Request, error) {
-	host := "{vaultBaseUrl}"
-	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
-	urlPath := "/keys"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
-	if err != nil {
-		return nil, err
-	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
-	if options != nil && options.Maxresults != nil {
-		reqQP.Set("maxresults", strconv.FormatInt(int64(*options.Maxresults), 10))
-	}
-	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["Accept"] = []string{"application/json"}
-	return req, nil
-}
-
-// getKeysHandleResponse handles the GetKeys response.
-func (client *KeyVaultClient) getKeysHandleResponse(resp *http.Response) (KeyVaultClientGetKeysResponse, error) {
-	result := KeyVaultClientGetKeysResponse{}
-	if err := runtime.UnmarshalAsJSON(resp, &result.KeyListResult); err != nil {
-		return KeyVaultClientGetKeysResponse{}, err
+		return GetKeyRotationPolicyResponse{}, err
 	}
 	return result, nil
 }
@@ -770,31 +580,31 @@ func (client *KeyVaultClient) getKeysHandleResponse(resp *http.Response) (KeyVau
 //
 // Generated from API version 7.6-preview.1
 //   - parameters - The request object to get random bytes.
-//   - options - KeyVaultClientGetRandomBytesOptions contains the optional parameters for the KeyVaultClient.GetRandomBytes method.
-func (client *KeyVaultClient) GetRandomBytes(ctx context.Context, parameters GetRandomBytesRequest, options *KeyVaultClientGetRandomBytesOptions) (KeyVaultClientGetRandomBytesResponse, error) {
+//   - options - GetRandomBytesOptions contains the optional parameters for the Client.GetRandomBytes method.
+func (client *Client) GetRandomBytes(ctx context.Context, parameters GetRandomBytesParameters, options *GetRandomBytesOptions) (GetRandomBytesResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.GetRandomBytes"
+	const operationName = "Client.GetRandomBytes"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.getRandomBytesCreateRequest(ctx, parameters, options)
 	if err != nil {
-		return KeyVaultClientGetRandomBytesResponse{}, err
+		return GetRandomBytesResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientGetRandomBytesResponse{}, err
+		return GetRandomBytesResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientGetRandomBytesResponse{}, err
+		return GetRandomBytesResponse{}, err
 	}
 	resp, err := client.getRandomBytesHandleResponse(httpResp)
 	return resp, err
 }
 
 // getRandomBytesCreateRequest creates the GetRandomBytes request.
-func (client *KeyVaultClient) getRandomBytesCreateRequest(ctx context.Context, parameters GetRandomBytesRequest, _ *KeyVaultClientGetRandomBytesOptions) (*policy.Request, error) {
+func (client *Client) getRandomBytesCreateRequest(ctx context.Context, parameters GetRandomBytesParameters, _ *GetRandomBytesOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/rng"
@@ -814,10 +624,10 @@ func (client *KeyVaultClient) getRandomBytesCreateRequest(ctx context.Context, p
 }
 
 // getRandomBytesHandleResponse handles the GetRandomBytes response.
-func (client *KeyVaultClient) getRandomBytesHandleResponse(resp *http.Response) (KeyVaultClientGetRandomBytesResponse, error) {
-	result := KeyVaultClientGetRandomBytesResponse{}
+func (client *Client) getRandomBytesHandleResponse(resp *http.Response) (GetRandomBytesResponse, error) {
+	result := GetRandomBytesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RandomBytes); err != nil {
-		return KeyVaultClientGetRandomBytesResponse{}, err
+		return GetRandomBytesResponse{}, err
 	}
 	return result, nil
 }
@@ -835,31 +645,31 @@ func (client *KeyVaultClient) getRandomBytesHandleResponse(resp *http.Response) 
 //     purpose of running the service. The value provided should not include
 //     personally identifiable or sensitive information.
 //   - parameters - The parameters to import a key.
-//   - options - KeyVaultClientImportKeyOptions contains the optional parameters for the KeyVaultClient.ImportKey method.
-func (client *KeyVaultClient) ImportKey(ctx context.Context, keyName string, parameters KeyImportParameters, options *KeyVaultClientImportKeyOptions) (KeyVaultClientImportKeyResponse, error) {
+//   - options - ImportKeyOptions contains the optional parameters for the Client.ImportKey method.
+func (client *Client) ImportKey(ctx context.Context, keyName string, parameters ImportKeyParameters, options *ImportKeyOptions) (ImportKeyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.ImportKey"
+	const operationName = "Client.ImportKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.importKeyCreateRequest(ctx, keyName, parameters, options)
 	if err != nil {
-		return KeyVaultClientImportKeyResponse{}, err
+		return ImportKeyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientImportKeyResponse{}, err
+		return ImportKeyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientImportKeyResponse{}, err
+		return ImportKeyResponse{}, err
 	}
 	resp, err := client.importKeyHandleResponse(httpResp)
 	return resp, err
 }
 
 // importKeyCreateRequest creates the ImportKey request.
-func (client *KeyVaultClient) importKeyCreateRequest(ctx context.Context, keyName string, parameters KeyImportParameters, _ *KeyVaultClientImportKeyOptions) (*policy.Request, error) {
+func (client *Client) importKeyCreateRequest(ctx context.Context, keyName string, parameters ImportKeyParameters, _ *ImportKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}"
@@ -883,10 +693,189 @@ func (client *KeyVaultClient) importKeyCreateRequest(ctx context.Context, keyNam
 }
 
 // importKeyHandleResponse handles the ImportKey response.
-func (client *KeyVaultClient) importKeyHandleResponse(resp *http.Response) (KeyVaultClientImportKeyResponse, error) {
-	result := KeyVaultClientImportKeyResponse{}
+func (client *Client) importKeyHandleResponse(resp *http.Response) (ImportKeyResponse, error) {
+	result := ImportKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
-		return KeyVaultClientImportKeyResponse{}, err
+		return ImportKeyResponse{}, err
+	}
+	return result, nil
+}
+
+// NewListDeletedKeyPropertiesPager - Lists the deleted keys in the specified vault.
+//
+// Retrieves a list of the keys in the Key Vault as JSON Web Key structures that
+// contain the public part of a deleted key. This operation includes
+// deletion-specific information. The Get Deleted Keys operation is applicable for
+// vaults enabled for soft-delete. While the operation can be invoked on any
+// vault, it will return an error if invoked on a non soft-delete enabled vault.
+// This operation requires the keys/list permission.
+//
+// Generated from API version 7.6-preview.1
+//   - options - ListDeletedKeyPropertiesOptions contains the optional parameters for the Client.NewListDeletedKeyPropertiesPager
+//     method.
+func (client *Client) NewListDeletedKeyPropertiesPager(options *ListDeletedKeyPropertiesOptions) *runtime.Pager[ListDeletedKeyPropertiesResponse] {
+	return runtime.NewPager(runtime.PagingHandler[ListDeletedKeyPropertiesResponse]{
+		More: func(page ListDeletedKeyPropertiesResponse) bool {
+			return page.NextLink != nil && len(*page.NextLink) > 0
+		},
+		Fetcher: func(ctx context.Context, page *ListDeletedKeyPropertiesResponse) (ListDeletedKeyPropertiesResponse, error) {
+			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "Client.NewListDeletedKeyPropertiesPager")
+			nextLink := ""
+			if page != nil {
+				nextLink = *page.NextLink
+			}
+			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
+				return client.listDeletedKeyPropertiesCreateRequest(ctx, options)
+			}, nil)
+			if err != nil {
+				return ListDeletedKeyPropertiesResponse{}, err
+			}
+			return client.listDeletedKeyPropertiesHandleResponse(resp)
+		},
+		Tracer: client.internal.Tracer(),
+	})
+}
+
+// listDeletedKeyPropertiesCreateRequest creates the ListDeletedKeyProperties request.
+func (client *Client) listDeletedKeyPropertiesCreateRequest(ctx context.Context, _ *ListDeletedKeyPropertiesOptions) (*policy.Request, error) {
+	host := "{vaultBaseUrl}"
+	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
+	urlPath := "/deletedkeys"
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "7.6-preview.1")
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
+}
+
+// listDeletedKeyPropertiesHandleResponse handles the ListDeletedKeyProperties response.
+func (client *Client) listDeletedKeyPropertiesHandleResponse(resp *http.Response) (ListDeletedKeyPropertiesResponse, error) {
+	result := ListDeletedKeyPropertiesResponse{}
+	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedKeyPropertiesListResult); err != nil {
+		return ListDeletedKeyPropertiesResponse{}, err
+	}
+	return result, nil
+}
+
+// NewListKeyPropertiesPager - List keys in the specified vault.
+//
+// Retrieves a list of the keys in the Key Vault as JSON Web Key structures that
+// contain the public part of a stored key. The LIST operation is applicable to
+// all key types, however only the base key identifier, attributes, and tags are
+// provided in the response. Individual versions of a key are not listed in the
+// response. This operation requires the keys/list permission.
+//
+// Generated from API version 7.6-preview.1
+//   - options - ListKeyPropertiesOptions contains the optional parameters for the Client.NewListKeyPropertiesPager method.
+func (client *Client) NewListKeyPropertiesPager(options *ListKeyPropertiesOptions) *runtime.Pager[ListKeyPropertiesResponse] {
+	return runtime.NewPager(runtime.PagingHandler[ListKeyPropertiesResponse]{
+		More: func(page ListKeyPropertiesResponse) bool {
+			return page.NextLink != nil && len(*page.NextLink) > 0
+		},
+		Fetcher: func(ctx context.Context, page *ListKeyPropertiesResponse) (ListKeyPropertiesResponse, error) {
+			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "Client.NewListKeyPropertiesPager")
+			nextLink := ""
+			if page != nil {
+				nextLink = *page.NextLink
+			}
+			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
+				return client.listKeyPropertiesCreateRequest(ctx, options)
+			}, nil)
+			if err != nil {
+				return ListKeyPropertiesResponse{}, err
+			}
+			return client.listKeyPropertiesHandleResponse(resp)
+		},
+		Tracer: client.internal.Tracer(),
+	})
+}
+
+// listKeyPropertiesCreateRequest creates the ListKeyProperties request.
+func (client *Client) listKeyPropertiesCreateRequest(ctx context.Context, _ *ListKeyPropertiesOptions) (*policy.Request, error) {
+	host := "{vaultBaseUrl}"
+	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
+	urlPath := "/keys"
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "7.6-preview.1")
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
+}
+
+// listKeyPropertiesHandleResponse handles the ListKeyProperties response.
+func (client *Client) listKeyPropertiesHandleResponse(resp *http.Response) (ListKeyPropertiesResponse, error) {
+	result := ListKeyPropertiesResponse{}
+	if err := runtime.UnmarshalAsJSON(resp, &result.KeyPropertiesListResult); err != nil {
+		return ListKeyPropertiesResponse{}, err
+	}
+	return result, nil
+}
+
+// NewListKeyPropertiesVersionsPager - Retrieves a list of individual key versions with the same key name.
+//
+// The full key identifier, attributes, and tags are provided in the response.
+// This operation requires the keys/list permission.
+//
+// Generated from API version 7.6-preview.1
+//   - keyName - The name of the key.
+//   - options - ListKeyPropertiesVersionsOptions contains the optional parameters for the Client.NewListKeyPropertiesVersionsPager
+//     method.
+func (client *Client) NewListKeyPropertiesVersionsPager(keyName string, options *ListKeyPropertiesVersionsOptions) *runtime.Pager[ListKeyPropertiesVersionsResponse] {
+	return runtime.NewPager(runtime.PagingHandler[ListKeyPropertiesVersionsResponse]{
+		More: func(page ListKeyPropertiesVersionsResponse) bool {
+			return page.NextLink != nil && len(*page.NextLink) > 0
+		},
+		Fetcher: func(ctx context.Context, page *ListKeyPropertiesVersionsResponse) (ListKeyPropertiesVersionsResponse, error) {
+			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "Client.NewListKeyPropertiesVersionsPager")
+			nextLink := ""
+			if page != nil {
+				nextLink = *page.NextLink
+			}
+			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
+				return client.listKeyPropertiesVersionsCreateRequest(ctx, keyName, options)
+			}, nil)
+			if err != nil {
+				return ListKeyPropertiesVersionsResponse{}, err
+			}
+			return client.listKeyPropertiesVersionsHandleResponse(resp)
+		},
+		Tracer: client.internal.Tracer(),
+	})
+}
+
+// listKeyPropertiesVersionsCreateRequest creates the ListKeyPropertiesVersions request.
+func (client *Client) listKeyPropertiesVersionsCreateRequest(ctx context.Context, keyName string, _ *ListKeyPropertiesVersionsOptions) (*policy.Request, error) {
+	host := "{vaultBaseUrl}"
+	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
+	urlPath := "/keys/{key-name}/versions"
+	if keyName == "" {
+		return nil, errors.New("parameter keyName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "7.6-preview.1")
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
+}
+
+// listKeyPropertiesVersionsHandleResponse handles the ListKeyPropertiesVersions response.
+func (client *Client) listKeyPropertiesVersionsHandleResponse(resp *http.Response) (ListKeyPropertiesVersionsResponse, error) {
+	result := ListKeyPropertiesVersionsResponse{}
+	if err := runtime.UnmarshalAsJSON(resp, &result.KeyPropertiesListResult); err != nil {
+		return ListKeyPropertiesVersionsResponse{}, err
 	}
 	return result, nil
 }
@@ -901,31 +890,30 @@ func (client *KeyVaultClient) importKeyHandleResponse(resp *http.Response) (KeyV
 //
 // Generated from API version 7.6-preview.1
 //   - keyName - The name of the key
-//   - options - KeyVaultClientPurgeDeletedKeyOptions contains the optional parameters for the KeyVaultClient.PurgeDeletedKey
-//     method.
-func (client *KeyVaultClient) PurgeDeletedKey(ctx context.Context, keyName string, options *KeyVaultClientPurgeDeletedKeyOptions) (KeyVaultClientPurgeDeletedKeyResponse, error) {
+//   - options - PurgeDeletedKeyOptions contains the optional parameters for the Client.PurgeDeletedKey method.
+func (client *Client) PurgeDeletedKey(ctx context.Context, keyName string, options *PurgeDeletedKeyOptions) (PurgeDeletedKeyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.PurgeDeletedKey"
+	const operationName = "Client.PurgeDeletedKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.purgeDeletedKeyCreateRequest(ctx, keyName, options)
 	if err != nil {
-		return KeyVaultClientPurgeDeletedKeyResponse{}, err
+		return PurgeDeletedKeyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientPurgeDeletedKeyResponse{}, err
+		return PurgeDeletedKeyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientPurgeDeletedKeyResponse{}, err
+		return PurgeDeletedKeyResponse{}, err
 	}
-	return KeyVaultClientPurgeDeletedKeyResponse{}, nil
+	return PurgeDeletedKeyResponse{}, nil
 }
 
 // purgeDeletedKeyCreateRequest creates the PurgeDeletedKey request.
-func (client *KeyVaultClient) purgeDeletedKeyCreateRequest(ctx context.Context, keyName string, _ *KeyVaultClientPurgeDeletedKeyOptions) (*policy.Request, error) {
+func (client *Client) purgeDeletedKeyCreateRequest(ctx context.Context, keyName string, _ *PurgeDeletedKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/deletedkeys/{key-name}"
@@ -955,32 +943,31 @@ func (client *KeyVaultClient) purgeDeletedKeyCreateRequest(ctx context.Context, 
 //
 // Generated from API version 7.6-preview.1
 //   - keyName - The name of the deleted key.
-//   - options - KeyVaultClientRecoverDeletedKeyOptions contains the optional parameters for the KeyVaultClient.RecoverDeletedKey
-//     method.
-func (client *KeyVaultClient) RecoverDeletedKey(ctx context.Context, keyName string, options *KeyVaultClientRecoverDeletedKeyOptions) (KeyVaultClientRecoverDeletedKeyResponse, error) {
+//   - options - RecoverDeletedKeyOptions contains the optional parameters for the Client.RecoverDeletedKey method.
+func (client *Client) RecoverDeletedKey(ctx context.Context, keyName string, options *RecoverDeletedKeyOptions) (RecoverDeletedKeyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.RecoverDeletedKey"
+	const operationName = "Client.RecoverDeletedKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.recoverDeletedKeyCreateRequest(ctx, keyName, options)
 	if err != nil {
-		return KeyVaultClientRecoverDeletedKeyResponse{}, err
+		return RecoverDeletedKeyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientRecoverDeletedKeyResponse{}, err
+		return RecoverDeletedKeyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientRecoverDeletedKeyResponse{}, err
+		return RecoverDeletedKeyResponse{}, err
 	}
 	resp, err := client.recoverDeletedKeyHandleResponse(httpResp)
 	return resp, err
 }
 
 // recoverDeletedKeyCreateRequest creates the RecoverDeletedKey request.
-func (client *KeyVaultClient) recoverDeletedKeyCreateRequest(ctx context.Context, keyName string, _ *KeyVaultClientRecoverDeletedKeyOptions) (*policy.Request, error) {
+func (client *Client) recoverDeletedKeyCreateRequest(ctx context.Context, keyName string, _ *RecoverDeletedKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/deletedkeys/{key-name}/recover"
@@ -1000,10 +987,10 @@ func (client *KeyVaultClient) recoverDeletedKeyCreateRequest(ctx context.Context
 }
 
 // recoverDeletedKeyHandleResponse handles the RecoverDeletedKey response.
-func (client *KeyVaultClient) recoverDeletedKeyHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedKeyResponse, error) {
-	result := KeyVaultClientRecoverDeletedKeyResponse{}
+func (client *Client) recoverDeletedKeyHandleResponse(resp *http.Response) (RecoverDeletedKeyResponse, error) {
+	result := RecoverDeletedKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
-		return KeyVaultClientRecoverDeletedKeyResponse{}, err
+		return RecoverDeletedKeyResponse{}, err
 	}
 	return result, nil
 }
@@ -1018,31 +1005,31 @@ func (client *KeyVaultClient) recoverDeletedKeyHandleResponse(resp *http.Respons
 //   - keyName - The name of the key to get.
 //   - keyVersion - Adding the version parameter retrieves a specific version of a key.
 //   - parameters - The parameters for the key release operation.
-//   - options - KeyVaultClientReleaseOptions contains the optional parameters for the KeyVaultClient.Release method.
-func (client *KeyVaultClient) Release(ctx context.Context, keyName string, keyVersion string, parameters KeyReleaseParameters, options *KeyVaultClientReleaseOptions) (KeyVaultClientReleaseResponse, error) {
+//   - options - ReleaseOptions contains the optional parameters for the Client.Release method.
+func (client *Client) Release(ctx context.Context, keyName string, keyVersion string, parameters ReleaseParameters, options *ReleaseOptions) (ReleaseResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.Release"
+	const operationName = "Client.Release"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.releaseCreateRequest(ctx, keyName, keyVersion, parameters, options)
 	if err != nil {
-		return KeyVaultClientReleaseResponse{}, err
+		return ReleaseResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientReleaseResponse{}, err
+		return ReleaseResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientReleaseResponse{}, err
+		return ReleaseResponse{}, err
 	}
 	resp, err := client.releaseHandleResponse(httpResp)
 	return resp, err
 }
 
 // releaseCreateRequest creates the Release request.
-func (client *KeyVaultClient) releaseCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeyReleaseParameters, _ *KeyVaultClientReleaseOptions) (*policy.Request, error) {
+func (client *Client) releaseCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters ReleaseParameters, _ *ReleaseOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}/{key-version}/release"
@@ -1070,10 +1057,10 @@ func (client *KeyVaultClient) releaseCreateRequest(ctx context.Context, keyName 
 }
 
 // releaseHandleResponse handles the Release response.
-func (client *KeyVaultClient) releaseHandleResponse(resp *http.Response) (KeyVaultClientReleaseResponse, error) {
-	result := KeyVaultClientReleaseResponse{}
+func (client *Client) releaseHandleResponse(resp *http.Response) (ReleaseResponse, error) {
+	result := ReleaseResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyReleaseResult); err != nil {
-		return KeyVaultClientReleaseResponse{}, err
+		return ReleaseResponse{}, err
 	}
 	return result, nil
 }
@@ -1096,31 +1083,31 @@ func (client *KeyVaultClient) releaseHandleResponse(resp *http.Response) (KeyVau
 //
 // Generated from API version 7.6-preview.1
 //   - parameters - The parameters to restore the key.
-//   - options - KeyVaultClientRestoreKeyOptions contains the optional parameters for the KeyVaultClient.RestoreKey method.
-func (client *KeyVaultClient) RestoreKey(ctx context.Context, parameters KeyRestoreParameters, options *KeyVaultClientRestoreKeyOptions) (KeyVaultClientRestoreKeyResponse, error) {
+//   - options - RestoreKeyOptions contains the optional parameters for the Client.RestoreKey method.
+func (client *Client) RestoreKey(ctx context.Context, parameters RestoreKeyParameters, options *RestoreKeyOptions) (RestoreKeyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.RestoreKey"
+	const operationName = "Client.RestoreKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.restoreKeyCreateRequest(ctx, parameters, options)
 	if err != nil {
-		return KeyVaultClientRestoreKeyResponse{}, err
+		return RestoreKeyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientRestoreKeyResponse{}, err
+		return RestoreKeyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientRestoreKeyResponse{}, err
+		return RestoreKeyResponse{}, err
 	}
 	resp, err := client.restoreKeyHandleResponse(httpResp)
 	return resp, err
 }
 
 // restoreKeyCreateRequest creates the RestoreKey request.
-func (client *KeyVaultClient) restoreKeyCreateRequest(ctx context.Context, parameters KeyRestoreParameters, _ *KeyVaultClientRestoreKeyOptions) (*policy.Request, error) {
+func (client *Client) restoreKeyCreateRequest(ctx context.Context, parameters RestoreKeyParameters, _ *RestoreKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/restore"
@@ -1140,10 +1127,10 @@ func (client *KeyVaultClient) restoreKeyCreateRequest(ctx context.Context, param
 }
 
 // restoreKeyHandleResponse handles the RestoreKey response.
-func (client *KeyVaultClient) restoreKeyHandleResponse(resp *http.Response) (KeyVaultClientRestoreKeyResponse, error) {
-	result := KeyVaultClientRestoreKeyResponse{}
+func (client *Client) restoreKeyHandleResponse(resp *http.Response) (RestoreKeyResponse, error) {
+	result := RestoreKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
-		return KeyVaultClientRestoreKeyResponse{}, err
+		return RestoreKeyResponse{}, err
 	}
 	return result, nil
 }
@@ -1158,31 +1145,31 @@ func (client *KeyVaultClient) restoreKeyHandleResponse(resp *http.Response) (Key
 // Generated from API version 7.6-preview.1
 //   - keyName - The name of key to be rotated. The system will generate a new version in the
 //     specified key.
-//   - options - KeyVaultClientRotateKeyOptions contains the optional parameters for the KeyVaultClient.RotateKey method.
-func (client *KeyVaultClient) RotateKey(ctx context.Context, keyName string, options *KeyVaultClientRotateKeyOptions) (KeyVaultClientRotateKeyResponse, error) {
+//   - options - RotateKeyOptions contains the optional parameters for the Client.RotateKey method.
+func (client *Client) RotateKey(ctx context.Context, keyName string, options *RotateKeyOptions) (RotateKeyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.RotateKey"
+	const operationName = "Client.RotateKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.rotateKeyCreateRequest(ctx, keyName, options)
 	if err != nil {
-		return KeyVaultClientRotateKeyResponse{}, err
+		return RotateKeyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientRotateKeyResponse{}, err
+		return RotateKeyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientRotateKeyResponse{}, err
+		return RotateKeyResponse{}, err
 	}
 	resp, err := client.rotateKeyHandleResponse(httpResp)
 	return resp, err
 }
 
 // rotateKeyCreateRequest creates the RotateKey request.
-func (client *KeyVaultClient) rotateKeyCreateRequest(ctx context.Context, keyName string, _ *KeyVaultClientRotateKeyOptions) (*policy.Request, error) {
+func (client *Client) rotateKeyCreateRequest(ctx context.Context, keyName string, _ *RotateKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}/rotate"
@@ -1202,10 +1189,10 @@ func (client *KeyVaultClient) rotateKeyCreateRequest(ctx context.Context, keyNam
 }
 
 // rotateKeyHandleResponse handles the RotateKey response.
-func (client *KeyVaultClient) rotateKeyHandleResponse(resp *http.Response) (KeyVaultClientRotateKeyResponse, error) {
-	result := KeyVaultClientRotateKeyResponse{}
+func (client *Client) rotateKeyHandleResponse(resp *http.Response) (RotateKeyResponse, error) {
+	result := RotateKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
-		return KeyVaultClientRotateKeyResponse{}, err
+		return RotateKeyResponse{}, err
 	}
 	return result, nil
 }
@@ -1221,31 +1208,31 @@ func (client *KeyVaultClient) rotateKeyHandleResponse(resp *http.Response) (KeyV
 //   - keyName - The name of the key.
 //   - keyVersion - The version of the key.
 //   - parameters - The parameters for the signing operation.
-//   - options - KeyVaultClientSignOptions contains the optional parameters for the KeyVaultClient.Sign method.
-func (client *KeyVaultClient) Sign(ctx context.Context, keyName string, keyVersion string, parameters KeySignParameters, options *KeyVaultClientSignOptions) (KeyVaultClientSignResponse, error) {
+//   - options - SignOptions contains the optional parameters for the Client.Sign method.
+func (client *Client) Sign(ctx context.Context, keyName string, keyVersion string, parameters SignParameters, options *SignOptions) (SignResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.Sign"
+	const operationName = "Client.Sign"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.signCreateRequest(ctx, keyName, keyVersion, parameters, options)
 	if err != nil {
-		return KeyVaultClientSignResponse{}, err
+		return SignResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientSignResponse{}, err
+		return SignResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientSignResponse{}, err
+		return SignResponse{}, err
 	}
 	resp, err := client.signHandleResponse(httpResp)
 	return resp, err
 }
 
 // signCreateRequest creates the Sign request.
-func (client *KeyVaultClient) signCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeySignParameters, _ *KeyVaultClientSignOptions) (*policy.Request, error) {
+func (client *Client) signCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters SignParameters, _ *SignOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}/{key-version}/sign"
@@ -1273,10 +1260,10 @@ func (client *KeyVaultClient) signCreateRequest(ctx context.Context, keyName str
 }
 
 // signHandleResponse handles the Sign response.
-func (client *KeyVaultClient) signHandleResponse(resp *http.Response) (KeyVaultClientSignResponse, error) {
-	result := KeyVaultClientSignResponse{}
+func (client *Client) signHandleResponse(resp *http.Response) (SignResponse, error) {
+	result := SignResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
-		return KeyVaultClientSignResponse{}, err
+		return SignResponse{}, err
 	}
 	return result, nil
 }
@@ -1295,31 +1282,31 @@ func (client *KeyVaultClient) signHandleResponse(resp *http.Response) (KeyVaultC
 //   - keyName - The name of the key.
 //   - keyVersion - The version of the key.
 //   - parameters - The parameters for the key operation.
-//   - options - KeyVaultClientUnwrapKeyOptions contains the optional parameters for the KeyVaultClient.UnwrapKey method.
-func (client *KeyVaultClient) UnwrapKey(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientUnwrapKeyOptions) (KeyVaultClientUnwrapKeyResponse, error) {
+//   - options - UnwrapKeyOptions contains the optional parameters for the Client.UnwrapKey method.
+func (client *Client) UnwrapKey(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, options *UnwrapKeyOptions) (UnwrapKeyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.UnwrapKey"
+	const operationName = "Client.UnwrapKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.unwrapKeyCreateRequest(ctx, keyName, keyVersion, parameters, options)
 	if err != nil {
-		return KeyVaultClientUnwrapKeyResponse{}, err
+		return UnwrapKeyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientUnwrapKeyResponse{}, err
+		return UnwrapKeyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientUnwrapKeyResponse{}, err
+		return UnwrapKeyResponse{}, err
 	}
 	resp, err := client.unwrapKeyHandleResponse(httpResp)
 	return resp, err
 }
 
 // unwrapKeyCreateRequest creates the UnwrapKey request.
-func (client *KeyVaultClient) unwrapKeyCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationsParameters, _ *KeyVaultClientUnwrapKeyOptions) (*policy.Request, error) {
+func (client *Client) unwrapKeyCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, _ *UnwrapKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}/{key-version}/unwrapkey"
@@ -1347,10 +1334,10 @@ func (client *KeyVaultClient) unwrapKeyCreateRequest(ctx context.Context, keyNam
 }
 
 // unwrapKeyHandleResponse handles the UnwrapKey response.
-func (client *KeyVaultClient) unwrapKeyHandleResponse(resp *http.Response) (KeyVaultClientUnwrapKeyResponse, error) {
-	result := KeyVaultClientUnwrapKeyResponse{}
+func (client *Client) unwrapKeyHandleResponse(resp *http.Response) (UnwrapKeyResponse, error) {
+	result := UnwrapKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
-		return KeyVaultClientUnwrapKeyResponse{}, err
+		return UnwrapKeyResponse{}, err
 	}
 	return result, nil
 }
@@ -1367,31 +1354,31 @@ func (client *KeyVaultClient) unwrapKeyHandleResponse(resp *http.Response) (KeyV
 //   - keyName - The name of key to update.
 //   - keyVersion - The version of the key to update.
 //   - parameters - The parameters of the key to update.
-//   - options - KeyVaultClientUpdateKeyOptions contains the optional parameters for the KeyVaultClient.UpdateKey method.
-func (client *KeyVaultClient) UpdateKey(ctx context.Context, keyName string, keyVersion string, parameters KeyUpdateParameters, options *KeyVaultClientUpdateKeyOptions) (KeyVaultClientUpdateKeyResponse, error) {
+//   - options - UpdateKeyOptions contains the optional parameters for the Client.UpdateKey method.
+func (client *Client) UpdateKey(ctx context.Context, keyName string, keyVersion string, parameters UpdateKeyParameters, options *UpdateKeyOptions) (UpdateKeyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.UpdateKey"
+	const operationName = "Client.UpdateKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.updateKeyCreateRequest(ctx, keyName, keyVersion, parameters, options)
 	if err != nil {
-		return KeyVaultClientUpdateKeyResponse{}, err
+		return UpdateKeyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientUpdateKeyResponse{}, err
+		return UpdateKeyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientUpdateKeyResponse{}, err
+		return UpdateKeyResponse{}, err
 	}
 	resp, err := client.updateKeyHandleResponse(httpResp)
 	return resp, err
 }
 
 // updateKeyCreateRequest creates the UpdateKey request.
-func (client *KeyVaultClient) updateKeyCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeyUpdateParameters, _ *KeyVaultClientUpdateKeyOptions) (*policy.Request, error) {
+func (client *Client) updateKeyCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters UpdateKeyParameters, _ *UpdateKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}/{key-version}"
@@ -1419,10 +1406,10 @@ func (client *KeyVaultClient) updateKeyCreateRequest(ctx context.Context, keyNam
 }
 
 // updateKeyHandleResponse handles the UpdateKey response.
-func (client *KeyVaultClient) updateKeyHandleResponse(resp *http.Response) (KeyVaultClientUpdateKeyResponse, error) {
-	result := KeyVaultClientUpdateKeyResponse{}
+func (client *Client) updateKeyHandleResponse(resp *http.Response) (UpdateKeyResponse, error) {
+	result := UpdateKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
-		return KeyVaultClientUpdateKeyResponse{}, err
+		return UpdateKeyResponse{}, err
 	}
 	return result, nil
 }
@@ -1436,32 +1423,31 @@ func (client *KeyVaultClient) updateKeyHandleResponse(resp *http.Response) (KeyV
 // Generated from API version 7.6-preview.1
 //   - keyName - The name of the key in the given vault.
 //   - keyRotationPolicy - The policy for the key.
-//   - options - KeyVaultClientUpdateKeyRotationPolicyOptions contains the optional parameters for the KeyVaultClient.UpdateKeyRotationPolicy
-//     method.
-func (client *KeyVaultClient) UpdateKeyRotationPolicy(ctx context.Context, keyName string, keyRotationPolicy KeyRotationPolicy, options *KeyVaultClientUpdateKeyRotationPolicyOptions) (KeyVaultClientUpdateKeyRotationPolicyResponse, error) {
+//   - options - UpdateKeyRotationPolicyOptions contains the optional parameters for the Client.UpdateKeyRotationPolicy method.
+func (client *Client) UpdateKeyRotationPolicy(ctx context.Context, keyName string, keyRotationPolicy KeyRotationPolicy, options *UpdateKeyRotationPolicyOptions) (UpdateKeyRotationPolicyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.UpdateKeyRotationPolicy"
+	const operationName = "Client.UpdateKeyRotationPolicy"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.updateKeyRotationPolicyCreateRequest(ctx, keyName, keyRotationPolicy, options)
 	if err != nil {
-		return KeyVaultClientUpdateKeyRotationPolicyResponse{}, err
+		return UpdateKeyRotationPolicyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientUpdateKeyRotationPolicyResponse{}, err
+		return UpdateKeyRotationPolicyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientUpdateKeyRotationPolicyResponse{}, err
+		return UpdateKeyRotationPolicyResponse{}, err
 	}
 	resp, err := client.updateKeyRotationPolicyHandleResponse(httpResp)
 	return resp, err
 }
 
 // updateKeyRotationPolicyCreateRequest creates the UpdateKeyRotationPolicy request.
-func (client *KeyVaultClient) updateKeyRotationPolicyCreateRequest(ctx context.Context, keyName string, keyRotationPolicy KeyRotationPolicy, _ *KeyVaultClientUpdateKeyRotationPolicyOptions) (*policy.Request, error) {
+func (client *Client) updateKeyRotationPolicyCreateRequest(ctx context.Context, keyName string, keyRotationPolicy KeyRotationPolicy, _ *UpdateKeyRotationPolicyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}/rotationpolicy"
@@ -1485,10 +1471,10 @@ func (client *KeyVaultClient) updateKeyRotationPolicyCreateRequest(ctx context.C
 }
 
 // updateKeyRotationPolicyHandleResponse handles the UpdateKeyRotationPolicy response.
-func (client *KeyVaultClient) updateKeyRotationPolicyHandleResponse(resp *http.Response) (KeyVaultClientUpdateKeyRotationPolicyResponse, error) {
-	result := KeyVaultClientUpdateKeyRotationPolicyResponse{}
+func (client *Client) updateKeyRotationPolicyHandleResponse(resp *http.Response) (UpdateKeyRotationPolicyResponse, error) {
+	result := UpdateKeyRotationPolicyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyRotationPolicy); err != nil {
-		return KeyVaultClientUpdateKeyRotationPolicyResponse{}, err
+		return UpdateKeyRotationPolicyResponse{}, err
 	}
 	return result, nil
 }
@@ -1507,31 +1493,31 @@ func (client *KeyVaultClient) updateKeyRotationPolicyHandleResponse(resp *http.R
 //   - keyName - The name of the key.
 //   - keyVersion - The version of the key.
 //   - parameters - The parameters for verify operations.
-//   - options - KeyVaultClientVerifyOptions contains the optional parameters for the KeyVaultClient.Verify method.
-func (client *KeyVaultClient) Verify(ctx context.Context, keyName string, keyVersion string, parameters KeyVerifyParameters, options *KeyVaultClientVerifyOptions) (KeyVaultClientVerifyResponse, error) {
+//   - options - VerifyOptions contains the optional parameters for the Client.Verify method.
+func (client *Client) Verify(ctx context.Context, keyName string, keyVersion string, parameters VerifyParameters, options *VerifyOptions) (VerifyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.Verify"
+	const operationName = "Client.Verify"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.verifyCreateRequest(ctx, keyName, keyVersion, parameters, options)
 	if err != nil {
-		return KeyVaultClientVerifyResponse{}, err
+		return VerifyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientVerifyResponse{}, err
+		return VerifyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientVerifyResponse{}, err
+		return VerifyResponse{}, err
 	}
 	resp, err := client.verifyHandleResponse(httpResp)
 	return resp, err
 }
 
 // verifyCreateRequest creates the Verify request.
-func (client *KeyVaultClient) verifyCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeyVerifyParameters, _ *KeyVaultClientVerifyOptions) (*policy.Request, error) {
+func (client *Client) verifyCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters VerifyParameters, _ *VerifyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}/{key-version}/verify"
@@ -1559,10 +1545,10 @@ func (client *KeyVaultClient) verifyCreateRequest(ctx context.Context, keyName s
 }
 
 // verifyHandleResponse handles the Verify response.
-func (client *KeyVaultClient) verifyHandleResponse(resp *http.Response) (KeyVaultClientVerifyResponse, error) {
-	result := KeyVaultClientVerifyResponse{}
+func (client *Client) verifyHandleResponse(resp *http.Response) (VerifyResponse, error) {
+	result := VerifyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyVerifyResult); err != nil {
-		return KeyVaultClientVerifyResponse{}, err
+		return VerifyResponse{}, err
 	}
 	return result, nil
 }
@@ -1582,31 +1568,31 @@ func (client *KeyVaultClient) verifyHandleResponse(resp *http.Response) (KeyVaul
 //   - keyName - The name of the key.
 //   - keyVersion - The version of the key.
 //   - parameters - The parameters for wrap operation.
-//   - options - KeyVaultClientWrapKeyOptions contains the optional parameters for the KeyVaultClient.WrapKey method.
-func (client *KeyVaultClient) WrapKey(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationsParameters, options *KeyVaultClientWrapKeyOptions) (KeyVaultClientWrapKeyResponse, error) {
+//   - options - WrapKeyOptions contains the optional parameters for the Client.WrapKey method.
+func (client *Client) WrapKey(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, options *WrapKeyOptions) (WrapKeyResponse, error) {
 	var err error
-	const operationName = "KeyVaultClient.WrapKey"
+	const operationName = "Client.WrapKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.wrapKeyCreateRequest(ctx, keyName, keyVersion, parameters, options)
 	if err != nil {
-		return KeyVaultClientWrapKeyResponse{}, err
+		return WrapKeyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return KeyVaultClientWrapKeyResponse{}, err
+		return WrapKeyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return KeyVaultClientWrapKeyResponse{}, err
+		return WrapKeyResponse{}, err
 	}
 	resp, err := client.wrapKeyHandleResponse(httpResp)
 	return resp, err
 }
 
 // wrapKeyCreateRequest creates the WrapKey request.
-func (client *KeyVaultClient) wrapKeyCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationsParameters, _ *KeyVaultClientWrapKeyOptions) (*policy.Request, error) {
+func (client *Client) wrapKeyCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, _ *WrapKeyOptions) (*policy.Request, error) {
 	host := "{vaultBaseUrl}"
 	host = strings.ReplaceAll(host, "{vaultBaseUrl}", client.vaultBaseUrl)
 	urlPath := "/keys/{key-name}/{key-version}/wrapkey"
@@ -1634,10 +1620,10 @@ func (client *KeyVaultClient) wrapKeyCreateRequest(ctx context.Context, keyName 
 }
 
 // wrapKeyHandleResponse handles the WrapKey response.
-func (client *KeyVaultClient) wrapKeyHandleResponse(resp *http.Response) (KeyVaultClientWrapKeyResponse, error) {
-	result := KeyVaultClientWrapKeyResponse{}
+func (client *Client) wrapKeyHandleResponse(resp *http.Response) (WrapKeyResponse, error) {
+	result := WrapKeyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
-		return KeyVaultClientWrapKeyResponse{}, err
+		return WrapKeyResponse{}, err
 	}
 	return result, nil
 }

--- a/packages/typespec-go/test/local/azkeys/zz_constants.go
+++ b/packages/typespec-go/test/local/azkeys/zz_constants.go
@@ -4,217 +4,94 @@
 
 package azkeys
 
-// JSONWebKeyCurveName - Elliptic curve name. For valid values, see JsonWebKeyCurveName.
-type JSONWebKeyCurveName string
+// CurveName - Elliptic curve name. For valid values, see JsonWebKeyCurveName.
+type CurveName string
 
 const (
-	// JSONWebKeyCurveNameP256 - The NIST P-256 elliptic curve, AKA SECG curve SECP256R1.
-	JSONWebKeyCurveNameP256 JSONWebKeyCurveName = "P-256"
-	// JSONWebKeyCurveNameP256K - The SECG SECP256K1 elliptic curve.
-	JSONWebKeyCurveNameP256K JSONWebKeyCurveName = "P-256K"
-	// JSONWebKeyCurveNameP384 - The NIST P-384 elliptic curve, AKA SECG curve SECP384R1.
-	JSONWebKeyCurveNameP384 JSONWebKeyCurveName = "P-384"
-	// JSONWebKeyCurveNameP521 - The NIST P-521 elliptic curve, AKA SECG curve SECP521R1.
-	JSONWebKeyCurveNameP521 JSONWebKeyCurveName = "P-521"
+	// CurveNameP256 - The NIST P-256 elliptic curve, AKA SECG curve SECP256R1.
+	CurveNameP256 CurveName = "P-256"
+	// CurveNameP256K - The SECG SECP256K1 elliptic curve.
+	CurveNameP256K CurveName = "P-256K"
+	// CurveNameP384 - The NIST P-384 elliptic curve, AKA SECG curve SECP384R1.
+	CurveNameP384 CurveName = "P-384"
+	// CurveNameP521 - The NIST P-521 elliptic curve, AKA SECG curve SECP521R1.
+	CurveNameP521 CurveName = "P-521"
 )
 
-// PossibleJSONWebKeyCurveNameValues returns the possible values for the JSONWebKeyCurveName const type.
-func PossibleJSONWebKeyCurveNameValues() []JSONWebKeyCurveName {
-	return []JSONWebKeyCurveName{
-		JSONWebKeyCurveNameP256,
-		JSONWebKeyCurveNameP256K,
-		JSONWebKeyCurveNameP384,
-		JSONWebKeyCurveNameP521,
+// PossibleCurveNameValues returns the possible values for the CurveName const type.
+func PossibleCurveNameValues() []CurveName {
+	return []CurveName{
+		CurveNameP256,
+		CurveNameP256K,
+		CurveNameP384,
+		CurveNameP521,
 	}
 }
 
-// JSONWebKeyEncryptionAlgorithm - An algorithm used for encryption and decryption.
-type JSONWebKeyEncryptionAlgorithm string
+// EncryptionAlgorithm - An algorithm used for encryption and decryption.
+type EncryptionAlgorithm string
 
 const (
-	// JSONWebKeyEncryptionAlgorithmA128CBC - 128-bit AES-CBC.
-	JSONWebKeyEncryptionAlgorithmA128CBC JSONWebKeyEncryptionAlgorithm = "A128CBC"
-	// JSONWebKeyEncryptionAlgorithmA128CBCPAD - 128-bit AES-CBC with PKCS padding.
-	JSONWebKeyEncryptionAlgorithmA128CBCPAD JSONWebKeyEncryptionAlgorithm = "A128CBCPAD"
-	// JSONWebKeyEncryptionAlgorithmA128GCM - 128-bit AES-GCM.
-	JSONWebKeyEncryptionAlgorithmA128GCM JSONWebKeyEncryptionAlgorithm = "A128GCM"
-	// JSONWebKeyEncryptionAlgorithmA128KW - 128-bit AES key wrap.
-	JSONWebKeyEncryptionAlgorithmA128KW JSONWebKeyEncryptionAlgorithm = "A128KW"
-	// JSONWebKeyEncryptionAlgorithmA192CBC - 192-bit AES-CBC.
-	JSONWebKeyEncryptionAlgorithmA192CBC JSONWebKeyEncryptionAlgorithm = "A192CBC"
-	// JSONWebKeyEncryptionAlgorithmA192CBCPAD - 192-bit AES-CBC with PKCS padding.
-	JSONWebKeyEncryptionAlgorithmA192CBCPAD JSONWebKeyEncryptionAlgorithm = "A192CBCPAD"
-	// JSONWebKeyEncryptionAlgorithmA192GCM - 192-bit AES-GCM.
-	JSONWebKeyEncryptionAlgorithmA192GCM JSONWebKeyEncryptionAlgorithm = "A192GCM"
-	// JSONWebKeyEncryptionAlgorithmA192KW - 192-bit AES key wrap.
-	JSONWebKeyEncryptionAlgorithmA192KW JSONWebKeyEncryptionAlgorithm = "A192KW"
-	// JSONWebKeyEncryptionAlgorithmA256CBC - 256-bit AES-CBC.
-	JSONWebKeyEncryptionAlgorithmA256CBC JSONWebKeyEncryptionAlgorithm = "A256CBC"
-	// JSONWebKeyEncryptionAlgorithmA256CBCPAD - 256-bit AES-CBC with PKCS padding.
-	JSONWebKeyEncryptionAlgorithmA256CBCPAD JSONWebKeyEncryptionAlgorithm = "A256CBCPAD"
-	// JSONWebKeyEncryptionAlgorithmA256GCM - 256-bit AES-GCM.
-	JSONWebKeyEncryptionAlgorithmA256GCM JSONWebKeyEncryptionAlgorithm = "A256GCM"
-	// JSONWebKeyEncryptionAlgorithmA256KW - 256-bit AES key wrap.
-	JSONWebKeyEncryptionAlgorithmA256KW JSONWebKeyEncryptionAlgorithm = "A256KW"
-	// JSONWebKeyEncryptionAlgorithmCKMAESKEYWRAP - CKM AES key wrap.
-	JSONWebKeyEncryptionAlgorithmCKMAESKEYWRAP JSONWebKeyEncryptionAlgorithm = "CKM_AES_KEY_WRAP"
-	// JSONWebKeyEncryptionAlgorithmCKMAESKEYWRAPPAD - CKM AES key wrap with padding.
-	JSONWebKeyEncryptionAlgorithmCKMAESKEYWRAPPAD JSONWebKeyEncryptionAlgorithm = "CKM_AES_KEY_WRAP_PAD"
-	// JSONWebKeyEncryptionAlgorithmRSA15 - RSAES-PKCS1-V1_5 key encryption, as described in https://tools.ietf.org/html/rfc3447.
-	JSONWebKeyEncryptionAlgorithmRSA15 JSONWebKeyEncryptionAlgorithm = "RSA1_5"
-	// JSONWebKeyEncryptionAlgorithmRSAOAEP - RSAES using Optimal Asymmetric Encryption Padding (OAEP), as described in
+	// EncryptionAlgorithmA128CBC - 128-bit AES-CBC.
+	EncryptionAlgorithmA128CBC EncryptionAlgorithm = "A128CBC"
+	// EncryptionAlgorithmA128CBCPAD - 128-bit AES-CBC with PKCS padding.
+	EncryptionAlgorithmA128CBCPAD EncryptionAlgorithm = "A128CBCPAD"
+	// EncryptionAlgorithmA128GCM - 128-bit AES-GCM.
+	EncryptionAlgorithmA128GCM EncryptionAlgorithm = "A128GCM"
+	// EncryptionAlgorithmA128KW - 128-bit AES key wrap.
+	EncryptionAlgorithmA128KW EncryptionAlgorithm = "A128KW"
+	// EncryptionAlgorithmA192CBC - 192-bit AES-CBC.
+	EncryptionAlgorithmA192CBC EncryptionAlgorithm = "A192CBC"
+	// EncryptionAlgorithmA192CBCPAD - 192-bit AES-CBC with PKCS padding.
+	EncryptionAlgorithmA192CBCPAD EncryptionAlgorithm = "A192CBCPAD"
+	// EncryptionAlgorithmA192GCM - 192-bit AES-GCM.
+	EncryptionAlgorithmA192GCM EncryptionAlgorithm = "A192GCM"
+	// EncryptionAlgorithmA192KW - 192-bit AES key wrap.
+	EncryptionAlgorithmA192KW EncryptionAlgorithm = "A192KW"
+	// EncryptionAlgorithmA256CBC - 256-bit AES-CBC.
+	EncryptionAlgorithmA256CBC EncryptionAlgorithm = "A256CBC"
+	// EncryptionAlgorithmA256CBCPAD - 256-bit AES-CBC with PKCS padding.
+	EncryptionAlgorithmA256CBCPAD EncryptionAlgorithm = "A256CBCPAD"
+	// EncryptionAlgorithmA256GCM - 256-bit AES-GCM.
+	EncryptionAlgorithmA256GCM EncryptionAlgorithm = "A256GCM"
+	// EncryptionAlgorithmA256KW - 256-bit AES key wrap.
+	EncryptionAlgorithmA256KW EncryptionAlgorithm = "A256KW"
+	// EncryptionAlgorithmCKMAESKEYWRAP - CKM AES key wrap.
+	EncryptionAlgorithmCKMAESKEYWRAP EncryptionAlgorithm = "CKM_AES_KEY_WRAP"
+	// EncryptionAlgorithmCKMAESKEYWRAPPAD - CKM AES key wrap with padding.
+	EncryptionAlgorithmCKMAESKEYWRAPPAD EncryptionAlgorithm = "CKM_AES_KEY_WRAP_PAD"
+	// EncryptionAlgorithmRSA15 - RSAES-PKCS1-V1_5 key encryption, as described in https://tools.ietf.org/html/rfc3447.
+	EncryptionAlgorithmRSA15 EncryptionAlgorithm = "RSA1_5"
+	// EncryptionAlgorithmRSAOAEP - RSAES using Optimal Asymmetric Encryption Padding (OAEP), as described in
 	// https://tools.ietf.org/html/rfc3447, with the default parameters specified by
 	// RFC 3447 in Section A.2.1. Those default parameters are using a hash function
 	// of SHA-1 and a mask generation function of MGF1 with SHA-1.
-	JSONWebKeyEncryptionAlgorithmRSAOAEP JSONWebKeyEncryptionAlgorithm = "RSA-OAEP"
-	// JSONWebKeyEncryptionAlgorithmRSAOAEP256 - RSAES using Optimal Asymmetric Encryption Padding with a hash function of SHA-256
+	EncryptionAlgorithmRSAOAEP EncryptionAlgorithm = "RSA-OAEP"
+	// EncryptionAlgorithmRSAOAEP256 - RSAES using Optimal Asymmetric Encryption Padding with a hash function of SHA-256
 	// and a mask generation function of MGF1 with SHA-256.
-	JSONWebKeyEncryptionAlgorithmRSAOAEP256 JSONWebKeyEncryptionAlgorithm = "RSA-OAEP-256"
+	EncryptionAlgorithmRSAOAEP256 EncryptionAlgorithm = "RSA-OAEP-256"
 )
 
-// PossibleJSONWebKeyEncryptionAlgorithmValues returns the possible values for the JSONWebKeyEncryptionAlgorithm const type.
-func PossibleJSONWebKeyEncryptionAlgorithmValues() []JSONWebKeyEncryptionAlgorithm {
-	return []JSONWebKeyEncryptionAlgorithm{
-		JSONWebKeyEncryptionAlgorithmA128CBC,
-		JSONWebKeyEncryptionAlgorithmA128CBCPAD,
-		JSONWebKeyEncryptionAlgorithmA128GCM,
-		JSONWebKeyEncryptionAlgorithmA128KW,
-		JSONWebKeyEncryptionAlgorithmA192CBC,
-		JSONWebKeyEncryptionAlgorithmA192CBCPAD,
-		JSONWebKeyEncryptionAlgorithmA192GCM,
-		JSONWebKeyEncryptionAlgorithmA192KW,
-		JSONWebKeyEncryptionAlgorithmA256CBC,
-		JSONWebKeyEncryptionAlgorithmA256CBCPAD,
-		JSONWebKeyEncryptionAlgorithmA256GCM,
-		JSONWebKeyEncryptionAlgorithmA256KW,
-		JSONWebKeyEncryptionAlgorithmCKMAESKEYWRAP,
-		JSONWebKeyEncryptionAlgorithmCKMAESKEYWRAPPAD,
-		JSONWebKeyEncryptionAlgorithmRSA15,
-		JSONWebKeyEncryptionAlgorithmRSAOAEP,
-		JSONWebKeyEncryptionAlgorithmRSAOAEP256,
-	}
-}
-
-// JSONWebKeyOperation - JSON web key operations. For more information, see JsonWebKeyOperation.
-type JSONWebKeyOperation string
-
-const (
-	// JSONWebKeyOperationDecrypt - Indicates that the key can be used to decrypt.
-	JSONWebKeyOperationDecrypt JSONWebKeyOperation = "decrypt"
-	// JSONWebKeyOperationEncrypt - Indicates that the key can be used to encrypt.
-	JSONWebKeyOperationEncrypt JSONWebKeyOperation = "encrypt"
-	// JSONWebKeyOperationExport - Indicates that the private component of the key can be exported.
-	JSONWebKeyOperationExport JSONWebKeyOperation = "export"
-	// JSONWebKeyOperationImport - Indicates that the key can be imported during creation.
-	JSONWebKeyOperationImport JSONWebKeyOperation = "import"
-	// JSONWebKeyOperationSign - Indicates that the key can be used to sign.
-	JSONWebKeyOperationSign JSONWebKeyOperation = "sign"
-	// JSONWebKeyOperationUnwrapKey - Indicates that the key can be used to unwrap another key.
-	JSONWebKeyOperationUnwrapKey JSONWebKeyOperation = "unwrapKey"
-	// JSONWebKeyOperationVerify - Indicates that the key can be used to verify.
-	JSONWebKeyOperationVerify JSONWebKeyOperation = "verify"
-	// JSONWebKeyOperationWrapKey - Indicates that the key can be used to wrap another key.
-	JSONWebKeyOperationWrapKey JSONWebKeyOperation = "wrapKey"
-)
-
-// PossibleJSONWebKeyOperationValues returns the possible values for the JSONWebKeyOperation const type.
-func PossibleJSONWebKeyOperationValues() []JSONWebKeyOperation {
-	return []JSONWebKeyOperation{
-		JSONWebKeyOperationDecrypt,
-		JSONWebKeyOperationEncrypt,
-		JSONWebKeyOperationExport,
-		JSONWebKeyOperationImport,
-		JSONWebKeyOperationSign,
-		JSONWebKeyOperationUnwrapKey,
-		JSONWebKeyOperationVerify,
-		JSONWebKeyOperationWrapKey,
-	}
-}
-
-// JSONWebKeySignatureAlgorithm - The signing/verification algorithm identifier. For more information on possible
-// algorithm types, see JsonWebKeySignatureAlgorithm.
-type JSONWebKeySignatureAlgorithm string
-
-const (
-	// JSONWebKeySignatureAlgorithmES256 - ECDSA using P-256 and SHA-256, as described in
-	// https://tools.ietf.org/html/rfc7518.
-	JSONWebKeySignatureAlgorithmES256 JSONWebKeySignatureAlgorithm = "ES256"
-	// JSONWebKeySignatureAlgorithmES256K - ECDSA using P-256K and SHA-256, as described in
-	// https://tools.ietf.org/html/rfc7518
-	JSONWebKeySignatureAlgorithmES256K JSONWebKeySignatureAlgorithm = "ES256K"
-	// JSONWebKeySignatureAlgorithmES384 - ECDSA using P-384 and SHA-384, as described in
-	// https://tools.ietf.org/html/rfc7518
-	JSONWebKeySignatureAlgorithmES384 JSONWebKeySignatureAlgorithm = "ES384"
-	// JSONWebKeySignatureAlgorithmES512 - ECDSA using P-521 and SHA-512, as described in
-	// https://tools.ietf.org/html/rfc7518
-	JSONWebKeySignatureAlgorithmES512 JSONWebKeySignatureAlgorithm = "ES512"
-	// JSONWebKeySignatureAlgorithmPS256 - RSASSA-PSS using SHA-256 and MGF1 with SHA-256, as described in
-	// https://tools.ietf.org/html/rfc7518
-	JSONWebKeySignatureAlgorithmPS256 JSONWebKeySignatureAlgorithm = "PS256"
-	// JSONWebKeySignatureAlgorithmPS384 - RSASSA-PSS using SHA-384 and MGF1 with SHA-384, as described in
-	// https://tools.ietf.org/html/rfc7518
-	JSONWebKeySignatureAlgorithmPS384 JSONWebKeySignatureAlgorithm = "PS384"
-	// JSONWebKeySignatureAlgorithmPS512 - RSASSA-PSS using SHA-512 and MGF1 with SHA-512, as described in
-	// https://tools.ietf.org/html/rfc7518
-	JSONWebKeySignatureAlgorithmPS512 JSONWebKeySignatureAlgorithm = "PS512"
-	// JSONWebKeySignatureAlgorithmRS256 - RSASSA-PKCS1-v1_5 using SHA-256, as described in
-	// https://tools.ietf.org/html/rfc7518
-	JSONWebKeySignatureAlgorithmRS256 JSONWebKeySignatureAlgorithm = "RS256"
-	// JSONWebKeySignatureAlgorithmRS384 - RSASSA-PKCS1-v1_5 using SHA-384, as described in
-	// https://tools.ietf.org/html/rfc7518
-	JSONWebKeySignatureAlgorithmRS384 JSONWebKeySignatureAlgorithm = "RS384"
-	// JSONWebKeySignatureAlgorithmRS512 - RSASSA-PKCS1-v1_5 using SHA-512, as described in
-	// https://tools.ietf.org/html/rfc7518
-	JSONWebKeySignatureAlgorithmRS512 JSONWebKeySignatureAlgorithm = "RS512"
-	// JSONWebKeySignatureAlgorithmRSNULL - Reserved
-	JSONWebKeySignatureAlgorithmRSNULL JSONWebKeySignatureAlgorithm = "RSNULL"
-)
-
-// PossibleJSONWebKeySignatureAlgorithmValues returns the possible values for the JSONWebKeySignatureAlgorithm const type.
-func PossibleJSONWebKeySignatureAlgorithmValues() []JSONWebKeySignatureAlgorithm {
-	return []JSONWebKeySignatureAlgorithm{
-		JSONWebKeySignatureAlgorithmES256,
-		JSONWebKeySignatureAlgorithmES256K,
-		JSONWebKeySignatureAlgorithmES384,
-		JSONWebKeySignatureAlgorithmES512,
-		JSONWebKeySignatureAlgorithmPS256,
-		JSONWebKeySignatureAlgorithmPS384,
-		JSONWebKeySignatureAlgorithmPS512,
-		JSONWebKeySignatureAlgorithmRS256,
-		JSONWebKeySignatureAlgorithmRS384,
-		JSONWebKeySignatureAlgorithmRS512,
-		JSONWebKeySignatureAlgorithmRSNULL,
-	}
-}
-
-// JSONWebKeyType - JsonWebKey Key Type (kty), as defined in
-// https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.
-type JSONWebKeyType string
-
-const (
-	// JSONWebKeyTypeEC - Elliptic Curve.
-	JSONWebKeyTypeEC JSONWebKeyType = "EC"
-	// JSONWebKeyTypeECHSM - Elliptic Curve with a private key which is stored in the HSM.
-	JSONWebKeyTypeECHSM JSONWebKeyType = "EC-HSM"
-	// JSONWebKeyTypeOct - Octet sequence (used to represent symmetric keys)
-	JSONWebKeyTypeOct JSONWebKeyType = "oct"
-	// JSONWebKeyTypeOctHSM - Octet sequence (used to represent symmetric keys) which is stored the HSM.
-	JSONWebKeyTypeOctHSM JSONWebKeyType = "oct-HSM"
-	// JSONWebKeyTypeRSA - RSA (https://tools.ietf.org/html/rfc3447)
-	JSONWebKeyTypeRSA JSONWebKeyType = "RSA"
-	// JSONWebKeyTypeRSAHSM - RSA with a private key which is stored in the HSM.
-	JSONWebKeyTypeRSAHSM JSONWebKeyType = "RSA-HSM"
-)
-
-// PossibleJSONWebKeyTypeValues returns the possible values for the JSONWebKeyType const type.
-func PossibleJSONWebKeyTypeValues() []JSONWebKeyType {
-	return []JSONWebKeyType{
-		JSONWebKeyTypeEC,
-		JSONWebKeyTypeECHSM,
-		JSONWebKeyTypeOct,
-		JSONWebKeyTypeOctHSM,
-		JSONWebKeyTypeRSA,
-		JSONWebKeyTypeRSAHSM,
+// PossibleEncryptionAlgorithmValues returns the possible values for the EncryptionAlgorithm const type.
+func PossibleEncryptionAlgorithmValues() []EncryptionAlgorithm {
+	return []EncryptionAlgorithm{
+		EncryptionAlgorithmA128CBC,
+		EncryptionAlgorithmA128CBCPAD,
+		EncryptionAlgorithmA128GCM,
+		EncryptionAlgorithmA128KW,
+		EncryptionAlgorithmA192CBC,
+		EncryptionAlgorithmA192CBCPAD,
+		EncryptionAlgorithmA192GCM,
+		EncryptionAlgorithmA192KW,
+		EncryptionAlgorithmA256CBC,
+		EncryptionAlgorithmA256CBCPAD,
+		EncryptionAlgorithmA256GCM,
+		EncryptionAlgorithmA256KW,
+		EncryptionAlgorithmCKMAESKEYWRAP,
+		EncryptionAlgorithmCKMAESKEYWRAPPAD,
+		EncryptionAlgorithmRSA15,
+		EncryptionAlgorithmRSAOAEP,
+		EncryptionAlgorithmRSAOAEP256,
 	}
 }
 
@@ -239,6 +116,42 @@ func PossibleKeyEncryptionAlgorithmValues() []KeyEncryptionAlgorithm {
 	}
 }
 
+// KeyOperation - JSON web key operations. For more information, see JsonWebKeyOperation.
+type KeyOperation string
+
+const (
+	// KeyOperationDecrypt - Indicates that the key can be used to decrypt.
+	KeyOperationDecrypt KeyOperation = "decrypt"
+	// KeyOperationEncrypt - Indicates that the key can be used to encrypt.
+	KeyOperationEncrypt KeyOperation = "encrypt"
+	// KeyOperationExport - Indicates that the private component of the key can be exported.
+	KeyOperationExport KeyOperation = "export"
+	// KeyOperationImport - Indicates that the key can be imported during creation.
+	KeyOperationImport KeyOperation = "import"
+	// KeyOperationSign - Indicates that the key can be used to sign.
+	KeyOperationSign KeyOperation = "sign"
+	// KeyOperationUnwrapKey - Indicates that the key can be used to unwrap another key.
+	KeyOperationUnwrapKey KeyOperation = "unwrapKey"
+	// KeyOperationVerify - Indicates that the key can be used to verify.
+	KeyOperationVerify KeyOperation = "verify"
+	// KeyOperationWrapKey - Indicates that the key can be used to wrap another key.
+	KeyOperationWrapKey KeyOperation = "wrapKey"
+)
+
+// PossibleKeyOperationValues returns the possible values for the KeyOperation const type.
+func PossibleKeyOperationValues() []KeyOperation {
+	return []KeyOperation{
+		KeyOperationDecrypt,
+		KeyOperationEncrypt,
+		KeyOperationExport,
+		KeyOperationImport,
+		KeyOperationSign,
+		KeyOperationUnwrapKey,
+		KeyOperationVerify,
+		KeyOperationWrapKey,
+	}
+}
+
 // KeyRotationPolicyAction - The type of the action. The value should be compared case-insensitively.
 type KeyRotationPolicyAction string
 
@@ -254,5 +167,92 @@ func PossibleKeyRotationPolicyActionValues() []KeyRotationPolicyAction {
 	return []KeyRotationPolicyAction{
 		KeyRotationPolicyActionNotify,
 		KeyRotationPolicyActionRotate,
+	}
+}
+
+// KeyType - JsonWebKey Key Type (kty), as defined in
+// https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.
+type KeyType string
+
+const (
+	// KeyTypeEC - Elliptic Curve.
+	KeyTypeEC KeyType = "EC"
+	// KeyTypeECHSM - Elliptic Curve with a private key which is stored in the HSM.
+	KeyTypeECHSM KeyType = "EC-HSM"
+	// KeyTypeOct - Octet sequence (used to represent symmetric keys)
+	KeyTypeOct KeyType = "oct"
+	// KeyTypeOctHSM - Octet sequence (used to represent symmetric keys) which is stored the HSM.
+	KeyTypeOctHSM KeyType = "oct-HSM"
+	// KeyTypeRSA - RSA (https://tools.ietf.org/html/rfc3447)
+	KeyTypeRSA KeyType = "RSA"
+	// KeyTypeRSAHSM - RSA with a private key which is stored in the HSM.
+	KeyTypeRSAHSM KeyType = "RSA-HSM"
+)
+
+// PossibleKeyTypeValues returns the possible values for the KeyType const type.
+func PossibleKeyTypeValues() []KeyType {
+	return []KeyType{
+		KeyTypeEC,
+		KeyTypeECHSM,
+		KeyTypeOct,
+		KeyTypeOctHSM,
+		KeyTypeRSA,
+		KeyTypeRSAHSM,
+	}
+}
+
+// SignatureAlgorithm - The signing/verification algorithm identifier. For more information on possible
+// algorithm types, see JsonWebKeySignatureAlgorithm.
+type SignatureAlgorithm string
+
+const (
+	// SignatureAlgorithmES256 - ECDSA using P-256 and SHA-256, as described in
+	// https://tools.ietf.org/html/rfc7518.
+	SignatureAlgorithmES256 SignatureAlgorithm = "ES256"
+	// SignatureAlgorithmES256K - ECDSA using P-256K and SHA-256, as described in
+	// https://tools.ietf.org/html/rfc7518
+	SignatureAlgorithmES256K SignatureAlgorithm = "ES256K"
+	// SignatureAlgorithmES384 - ECDSA using P-384 and SHA-384, as described in
+	// https://tools.ietf.org/html/rfc7518
+	SignatureAlgorithmES384 SignatureAlgorithm = "ES384"
+	// SignatureAlgorithmES512 - ECDSA using P-521 and SHA-512, as described in
+	// https://tools.ietf.org/html/rfc7518
+	SignatureAlgorithmES512 SignatureAlgorithm = "ES512"
+	// SignatureAlgorithmPS256 - RSASSA-PSS using SHA-256 and MGF1 with SHA-256, as described in
+	// https://tools.ietf.org/html/rfc7518
+	SignatureAlgorithmPS256 SignatureAlgorithm = "PS256"
+	// SignatureAlgorithmPS384 - RSASSA-PSS using SHA-384 and MGF1 with SHA-384, as described in
+	// https://tools.ietf.org/html/rfc7518
+	SignatureAlgorithmPS384 SignatureAlgorithm = "PS384"
+	// SignatureAlgorithmPS512 - RSASSA-PSS using SHA-512 and MGF1 with SHA-512, as described in
+	// https://tools.ietf.org/html/rfc7518
+	SignatureAlgorithmPS512 SignatureAlgorithm = "PS512"
+	// SignatureAlgorithmRS256 - RSASSA-PKCS1-v1_5 using SHA-256, as described in
+	// https://tools.ietf.org/html/rfc7518
+	SignatureAlgorithmRS256 SignatureAlgorithm = "RS256"
+	// SignatureAlgorithmRS384 - RSASSA-PKCS1-v1_5 using SHA-384, as described in
+	// https://tools.ietf.org/html/rfc7518
+	SignatureAlgorithmRS384 SignatureAlgorithm = "RS384"
+	// SignatureAlgorithmRS512 - RSASSA-PKCS1-v1_5 using SHA-512, as described in
+	// https://tools.ietf.org/html/rfc7518
+	SignatureAlgorithmRS512 SignatureAlgorithm = "RS512"
+	// SignatureAlgorithmRSNULL - Reserved
+	SignatureAlgorithmRSNULL SignatureAlgorithm = "RSNULL"
+)
+
+// PossibleSignatureAlgorithmValues returns the possible values for the SignatureAlgorithm const type.
+func PossibleSignatureAlgorithmValues() []SignatureAlgorithm {
+	return []SignatureAlgorithm{
+		SignatureAlgorithmES256,
+		SignatureAlgorithmES256K,
+		SignatureAlgorithmES384,
+		SignatureAlgorithmES512,
+		SignatureAlgorithmPS256,
+		SignatureAlgorithmPS384,
+		SignatureAlgorithmPS512,
+		SignatureAlgorithmRS256,
+		SignatureAlgorithmRS384,
+		SignatureAlgorithmRS512,
+		SignatureAlgorithmRSNULL,
 	}
 }

--- a/packages/typespec-go/test/local/azkeys/zz_models.go
+++ b/packages/typespec-go/test/local/azkeys/zz_models.go
@@ -12,8 +12,36 @@ type BackupKeyResult struct {
 	Value []byte
 }
 
-// DeletedKeyBundle - A DeletedKeyBundle consisting of a WebKey plus its Attributes and deletion info
-type DeletedKeyBundle struct {
+// CreateKeyParameters - The key create parameters.
+type CreateKeyParameters struct {
+	// REQUIRED; The type of key to create. For valid values, see JsonWebKeyType.
+	Kty *KeyType
+
+	// Elliptic curve name. For valid values, see JsonWebKeyCurveName.
+	Curve *CurveName
+
+	// The attributes of a key managed by the key vault service.
+	KeyAttributes *KeyAttributes
+
+	// Json web key operations. For more information on possible key operations, see
+	// JsonWebKeyOperation.
+	KeyOps []*KeyOperation
+
+	// The key size in bits. For example: 2048, 3072, or 4096 for RSA.
+	KeySize *int32
+
+	// The public exponent for a RSA key.
+	PublicExponent *int32
+
+	// The policy rules under which the key can be exported.
+	ReleasePolicy *KeyReleasePolicy
+
+	// Application specific metadata in the form of key-value pairs.
+	Tags map[string]*string
+}
+
+// DeletedKey - A DeletedKeyBundle consisting of a WebKey plus its Attributes and deletion info
+type DeletedKey struct {
 	// The key management attributes.
 	Attributes *KeyAttributes
 
@@ -40,14 +68,14 @@ type DeletedKeyBundle struct {
 	ScheduledPurgeDate *time.Time
 }
 
-// DeletedKeyItem - The deleted key item containing the deleted key metadata and information about
+// DeletedKeyProperties - The deleted key item containing the deleted key metadata and information about
 // deletion.
-type DeletedKeyItem struct {
+type DeletedKeyProperties struct {
 	// The key management attributes.
 	Attributes *KeyAttributes
 
 	// Key identifier.
-	Kid *string
+	KID *string
 
 	// The url of the recovery object, used to identify and recover the deleted key.
 	RecoveryID *string
@@ -66,35 +94,53 @@ type DeletedKeyItem struct {
 	ScheduledPurgeDate *time.Time
 }
 
-// DeletedKeyListResult - A list of keys that have been deleted in this vault.
-type DeletedKeyListResult struct {
+// DeletedKeyPropertiesListResult - A list of keys that have been deleted in this vault.
+type DeletedKeyPropertiesListResult struct {
 	// READ-ONLY; The URL to get the next set of deleted keys.
 	NextLink *string
 
 	// READ-ONLY; A response message containing a list of deleted keys in the key vault along with a link to the next page of
 	// deleted keys.
-	Value []*DeletedKeyItem
+	Value []*DeletedKeyProperties
 }
 
-// GetRandomBytesRequest - The get random bytes request object.
-type GetRandomBytesRequest struct {
+// GetRandomBytesParameters - The get random bytes request object.
+type GetRandomBytesParameters struct {
 	// REQUIRED; The requested number of random bytes.
 	Count *int32
+}
+
+// ImportKeyParameters - The key import parameters.
+type ImportKeyParameters struct {
+	// REQUIRED; The Json web key
+	Key *JSONWebKey
+
+	// Whether to import as a hardware key (HSM) or software key.
+	HSM *bool
+
+	// The key management attributes.
+	KeyAttributes *KeyAttributes
+
+	// The policy rules under which the key can be exported.
+	ReleasePolicy *KeyReleasePolicy
+
+	// Application specific metadata in the form of key-value pairs.
+	Tags map[string]*string
 }
 
 // JSONWebKey - As of http://tools.ietf.org/html/draft-ietf-jose-json-web-key-18
 type JSONWebKey struct {
 	// Elliptic curve name. For valid values, see JsonWebKeyCurveName.
-	Crv *JSONWebKeyCurveName
+	Crv *CurveName
 
 	// RSA private exponent, or the D component of an EC private key.
 	D []byte
 
 	// RSA private key parameter.
-	Dp []byte
+	DP []byte
 
 	// RSA private key parameter.
-	Dq []byte
+	DQ []byte
 
 	// RSA public exponent.
 	E []byte
@@ -102,16 +148,16 @@ type JSONWebKey struct {
 	// Symmetric key.
 	K []byte
 
+	// Key identifier.
+	KID *string
+
 	// Json web key operations. For more information on possible key operations, see
 	// JsonWebKeyOperation.
 	KeyOps []*string
 
-	// Key identifier.
-	Kid *string
-
 	// JsonWebKey Key Type (kty), as defined in
 	// https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.
-	Kty *JSONWebKeyType
+	Kty *KeyType
 
 	// RSA modulus.
 	N []byte
@@ -123,7 +169,7 @@ type JSONWebKey struct {
 	Q []byte
 
 	// RSA private key parameter.
-	Qi []byte
+	QI []byte
 
 	// Protected Key, used with 'Bring Your Own Key'.
 	T []byte
@@ -154,7 +200,7 @@ type KeyAttributes struct {
 	Created *time.Time
 
 	// READ-ONLY; The underlying HSM Platform.
-	HsmPlatform *string
+	HSMPlatform *string
 
 	// READ-ONLY; softDelete data retention days. Value should be >=7 and <=90 when softDelete
 	// enabled, otherwise 0.
@@ -189,75 +235,25 @@ type KeyBundle struct {
 	Managed *bool
 }
 
-// KeyCreateParameters - The key create parameters.
-type KeyCreateParameters struct {
-	// REQUIRED; The type of key to create. For valid values, see JsonWebKeyType.
-	Kty *JSONWebKeyType
+// KeyOperationParameters - The key operations parameters.
+type KeyOperationParameters struct {
+	// REQUIRED; algorithm identifier
+	Algorithm *EncryptionAlgorithm
 
-	// Elliptic curve name. For valid values, see JsonWebKeyCurveName.
-	Curve *JSONWebKeyCurveName
+	// REQUIRED; The value to operate on.
+	Value []byte
 
-	// The attributes of a key managed by the key vault service.
-	KeyAttributes *KeyAttributes
+	// Additional data to authenticate but not encrypt/decrypt when using
+	// authenticated crypto algorithms.
+	AdditionalAuthenticatedData []byte
 
-	// Json web key operations. For more information on possible key operations, see
-	// JsonWebKeyOperation.
-	KeyOps []*JSONWebKeyOperation
+	// The tag to authenticate when performing decryption with an authenticated
+	// algorithm.
+	AuthenticationTag []byte
 
-	// The key size in bits. For example: 2048, 3072, or 4096 for RSA.
-	KeySize *int32
-
-	// The public exponent for a RSA key.
-	PublicExponent *int32
-
-	// The policy rules under which the key can be exported.
-	ReleasePolicy *KeyReleasePolicy
-
-	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string
-}
-
-// KeyImportParameters - The key import parameters.
-type KeyImportParameters struct {
-	// REQUIRED; The Json web key
-	Key *JSONWebKey
-
-	// Whether to import as a hardware key (HSM) or software key.
-	Hsm *bool
-
-	// The key management attributes.
-	KeyAttributes *KeyAttributes
-
-	// The policy rules under which the key can be exported.
-	ReleasePolicy *KeyReleasePolicy
-
-	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string
-}
-
-// KeyItem - The key item containing key metadata.
-type KeyItem struct {
-	// The key management attributes.
-	Attributes *KeyAttributes
-
-	// Key identifier.
-	Kid *string
-
-	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string
-
-	// READ-ONLY; True if the key's lifetime is managed by key vault. If this is a key backing a
-	// certificate, then managed will be true.
-	Managed *bool
-}
-
-// KeyListResult - The key list result.
-type KeyListResult struct {
-	// READ-ONLY; The URL to get the next set of keys.
-	NextLink *string
-
-	// READ-ONLY; A response message containing a list of keys in the key vault along with a link to the next page of keys.
-	Value []*KeyItem
+	// Cryptographically random, non-repeating initialization vector for symmetric
+	// algorithms.
+	IV []byte
 }
 
 // KeyOperationResult - The key operation result.
@@ -272,46 +268,38 @@ type KeyOperationResult struct {
 
 	// READ-ONLY; Cryptographically random, non-repeating initialization vector for symmetric
 	// algorithms.
-	Iv []byte
+	IV []byte
 
 	// READ-ONLY; Key identifier
-	Kid *string
+	KID *string
 
 	// READ-ONLY; The result of the operation.
 	Result []byte
 }
 
-// KeyOperationsParameters - The key operations parameters.
-type KeyOperationsParameters struct {
-	// REQUIRED; algorithm identifier
-	Algorithm *JSONWebKeyEncryptionAlgorithm
+// KeyProperties - The key item containing key metadata.
+type KeyProperties struct {
+	// The key management attributes.
+	Attributes *KeyAttributes
 
-	// REQUIRED; The value to operate on.
-	Value []byte
+	// Key identifier.
+	KID *string
 
-	// Additional data to authenticate but not encrypt/decrypt when using
-	// authenticated crypto algorithms.
-	AAD []byte
+	// Application specific metadata in the form of key-value pairs.
+	Tags map[string]*string
 
-	// Cryptographically random, non-repeating initialization vector for symmetric
-	// algorithms.
-	Iv []byte
-
-	// The tag to authenticate when performing decryption with an authenticated
-	// algorithm.
-	Tag []byte
+	// READ-ONLY; True if the key's lifetime is managed by key vault. If this is a key backing a
+	// certificate, then managed will be true.
+	Managed *bool
 }
 
-// KeyReleaseParameters - The release key parameters.
-type KeyReleaseParameters struct {
-	// REQUIRED; The attestation assertion for the target of the key release.
-	TargetAttestationToken *string
+// KeyPropertiesListResult - The key list result.
+type KeyPropertiesListResult struct {
+	// READ-ONLY; The URL to get the next set of keys.
+	NextLink *string
 
-	// The encryption algorithm to use to protected the exported key material
-	Enc *KeyEncryptionAlgorithm
-
-	// A client provided nonce for freshness.
-	Nonce *string
+	// READ-ONLY; A response message containing a list of keys in the key vault along with a link to the next page of keys.
+	Value []*KeyProperties
 }
 
 // KeyReleasePolicy - The policy rules under which the key can be exported.
@@ -334,12 +322,6 @@ type KeyReleaseResult struct {
 	Value *string
 }
 
-// KeyRestoreParameters - The key restore parameters.
-type KeyRestoreParameters struct {
-	// REQUIRED; The backup blob associated with a key bundle.
-	KeyBundleBackup []byte
-}
-
 // KeyRotationPolicy - Management policy for a key.
 type KeyRotationPolicy struct {
 	// The key rotation policy attributes.
@@ -349,7 +331,7 @@ type KeyRotationPolicy struct {
 	// preview, lifetimeActions can only have two items at maximum: one for rotate,
 	// one for notify. Notification time would be default to 30 days before expiry and
 	// it is not configurable.
-	LifetimeActions []*LifetimeActions
+	LifetimeActions []*LifetimeAction
 
 	// READ-ONLY; The key policy id.
 	ID *string
@@ -369,63 +351,24 @@ type KeyRotationPolicyAttributes struct {
 	Updated *time.Time
 }
 
-// KeySignParameters - The key operations parameters.
-type KeySignParameters struct {
-	// REQUIRED; The signing/verification algorithm identifier. For more information on possible
-	// algorithm types, see JsonWebKeySignatureAlgorithm.
-	Algorithm *JSONWebKeySignatureAlgorithm
-
-	// REQUIRED; The value to operate on.
-	Value []byte
-}
-
-// KeyUpdateParameters - The key update parameters.
-type KeyUpdateParameters struct {
-	// The attributes of a key managed by the key vault service.
-	KeyAttributes *KeyAttributes
-
-	// Json web key operations. For more information on possible key operations, see
-	// JsonWebKeyOperation.
-	KeyOps []*JSONWebKeyOperation
-
-	// The policy rules under which the key can be exported.
-	ReleasePolicy *KeyReleasePolicy
-
-	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string
-}
-
-// KeyVerifyParameters - The key verify parameters.
-type KeyVerifyParameters struct {
-	// REQUIRED; The signing/verification algorithm. For more information on possible algorithm
-	// types, see JsonWebKeySignatureAlgorithm.
-	Algorithm *JSONWebKeySignatureAlgorithm
-
-	// REQUIRED; The digest used for signing.
-	Digest []byte
-
-	// REQUIRED; The signature to be verified.
-	Signature []byte
-}
-
 // KeyVerifyResult - The key verify result.
 type KeyVerifyResult struct {
 	// READ-ONLY; True if the signature is verified, otherwise false.
 	Value *bool
 }
 
-// LifetimeActions - Action and its trigger that will be performed by Key Vault over the lifetime of
+// LifetimeAction - Action and its trigger that will be performed by Key Vault over the lifetime of
 // a key.
-type LifetimeActions struct {
+type LifetimeAction struct {
 	// The action that will be executed.
-	Action *LifetimeActionsType
+	Action *LifetimeActionType
 
 	// The condition that will execute the action.
-	Trigger *LifetimeActionsTrigger
+	Trigger *LifetimeActionTrigger
 }
 
-// LifetimeActionsTrigger - A condition to be satisfied for an action to be executed.
-type LifetimeActionsTrigger struct {
+// LifetimeActionTrigger - A condition to be satisfied for an action to be executed.
+type LifetimeActionTrigger struct {
 	// Time after creation to attempt to rotate. It only applies to rotate. It will be
 	// in ISO 8601 duration format. Example: 90 days : "P90D"
 	TimeAfterCreate *string
@@ -435,8 +378,8 @@ type LifetimeActionsTrigger struct {
 	TimeBeforeExpiry *string
 }
 
-// LifetimeActionsType - The action that will be executed.
-type LifetimeActionsType struct {
+// LifetimeActionType - The action that will be executed.
+type LifetimeActionType struct {
 	// The type of the action. The value should be compared case-insensitively.
 	Type *KeyRotationPolicyAction
 }
@@ -445,4 +388,61 @@ type LifetimeActionsType struct {
 type RandomBytes struct {
 	// REQUIRED; The bytes encoded as a base64url string.
 	Value []byte
+}
+
+// ReleaseParameters - The release key parameters.
+type ReleaseParameters struct {
+	// REQUIRED; The attestation assertion for the target of the key release.
+	TargetAttestationToken *string
+
+	// The encryption algorithm to use to protected the exported key material
+	Algorithm *KeyEncryptionAlgorithm
+
+	// A client provided nonce for freshness.
+	Nonce *string
+}
+
+// RestoreKeyParameters - The key restore parameters.
+type RestoreKeyParameters struct {
+	// REQUIRED; The backup blob associated with a key bundle.
+	KeyBackup []byte
+}
+
+// SignParameters - The key operations parameters.
+type SignParameters struct {
+	// REQUIRED; The signing/verification algorithm identifier. For more information on possible
+	// algorithm types, see JsonWebKeySignatureAlgorithm.
+	Algorithm *SignatureAlgorithm
+
+	// REQUIRED; The value to operate on.
+	Value []byte
+}
+
+// UpdateKeyParameters - The key update parameters.
+type UpdateKeyParameters struct {
+	// The attributes of a key managed by the key vault service.
+	KeyAttributes *KeyAttributes
+
+	// Json web key operations. For more information on possible key operations, see
+	// JsonWebKeyOperation.
+	KeyOps []*KeyOperation
+
+	// The policy rules under which the key can be exported.
+	ReleasePolicy *KeyReleasePolicy
+
+	// Application specific metadata in the form of key-value pairs.
+	Tags map[string]*string
+}
+
+// VerifyParameters - The key verify parameters.
+type VerifyParameters struct {
+	// REQUIRED; The signing/verification algorithm. For more information on possible algorithm
+	// types, see JsonWebKeySignatureAlgorithm.
+	Algorithm *SignatureAlgorithm
+
+	// REQUIRED; The digest used for signing.
+	Digest []byte
+
+	// REQUIRED; The signature to be verified.
+	Signature []byte
 }

--- a/packages/typespec-go/test/local/azkeys/zz_models_serde.go
+++ b/packages/typespec-go/test/local/azkeys/zz_models_serde.go
@@ -43,8 +43,63 @@ func (b *BackupKeyResult) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type DeletedKeyBundle.
-func (d DeletedKeyBundle) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type CreateKeyParameters.
+func (c CreateKeyParameters) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "crv", c.Curve)
+	populate(objectMap, "attributes", c.KeyAttributes)
+	populate(objectMap, "key_ops", c.KeyOps)
+	populate(objectMap, "key_size", c.KeySize)
+	populate(objectMap, "kty", c.Kty)
+	populate(objectMap, "public_exponent", c.PublicExponent)
+	populate(objectMap, "release_policy", c.ReleasePolicy)
+	populate(objectMap, "tags", c.Tags)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type CreateKeyParameters.
+func (c *CreateKeyParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", c, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "crv":
+			err = unpopulate(val, "Curve", &c.Curve)
+			delete(rawMsg, key)
+		case "attributes":
+			err = unpopulate(val, "KeyAttributes", &c.KeyAttributes)
+			delete(rawMsg, key)
+		case "key_ops":
+			err = unpopulate(val, "KeyOps", &c.KeyOps)
+			delete(rawMsg, key)
+		case "key_size":
+			err = unpopulate(val, "KeySize", &c.KeySize)
+			delete(rawMsg, key)
+		case "kty":
+			err = unpopulate(val, "Kty", &c.Kty)
+			delete(rawMsg, key)
+		case "public_exponent":
+			err = unpopulate(val, "PublicExponent", &c.PublicExponent)
+			delete(rawMsg, key)
+		case "release_policy":
+			err = unpopulate(val, "ReleasePolicy", &c.ReleasePolicy)
+			delete(rawMsg, key)
+		case "tags":
+			err = unpopulate(val, "Tags", &c.Tags)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", c, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DeletedKey.
+func (d DeletedKey) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "attributes", d.Attributes)
 	populateTimeUnix(objectMap, "deletedDate", d.DeletedDate)
@@ -57,8 +112,8 @@ func (d DeletedKeyBundle) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type DeletedKeyBundle.
-func (d *DeletedKeyBundle) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type DeletedKey.
+func (d *DeletedKey) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return fmt.Errorf("unmarshalling type %T: %v", d, err)
@@ -98,12 +153,12 @@ func (d *DeletedKeyBundle) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type DeletedKeyItem.
-func (d DeletedKeyItem) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type DeletedKeyProperties.
+func (d DeletedKeyProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "attributes", d.Attributes)
 	populateTimeUnix(objectMap, "deletedDate", d.DeletedDate)
-	populate(objectMap, "kid", d.Kid)
+	populate(objectMap, "kid", d.KID)
 	populate(objectMap, "managed", d.Managed)
 	populate(objectMap, "recoveryId", d.RecoveryID)
 	populateTimeUnix(objectMap, "scheduledPurgeDate", d.ScheduledPurgeDate)
@@ -111,8 +166,8 @@ func (d DeletedKeyItem) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type DeletedKeyItem.
-func (d *DeletedKeyItem) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type DeletedKeyProperties.
+func (d *DeletedKeyProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return fmt.Errorf("unmarshalling type %T: %v", d, err)
@@ -127,7 +182,7 @@ func (d *DeletedKeyItem) UnmarshalJSON(data []byte) error {
 			err = unpopulateTimeUnix(val, "DeletedDate", &d.DeletedDate)
 			delete(rawMsg, key)
 		case "kid":
-			err = unpopulate(val, "Kid", &d.Kid)
+			err = unpopulate(val, "KID", &d.KID)
 			delete(rawMsg, key)
 		case "managed":
 			err = unpopulate(val, "Managed", &d.Managed)
@@ -149,16 +204,16 @@ func (d *DeletedKeyItem) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type DeletedKeyListResult.
-func (d DeletedKeyListResult) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type DeletedKeyPropertiesListResult.
+func (d DeletedKeyPropertiesListResult) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "nextLink", d.NextLink)
 	populate(objectMap, "value", d.Value)
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type DeletedKeyListResult.
-func (d *DeletedKeyListResult) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type DeletedKeyPropertiesListResult.
+func (d *DeletedKeyPropertiesListResult) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return fmt.Errorf("unmarshalling type %T: %v", d, err)
@@ -180,15 +235,15 @@ func (d *DeletedKeyListResult) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type GetRandomBytesRequest.
-func (g GetRandomBytesRequest) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type GetRandomBytesParameters.
+func (g GetRandomBytesParameters) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "count", g.Count)
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type GetRandomBytesRequest.
-func (g *GetRandomBytesRequest) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type GetRandomBytesParameters.
+func (g *GetRandomBytesParameters) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return fmt.Errorf("unmarshalling type %T: %v", g, err)
@@ -207,6 +262,49 @@ func (g *GetRandomBytesRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ImportKeyParameters.
+func (i ImportKeyParameters) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "Hsm", i.HSM)
+	populate(objectMap, "key", i.Key)
+	populate(objectMap, "attributes", i.KeyAttributes)
+	populate(objectMap, "release_policy", i.ReleasePolicy)
+	populate(objectMap, "tags", i.Tags)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ImportKeyParameters.
+func (i *ImportKeyParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", i, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "Hsm":
+			err = unpopulate(val, "HSM", &i.HSM)
+			delete(rawMsg, key)
+		case "key":
+			err = unpopulate(val, "Key", &i.Key)
+			delete(rawMsg, key)
+		case "attributes":
+			err = unpopulate(val, "KeyAttributes", &i.KeyAttributes)
+			delete(rawMsg, key)
+		case "release_policy":
+			err = unpopulate(val, "ReleasePolicy", &i.ReleasePolicy)
+			delete(rawMsg, key)
+		case "tags":
+			err = unpopulate(val, "Tags", &i.Tags)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", i, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type JSONWebKey.
 func (j JSONWebKey) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -214,11 +312,11 @@ func (j JSONWebKey) MarshalJSON() ([]byte, error) {
 	populateByteArray(objectMap, "d", j.D, func() any {
 		return runtime.EncodeByteArray(j.D, runtime.Base64URLFormat)
 	})
-	populateByteArray(objectMap, "dp", j.Dp, func() any {
-		return runtime.EncodeByteArray(j.Dp, runtime.Base64URLFormat)
+	populateByteArray(objectMap, "dp", j.DP, func() any {
+		return runtime.EncodeByteArray(j.DP, runtime.Base64URLFormat)
 	})
-	populateByteArray(objectMap, "dq", j.Dq, func() any {
-		return runtime.EncodeByteArray(j.Dq, runtime.Base64URLFormat)
+	populateByteArray(objectMap, "dq", j.DQ, func() any {
+		return runtime.EncodeByteArray(j.DQ, runtime.Base64URLFormat)
 	})
 	populateByteArray(objectMap, "e", j.E, func() any {
 		return runtime.EncodeByteArray(j.E, runtime.Base64URLFormat)
@@ -226,8 +324,8 @@ func (j JSONWebKey) MarshalJSON() ([]byte, error) {
 	populateByteArray(objectMap, "k", j.K, func() any {
 		return runtime.EncodeByteArray(j.K, runtime.Base64URLFormat)
 	})
+	populate(objectMap, "kid", j.KID)
 	populate(objectMap, "key_ops", j.KeyOps)
-	populate(objectMap, "kid", j.Kid)
 	populate(objectMap, "kty", j.Kty)
 	populateByteArray(objectMap, "n", j.N, func() any {
 		return runtime.EncodeByteArray(j.N, runtime.Base64URLFormat)
@@ -238,8 +336,8 @@ func (j JSONWebKey) MarshalJSON() ([]byte, error) {
 	populateByteArray(objectMap, "q", j.Q, func() any {
 		return runtime.EncodeByteArray(j.Q, runtime.Base64URLFormat)
 	})
-	populateByteArray(objectMap, "qi", j.Qi, func() any {
-		return runtime.EncodeByteArray(j.Qi, runtime.Base64URLFormat)
+	populateByteArray(objectMap, "qi", j.QI, func() any {
+		return runtime.EncodeByteArray(j.QI, runtime.Base64URLFormat)
 	})
 	populateByteArray(objectMap, "key_hsm", j.T, func() any {
 		return runtime.EncodeByteArray(j.T, runtime.Base64URLFormat)
@@ -272,12 +370,12 @@ func (j *JSONWebKey) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "dp":
 			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &j.Dp, runtime.Base64URLFormat)
+				err = runtime.DecodeByteArray(string(val), &j.DP, runtime.Base64URLFormat)
 			}
 			delete(rawMsg, key)
 		case "dq":
 			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &j.Dq, runtime.Base64URLFormat)
+				err = runtime.DecodeByteArray(string(val), &j.DQ, runtime.Base64URLFormat)
 			}
 			delete(rawMsg, key)
 		case "e":
@@ -290,11 +388,11 @@ func (j *JSONWebKey) UnmarshalJSON(data []byte) error {
 				err = runtime.DecodeByteArray(string(val), &j.K, runtime.Base64URLFormat)
 			}
 			delete(rawMsg, key)
+		case "kid":
+			err = unpopulate(val, "KID", &j.KID)
+			delete(rawMsg, key)
 		case "key_ops":
 			err = unpopulate(val, "KeyOps", &j.KeyOps)
-			delete(rawMsg, key)
-		case "kid":
-			err = unpopulate(val, "Kid", &j.Kid)
 			delete(rawMsg, key)
 		case "kty":
 			err = unpopulate(val, "Kty", &j.Kty)
@@ -316,7 +414,7 @@ func (j *JSONWebKey) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "qi":
 			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &j.Qi, runtime.Base64URLFormat)
+				err = runtime.DecodeByteArray(string(val), &j.QI, runtime.Base64URLFormat)
 			}
 			delete(rawMsg, key)
 		case "key_hsm":
@@ -349,7 +447,7 @@ func (k KeyAttributes) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "enabled", k.Enabled)
 	populateTimeUnix(objectMap, "exp", k.Expires)
 	populate(objectMap, "exportable", k.Exportable)
-	populate(objectMap, "hsmPlatform", k.HsmPlatform)
+	populate(objectMap, "hsmPlatform", k.HSMPlatform)
 	populateTimeUnix(objectMap, "nbf", k.NotBefore)
 	populate(objectMap, "recoverableDays", k.RecoverableDays)
 	populate(objectMap, "recoveryLevel", k.RecoveryLevel)
@@ -379,7 +477,7 @@ func (k *KeyAttributes) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "Exportable", &k.Exportable)
 			delete(rawMsg, key)
 		case "hsmPlatform":
-			err = unpopulate(val, "HsmPlatform", &k.HsmPlatform)
+			err = unpopulate(val, "HSMPlatform", &k.HSMPlatform)
 			delete(rawMsg, key)
 		case "nbf":
 			err = unpopulateTimeUnix(val, "NotBefore", &k.NotBefore)
@@ -444,22 +542,27 @@ func (k *KeyBundle) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type KeyCreateParameters.
-func (k KeyCreateParameters) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type KeyOperationParameters.
+func (k KeyOperationParameters) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "crv", k.Curve)
-	populate(objectMap, "attributes", k.KeyAttributes)
-	populate(objectMap, "key_ops", k.KeyOps)
-	populate(objectMap, "key_size", k.KeySize)
-	populate(objectMap, "kty", k.Kty)
-	populate(objectMap, "public_exponent", k.PublicExponent)
-	populate(objectMap, "release_policy", k.ReleasePolicy)
-	populate(objectMap, "tags", k.Tags)
+	populateByteArray(objectMap, "aad", k.AdditionalAuthenticatedData, func() any {
+		return runtime.EncodeByteArray(k.AdditionalAuthenticatedData, runtime.Base64URLFormat)
+	})
+	populate(objectMap, "alg", k.Algorithm)
+	populateByteArray(objectMap, "tag", k.AuthenticationTag, func() any {
+		return runtime.EncodeByteArray(k.AuthenticationTag, runtime.Base64URLFormat)
+	})
+	populateByteArray(objectMap, "iv", k.IV, func() any {
+		return runtime.EncodeByteArray(k.IV, runtime.Base64URLFormat)
+	})
+	populateByteArray(objectMap, "value", k.Value, func() any {
+		return runtime.EncodeByteArray(k.Value, runtime.Base64URLFormat)
+	})
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type KeyCreateParameters.
-func (k *KeyCreateParameters) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type KeyOperationParameters.
+func (k *KeyOperationParameters) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return fmt.Errorf("unmarshalling type %T: %v", k, err)
@@ -467,142 +570,28 @@ func (k *KeyCreateParameters) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "crv":
-			err = unpopulate(val, "Curve", &k.Curve)
+		case "aad":
+			if val != nil && string(val) != "null" {
+				err = runtime.DecodeByteArray(string(val), &k.AdditionalAuthenticatedData, runtime.Base64URLFormat)
+			}
 			delete(rawMsg, key)
-		case "attributes":
-			err = unpopulate(val, "KeyAttributes", &k.KeyAttributes)
+		case "alg":
+			err = unpopulate(val, "Algorithm", &k.Algorithm)
 			delete(rawMsg, key)
-		case "key_ops":
-			err = unpopulate(val, "KeyOps", &k.KeyOps)
+		case "tag":
+			if val != nil && string(val) != "null" {
+				err = runtime.DecodeByteArray(string(val), &k.AuthenticationTag, runtime.Base64URLFormat)
+			}
 			delete(rawMsg, key)
-		case "key_size":
-			err = unpopulate(val, "KeySize", &k.KeySize)
-			delete(rawMsg, key)
-		case "kty":
-			err = unpopulate(val, "Kty", &k.Kty)
-			delete(rawMsg, key)
-		case "public_exponent":
-			err = unpopulate(val, "PublicExponent", &k.PublicExponent)
-			delete(rawMsg, key)
-		case "release_policy":
-			err = unpopulate(val, "ReleasePolicy", &k.ReleasePolicy)
-			delete(rawMsg, key)
-		case "tags":
-			err = unpopulate(val, "Tags", &k.Tags)
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", k, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type KeyImportParameters.
-func (k KeyImportParameters) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "Hsm", k.Hsm)
-	populate(objectMap, "key", k.Key)
-	populate(objectMap, "attributes", k.KeyAttributes)
-	populate(objectMap, "release_policy", k.ReleasePolicy)
-	populate(objectMap, "tags", k.Tags)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type KeyImportParameters.
-func (k *KeyImportParameters) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", k, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "Hsm":
-			err = unpopulate(val, "Hsm", &k.Hsm)
-			delete(rawMsg, key)
-		case "key":
-			err = unpopulate(val, "Key", &k.Key)
-			delete(rawMsg, key)
-		case "attributes":
-			err = unpopulate(val, "KeyAttributes", &k.KeyAttributes)
-			delete(rawMsg, key)
-		case "release_policy":
-			err = unpopulate(val, "ReleasePolicy", &k.ReleasePolicy)
-			delete(rawMsg, key)
-		case "tags":
-			err = unpopulate(val, "Tags", &k.Tags)
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", k, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type KeyItem.
-func (k KeyItem) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "attributes", k.Attributes)
-	populate(objectMap, "kid", k.Kid)
-	populate(objectMap, "managed", k.Managed)
-	populate(objectMap, "tags", k.Tags)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type KeyItem.
-func (k *KeyItem) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", k, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "attributes":
-			err = unpopulate(val, "Attributes", &k.Attributes)
-			delete(rawMsg, key)
-		case "kid":
-			err = unpopulate(val, "Kid", &k.Kid)
-			delete(rawMsg, key)
-		case "managed":
-			err = unpopulate(val, "Managed", &k.Managed)
-			delete(rawMsg, key)
-		case "tags":
-			err = unpopulate(val, "Tags", &k.Tags)
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", k, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type KeyListResult.
-func (k KeyListResult) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "nextLink", k.NextLink)
-	populate(objectMap, "value", k.Value)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type KeyListResult.
-func (k *KeyListResult) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", k, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "nextLink":
-			err = unpopulate(val, "NextLink", &k.NextLink)
+		case "iv":
+			if val != nil && string(val) != "null" {
+				err = runtime.DecodeByteArray(string(val), &k.IV, runtime.Base64URLFormat)
+			}
 			delete(rawMsg, key)
 		case "value":
-			err = unpopulate(val, "Value", &k.Value)
+			if val != nil && string(val) != "null" {
+				err = runtime.DecodeByteArray(string(val), &k.Value, runtime.Base64URLFormat)
+			}
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -621,10 +610,10 @@ func (k KeyOperationResult) MarshalJSON() ([]byte, error) {
 	populateByteArray(objectMap, "tag", k.AuthenticationTag, func() any {
 		return runtime.EncodeByteArray(k.AuthenticationTag, runtime.Base64URLFormat)
 	})
-	populateByteArray(objectMap, "iv", k.Iv, func() any {
-		return runtime.EncodeByteArray(k.Iv, runtime.Base64URLFormat)
+	populateByteArray(objectMap, "iv", k.IV, func() any {
+		return runtime.EncodeByteArray(k.IV, runtime.Base64URLFormat)
 	})
-	populate(objectMap, "kid", k.Kid)
+	populate(objectMap, "kid", k.KID)
 	populateByteArray(objectMap, "value", k.Result, func() any {
 		return runtime.EncodeByteArray(k.Result, runtime.Base64URLFormat)
 	})
@@ -652,11 +641,11 @@ func (k *KeyOperationResult) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "iv":
 			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &k.Iv, runtime.Base64URLFormat)
+				err = runtime.DecodeByteArray(string(val), &k.IV, runtime.Base64URLFormat)
 			}
 			delete(rawMsg, key)
 		case "kid":
-			err = unpopulate(val, "Kid", &k.Kid)
+			err = unpopulate(val, "KID", &k.KID)
 			delete(rawMsg, key)
 		case "value":
 			if val != nil && string(val) != "null" {
@@ -671,27 +660,18 @@ func (k *KeyOperationResult) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type KeyOperationsParameters.
-func (k KeyOperationsParameters) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type KeyProperties.
+func (k KeyProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populateByteArray(objectMap, "aad", k.AAD, func() any {
-		return runtime.EncodeByteArray(k.AAD, runtime.Base64URLFormat)
-	})
-	populate(objectMap, "alg", k.Algorithm)
-	populateByteArray(objectMap, "iv", k.Iv, func() any {
-		return runtime.EncodeByteArray(k.Iv, runtime.Base64URLFormat)
-	})
-	populateByteArray(objectMap, "tag", k.Tag, func() any {
-		return runtime.EncodeByteArray(k.Tag, runtime.Base64URLFormat)
-	})
-	populateByteArray(objectMap, "value", k.Value, func() any {
-		return runtime.EncodeByteArray(k.Value, runtime.Base64URLFormat)
-	})
+	populate(objectMap, "attributes", k.Attributes)
+	populate(objectMap, "kid", k.KID)
+	populate(objectMap, "managed", k.Managed)
+	populate(objectMap, "tags", k.Tags)
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type KeyOperationsParameters.
-func (k *KeyOperationsParameters) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type KeyProperties.
+func (k *KeyProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return fmt.Errorf("unmarshalling type %T: %v", k, err)
@@ -699,28 +679,17 @@ func (k *KeyOperationsParameters) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "aad":
-			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &k.AAD, runtime.Base64URLFormat)
-			}
+		case "attributes":
+			err = unpopulate(val, "Attributes", &k.Attributes)
 			delete(rawMsg, key)
-		case "alg":
-			err = unpopulate(val, "Algorithm", &k.Algorithm)
+		case "kid":
+			err = unpopulate(val, "KID", &k.KID)
 			delete(rawMsg, key)
-		case "iv":
-			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &k.Iv, runtime.Base64URLFormat)
-			}
+		case "managed":
+			err = unpopulate(val, "Managed", &k.Managed)
 			delete(rawMsg, key)
-		case "tag":
-			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &k.Tag, runtime.Base64URLFormat)
-			}
-			delete(rawMsg, key)
-		case "value":
-			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &k.Value, runtime.Base64URLFormat)
-			}
+		case "tags":
+			err = unpopulate(val, "Tags", &k.Tags)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -730,17 +699,16 @@ func (k *KeyOperationsParameters) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type KeyReleaseParameters.
-func (k KeyReleaseParameters) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type KeyPropertiesListResult.
+func (k KeyPropertiesListResult) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "enc", k.Enc)
-	populate(objectMap, "nonce", k.Nonce)
-	populate(objectMap, "target", k.TargetAttestationToken)
+	populate(objectMap, "nextLink", k.NextLink)
+	populate(objectMap, "value", k.Value)
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type KeyReleaseParameters.
-func (k *KeyReleaseParameters) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type KeyPropertiesListResult.
+func (k *KeyPropertiesListResult) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return fmt.Errorf("unmarshalling type %T: %v", k, err)
@@ -748,14 +716,11 @@ func (k *KeyReleaseParameters) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "enc":
-			err = unpopulate(val, "Enc", &k.Enc)
+		case "nextLink":
+			err = unpopulate(val, "NextLink", &k.NextLink)
 			delete(rawMsg, key)
-		case "nonce":
-			err = unpopulate(val, "Nonce", &k.Nonce)
-			delete(rawMsg, key)
-		case "target":
-			err = unpopulate(val, "TargetAttestationToken", &k.TargetAttestationToken)
+		case "value":
+			err = unpopulate(val, "Value", &k.Value)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -822,37 +787,6 @@ func (k *KeyReleaseResult) UnmarshalJSON(data []byte) error {
 		switch key {
 		case "value":
 			err = unpopulate(val, "Value", &k.Value)
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", k, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type KeyRestoreParameters.
-func (k KeyRestoreParameters) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populateByteArray(objectMap, "value", k.KeyBundleBackup, func() any {
-		return runtime.EncodeByteArray(k.KeyBundleBackup, runtime.Base64URLFormat)
-	})
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type KeyRestoreParameters.
-func (k *KeyRestoreParameters) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", k, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "value":
-			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &k.KeyBundleBackup, runtime.Base64URLFormat)
-			}
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -932,123 +866,6 @@ func (k *KeyRotationPolicyAttributes) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type KeySignParameters.
-func (k KeySignParameters) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "alg", k.Algorithm)
-	populateByteArray(objectMap, "value", k.Value, func() any {
-		return runtime.EncodeByteArray(k.Value, runtime.Base64URLFormat)
-	})
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type KeySignParameters.
-func (k *KeySignParameters) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", k, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "alg":
-			err = unpopulate(val, "Algorithm", &k.Algorithm)
-			delete(rawMsg, key)
-		case "value":
-			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &k.Value, runtime.Base64URLFormat)
-			}
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", k, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type KeyUpdateParameters.
-func (k KeyUpdateParameters) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "attributes", k.KeyAttributes)
-	populate(objectMap, "key_ops", k.KeyOps)
-	populate(objectMap, "release_policy", k.ReleasePolicy)
-	populate(objectMap, "tags", k.Tags)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type KeyUpdateParameters.
-func (k *KeyUpdateParameters) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", k, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "attributes":
-			err = unpopulate(val, "KeyAttributes", &k.KeyAttributes)
-			delete(rawMsg, key)
-		case "key_ops":
-			err = unpopulate(val, "KeyOps", &k.KeyOps)
-			delete(rawMsg, key)
-		case "release_policy":
-			err = unpopulate(val, "ReleasePolicy", &k.ReleasePolicy)
-			delete(rawMsg, key)
-		case "tags":
-			err = unpopulate(val, "Tags", &k.Tags)
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", k, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type KeyVerifyParameters.
-func (k KeyVerifyParameters) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "alg", k.Algorithm)
-	populateByteArray(objectMap, "digest", k.Digest, func() any {
-		return runtime.EncodeByteArray(k.Digest, runtime.Base64URLFormat)
-	})
-	populateByteArray(objectMap, "value", k.Signature, func() any {
-		return runtime.EncodeByteArray(k.Signature, runtime.Base64URLFormat)
-	})
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type KeyVerifyParameters.
-func (k *KeyVerifyParameters) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", k, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "alg":
-			err = unpopulate(val, "Algorithm", &k.Algorithm)
-			delete(rawMsg, key)
-		case "digest":
-			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &k.Digest, runtime.Base64URLFormat)
-			}
-			delete(rawMsg, key)
-		case "value":
-			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &k.Signature, runtime.Base64URLFormat)
-			}
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", k, err)
-		}
-	}
-	return nil
-}
-
 // MarshalJSON implements the json.Marshaller interface for type KeyVerifyResult.
 func (k KeyVerifyResult) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -1076,16 +893,16 @@ func (k *KeyVerifyResult) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type LifetimeActions.
-func (l LifetimeActions) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type LifetimeAction.
+func (l LifetimeAction) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "action", l.Action)
 	populate(objectMap, "trigger", l.Trigger)
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type LifetimeActions.
-func (l *LifetimeActions) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type LifetimeAction.
+func (l *LifetimeAction) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return fmt.Errorf("unmarshalling type %T: %v", l, err)
@@ -1107,16 +924,16 @@ func (l *LifetimeActions) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type LifetimeActionsTrigger.
-func (l LifetimeActionsTrigger) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type LifetimeActionTrigger.
+func (l LifetimeActionTrigger) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "timeAfterCreate", l.TimeAfterCreate)
 	populate(objectMap, "timeBeforeExpiry", l.TimeBeforeExpiry)
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type LifetimeActionsTrigger.
-func (l *LifetimeActionsTrigger) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type LifetimeActionTrigger.
+func (l *LifetimeActionTrigger) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return fmt.Errorf("unmarshalling type %T: %v", l, err)
@@ -1138,15 +955,15 @@ func (l *LifetimeActionsTrigger) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type LifetimeActionsType.
-func (l LifetimeActionsType) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaller interface for type LifetimeActionType.
+func (l LifetimeActionType) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "type", l.Type)
 	return json.Marshal(objectMap)
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type LifetimeActionsType.
-func (l *LifetimeActionsType) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON implements the json.Unmarshaller interface for type LifetimeActionType.
+func (l *LifetimeActionType) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return fmt.Errorf("unmarshalling type %T: %v", l, err)
@@ -1191,6 +1008,189 @@ func (r *RandomBytes) UnmarshalJSON(data []byte) error {
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", r, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ReleaseParameters.
+func (r ReleaseParameters) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "enc", r.Algorithm)
+	populate(objectMap, "nonce", r.Nonce)
+	populate(objectMap, "target", r.TargetAttestationToken)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ReleaseParameters.
+func (r *ReleaseParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", r, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "enc":
+			err = unpopulate(val, "Algorithm", &r.Algorithm)
+			delete(rawMsg, key)
+		case "nonce":
+			err = unpopulate(val, "Nonce", &r.Nonce)
+			delete(rawMsg, key)
+		case "target":
+			err = unpopulate(val, "TargetAttestationToken", &r.TargetAttestationToken)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", r, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RestoreKeyParameters.
+func (r RestoreKeyParameters) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populateByteArray(objectMap, "value", r.KeyBackup, func() any {
+		return runtime.EncodeByteArray(r.KeyBackup, runtime.Base64URLFormat)
+	})
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type RestoreKeyParameters.
+func (r *RestoreKeyParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", r, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "value":
+			if val != nil && string(val) != "null" {
+				err = runtime.DecodeByteArray(string(val), &r.KeyBackup, runtime.Base64URLFormat)
+			}
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", r, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SignParameters.
+func (s SignParameters) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "alg", s.Algorithm)
+	populateByteArray(objectMap, "value", s.Value, func() any {
+		return runtime.EncodeByteArray(s.Value, runtime.Base64URLFormat)
+	})
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type SignParameters.
+func (s *SignParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", s, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "alg":
+			err = unpopulate(val, "Algorithm", &s.Algorithm)
+			delete(rawMsg, key)
+		case "value":
+			if val != nil && string(val) != "null" {
+				err = runtime.DecodeByteArray(string(val), &s.Value, runtime.Base64URLFormat)
+			}
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", s, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type UpdateKeyParameters.
+func (u UpdateKeyParameters) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "attributes", u.KeyAttributes)
+	populate(objectMap, "key_ops", u.KeyOps)
+	populate(objectMap, "release_policy", u.ReleasePolicy)
+	populate(objectMap, "tags", u.Tags)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type UpdateKeyParameters.
+func (u *UpdateKeyParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", u, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "attributes":
+			err = unpopulate(val, "KeyAttributes", &u.KeyAttributes)
+			delete(rawMsg, key)
+		case "key_ops":
+			err = unpopulate(val, "KeyOps", &u.KeyOps)
+			delete(rawMsg, key)
+		case "release_policy":
+			err = unpopulate(val, "ReleasePolicy", &u.ReleasePolicy)
+			delete(rawMsg, key)
+		case "tags":
+			err = unpopulate(val, "Tags", &u.Tags)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", u, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VerifyParameters.
+func (v VerifyParameters) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "alg", v.Algorithm)
+	populateByteArray(objectMap, "digest", v.Digest, func() any {
+		return runtime.EncodeByteArray(v.Digest, runtime.Base64URLFormat)
+	})
+	populateByteArray(objectMap, "value", v.Signature, func() any {
+		return runtime.EncodeByteArray(v.Signature, runtime.Base64URLFormat)
+	})
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type VerifyParameters.
+func (v *VerifyParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", v, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "alg":
+			err = unpopulate(val, "Algorithm", &v.Algorithm)
+			delete(rawMsg, key)
+		case "digest":
+			if val != nil && string(val) != "null" {
+				err = runtime.DecodeByteArray(string(val), &v.Digest, runtime.Base64URLFormat)
+			}
+			delete(rawMsg, key)
+		case "value":
+			if val != nil && string(val) != "null" {
+				err = runtime.DecodeByteArray(string(val), &v.Signature, runtime.Base64URLFormat)
+			}
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", v, err)
 		}
 	}
 	return nil

--- a/packages/typespec-go/test/local/azkeys/zz_options.go
+++ b/packages/typespec-go/test/local/azkeys/zz_options.go
@@ -4,130 +4,122 @@
 
 package azkeys
 
-// KeyVaultClientBackupKeyOptions contains the optional parameters for the KeyVaultClient.BackupKey method.
-type KeyVaultClientBackupKeyOptions struct {
+// BackupKeyOptions contains the optional parameters for the Client.BackupKey method.
+type BackupKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientCreateKeyOptions contains the optional parameters for the KeyVaultClient.CreateKey method.
-type KeyVaultClientCreateKeyOptions struct {
+// CreateKeyOptions contains the optional parameters for the Client.CreateKey method.
+type CreateKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientDecryptOptions contains the optional parameters for the KeyVaultClient.Decrypt method.
-type KeyVaultClientDecryptOptions struct {
+// DecryptOptions contains the optional parameters for the Client.Decrypt method.
+type DecryptOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientDeleteKeyOptions contains the optional parameters for the KeyVaultClient.DeleteKey method.
-type KeyVaultClientDeleteKeyOptions struct {
+// DeleteKeyOptions contains the optional parameters for the Client.DeleteKey method.
+type DeleteKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientEncryptOptions contains the optional parameters for the KeyVaultClient.Encrypt method.
-type KeyVaultClientEncryptOptions struct {
+// EncryptOptions contains the optional parameters for the Client.Encrypt method.
+type EncryptOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetDeletedKeyOptions contains the optional parameters for the KeyVaultClient.GetDeletedKey method.
-type KeyVaultClientGetDeletedKeyOptions struct {
+// GetDeletedKeyOptions contains the optional parameters for the Client.GetDeletedKey method.
+type GetDeletedKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetDeletedKeysOptions contains the optional parameters for the KeyVaultClient.NewGetDeletedKeysPager method.
-type KeyVaultClientGetDeletedKeysOptions struct {
-	// Maximum number of results to return in a page. If not specified the service
-	// will return up to 25 results.
-	Maxresults *int32
-}
-
-// KeyVaultClientGetKeyOptions contains the optional parameters for the KeyVaultClient.GetKey method.
-type KeyVaultClientGetKeyOptions struct {
+// GetKeyOptions contains the optional parameters for the Client.GetKey method.
+type GetKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetKeyRotationPolicyOptions contains the optional parameters for the KeyVaultClient.GetKeyRotationPolicy
-// method.
-type KeyVaultClientGetKeyRotationPolicyOptions struct {
+// GetKeyRotationPolicyOptions contains the optional parameters for the Client.GetKeyRotationPolicy method.
+type GetKeyRotationPolicyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientGetKeyVersionsOptions contains the optional parameters for the KeyVaultClient.NewGetKeyVersionsPager method.
-type KeyVaultClientGetKeyVersionsOptions struct {
-	// Maximum number of results to return in a page. If not specified the service
-	// will return up to 25 results.
-	Maxresults *int32
-}
-
-// KeyVaultClientGetKeysOptions contains the optional parameters for the KeyVaultClient.NewGetKeysPager method.
-type KeyVaultClientGetKeysOptions struct {
-	// Maximum number of results to return in a page. If not specified the service
-	// will return up to 25 results.
-	Maxresults *int32
-}
-
-// KeyVaultClientGetRandomBytesOptions contains the optional parameters for the KeyVaultClient.GetRandomBytes method.
-type KeyVaultClientGetRandomBytesOptions struct {
+// GetRandomBytesOptions contains the optional parameters for the Client.GetRandomBytes method.
+type GetRandomBytesOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientImportKeyOptions contains the optional parameters for the KeyVaultClient.ImportKey method.
-type KeyVaultClientImportKeyOptions struct {
+// ImportKeyOptions contains the optional parameters for the Client.ImportKey method.
+type ImportKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientPurgeDeletedKeyOptions contains the optional parameters for the KeyVaultClient.PurgeDeletedKey method.
-type KeyVaultClientPurgeDeletedKeyOptions struct {
+// ListDeletedKeyPropertiesOptions contains the optional parameters for the Client.NewListDeletedKeyPropertiesPager method.
+type ListDeletedKeyPropertiesOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientRecoverDeletedKeyOptions contains the optional parameters for the KeyVaultClient.RecoverDeletedKey method.
-type KeyVaultClientRecoverDeletedKeyOptions struct {
+// ListKeyPropertiesOptions contains the optional parameters for the Client.NewListKeyPropertiesPager method.
+type ListKeyPropertiesOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientReleaseOptions contains the optional parameters for the KeyVaultClient.Release method.
-type KeyVaultClientReleaseOptions struct {
+// ListKeyPropertiesVersionsOptions contains the optional parameters for the Client.NewListKeyPropertiesVersionsPager method.
+type ListKeyPropertiesVersionsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientRestoreKeyOptions contains the optional parameters for the KeyVaultClient.RestoreKey method.
-type KeyVaultClientRestoreKeyOptions struct {
+// PurgeDeletedKeyOptions contains the optional parameters for the Client.PurgeDeletedKey method.
+type PurgeDeletedKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientRotateKeyOptions contains the optional parameters for the KeyVaultClient.RotateKey method.
-type KeyVaultClientRotateKeyOptions struct {
+// RecoverDeletedKeyOptions contains the optional parameters for the Client.RecoverDeletedKey method.
+type RecoverDeletedKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientSignOptions contains the optional parameters for the KeyVaultClient.Sign method.
-type KeyVaultClientSignOptions struct {
+// ReleaseOptions contains the optional parameters for the Client.Release method.
+type ReleaseOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientUnwrapKeyOptions contains the optional parameters for the KeyVaultClient.UnwrapKey method.
-type KeyVaultClientUnwrapKeyOptions struct {
+// RestoreKeyOptions contains the optional parameters for the Client.RestoreKey method.
+type RestoreKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientUpdateKeyOptions contains the optional parameters for the KeyVaultClient.UpdateKey method.
-type KeyVaultClientUpdateKeyOptions struct {
+// RotateKeyOptions contains the optional parameters for the Client.RotateKey method.
+type RotateKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientUpdateKeyRotationPolicyOptions contains the optional parameters for the KeyVaultClient.UpdateKeyRotationPolicy
-// method.
-type KeyVaultClientUpdateKeyRotationPolicyOptions struct {
+// SignOptions contains the optional parameters for the Client.Sign method.
+type SignOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientVerifyOptions contains the optional parameters for the KeyVaultClient.Verify method.
-type KeyVaultClientVerifyOptions struct {
+// UnwrapKeyOptions contains the optional parameters for the Client.UnwrapKey method.
+type UnwrapKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
-// KeyVaultClientWrapKeyOptions contains the optional parameters for the KeyVaultClient.WrapKey method.
-type KeyVaultClientWrapKeyOptions struct {
+// UpdateKeyOptions contains the optional parameters for the Client.UpdateKey method.
+type UpdateKeyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// UpdateKeyRotationPolicyOptions contains the optional parameters for the Client.UpdateKeyRotationPolicy method.
+type UpdateKeyRotationPolicyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VerifyOptions contains the optional parameters for the Client.Verify method.
+type VerifyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// WrapKeyOptions contains the optional parameters for the Client.WrapKey method.
+type WrapKeyOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/local/azkeys/zz_responses.go
+++ b/packages/typespec-go/test/local/azkeys/zz_responses.go
@@ -4,145 +4,145 @@
 
 package azkeys
 
-// KeyVaultClientBackupKeyResponse contains the response from method KeyVaultClient.BackupKey.
-type KeyVaultClientBackupKeyResponse struct {
+// BackupKeyResponse contains the response from method Client.BackupKey.
+type BackupKeyResponse struct {
 	// The backup key result, containing the backup blob.
 	BackupKeyResult
 }
 
-// KeyVaultClientCreateKeyResponse contains the response from method KeyVaultClient.CreateKey.
-type KeyVaultClientCreateKeyResponse struct {
+// CreateKeyResponse contains the response from method Client.CreateKey.
+type CreateKeyResponse struct {
 	// A KeyBundle consisting of a WebKey plus its attributes.
 	KeyBundle
 }
 
-// KeyVaultClientDecryptResponse contains the response from method KeyVaultClient.Decrypt.
-type KeyVaultClientDecryptResponse struct {
+// DecryptResponse contains the response from method Client.Decrypt.
+type DecryptResponse struct {
 	// The key operation result.
 	KeyOperationResult
 }
 
-// KeyVaultClientDeleteKeyResponse contains the response from method KeyVaultClient.DeleteKey.
-type KeyVaultClientDeleteKeyResponse struct {
+// DeleteKeyResponse contains the response from method Client.DeleteKey.
+type DeleteKeyResponse struct {
 	// A DeletedKeyBundle consisting of a WebKey plus its Attributes and deletion info
-	DeletedKeyBundle
+	DeletedKey
 }
 
-// KeyVaultClientEncryptResponse contains the response from method KeyVaultClient.Encrypt.
-type KeyVaultClientEncryptResponse struct {
+// EncryptResponse contains the response from method Client.Encrypt.
+type EncryptResponse struct {
 	// The key operation result.
 	KeyOperationResult
 }
 
-// KeyVaultClientGetDeletedKeyResponse contains the response from method KeyVaultClient.GetDeletedKey.
-type KeyVaultClientGetDeletedKeyResponse struct {
+// GetDeletedKeyResponse contains the response from method Client.GetDeletedKey.
+type GetDeletedKeyResponse struct {
 	// A DeletedKeyBundle consisting of a WebKey plus its Attributes and deletion info
-	DeletedKeyBundle
+	DeletedKey
 }
 
-// KeyVaultClientGetDeletedKeysResponse contains the response from method KeyVaultClient.NewGetDeletedKeysPager.
-type KeyVaultClientGetDeletedKeysResponse struct {
-	// A list of keys that have been deleted in this vault.
-	DeletedKeyListResult
-}
-
-// KeyVaultClientGetKeyResponse contains the response from method KeyVaultClient.GetKey.
-type KeyVaultClientGetKeyResponse struct {
+// GetKeyResponse contains the response from method Client.GetKey.
+type GetKeyResponse struct {
 	// A KeyBundle consisting of a WebKey plus its attributes.
 	KeyBundle
 }
 
-// KeyVaultClientGetKeyRotationPolicyResponse contains the response from method KeyVaultClient.GetKeyRotationPolicy.
-type KeyVaultClientGetKeyRotationPolicyResponse struct {
+// GetKeyRotationPolicyResponse contains the response from method Client.GetKeyRotationPolicy.
+type GetKeyRotationPolicyResponse struct {
 	// Management policy for a key.
 	KeyRotationPolicy
 }
 
-// KeyVaultClientGetKeyVersionsResponse contains the response from method KeyVaultClient.NewGetKeyVersionsPager.
-type KeyVaultClientGetKeyVersionsResponse struct {
-	// The key list result.
-	KeyListResult
-}
-
-// KeyVaultClientGetKeysResponse contains the response from method KeyVaultClient.NewGetKeysPager.
-type KeyVaultClientGetKeysResponse struct {
-	// The key list result.
-	KeyListResult
-}
-
-// KeyVaultClientGetRandomBytesResponse contains the response from method KeyVaultClient.GetRandomBytes.
-type KeyVaultClientGetRandomBytesResponse struct {
+// GetRandomBytesResponse contains the response from method Client.GetRandomBytes.
+type GetRandomBytesResponse struct {
 	// The get random bytes response object containing the bytes.
 	RandomBytes
 }
 
-// KeyVaultClientImportKeyResponse contains the response from method KeyVaultClient.ImportKey.
-type KeyVaultClientImportKeyResponse struct {
+// ImportKeyResponse contains the response from method Client.ImportKey.
+type ImportKeyResponse struct {
 	// A KeyBundle consisting of a WebKey plus its attributes.
 	KeyBundle
 }
 
-// KeyVaultClientPurgeDeletedKeyResponse contains the response from method KeyVaultClient.PurgeDeletedKey.
-type KeyVaultClientPurgeDeletedKeyResponse struct {
+// ListDeletedKeyPropertiesResponse contains the response from method Client.NewListDeletedKeyPropertiesPager.
+type ListDeletedKeyPropertiesResponse struct {
+	// A list of keys that have been deleted in this vault.
+	DeletedKeyPropertiesListResult
+}
+
+// ListKeyPropertiesResponse contains the response from method Client.NewListKeyPropertiesPager.
+type ListKeyPropertiesResponse struct {
+	// The key list result.
+	KeyPropertiesListResult
+}
+
+// ListKeyPropertiesVersionsResponse contains the response from method Client.NewListKeyPropertiesVersionsPager.
+type ListKeyPropertiesVersionsResponse struct {
+	// The key list result.
+	KeyPropertiesListResult
+}
+
+// PurgeDeletedKeyResponse contains the response from method Client.PurgeDeletedKey.
+type PurgeDeletedKeyResponse struct {
 	// placeholder for future response values
 }
 
-// KeyVaultClientRecoverDeletedKeyResponse contains the response from method KeyVaultClient.RecoverDeletedKey.
-type KeyVaultClientRecoverDeletedKeyResponse struct {
+// RecoverDeletedKeyResponse contains the response from method Client.RecoverDeletedKey.
+type RecoverDeletedKeyResponse struct {
 	// A KeyBundle consisting of a WebKey plus its attributes.
 	KeyBundle
 }
 
-// KeyVaultClientReleaseResponse contains the response from method KeyVaultClient.Release.
-type KeyVaultClientReleaseResponse struct {
+// ReleaseResponse contains the response from method Client.Release.
+type ReleaseResponse struct {
 	// The release result, containing the released key.
 	KeyReleaseResult
 }
 
-// KeyVaultClientRestoreKeyResponse contains the response from method KeyVaultClient.RestoreKey.
-type KeyVaultClientRestoreKeyResponse struct {
+// RestoreKeyResponse contains the response from method Client.RestoreKey.
+type RestoreKeyResponse struct {
 	// A KeyBundle consisting of a WebKey plus its attributes.
 	KeyBundle
 }
 
-// KeyVaultClientRotateKeyResponse contains the response from method KeyVaultClient.RotateKey.
-type KeyVaultClientRotateKeyResponse struct {
+// RotateKeyResponse contains the response from method Client.RotateKey.
+type RotateKeyResponse struct {
 	// A KeyBundle consisting of a WebKey plus its attributes.
 	KeyBundle
 }
 
-// KeyVaultClientSignResponse contains the response from method KeyVaultClient.Sign.
-type KeyVaultClientSignResponse struct {
+// SignResponse contains the response from method Client.Sign.
+type SignResponse struct {
 	// The key operation result.
 	KeyOperationResult
 }
 
-// KeyVaultClientUnwrapKeyResponse contains the response from method KeyVaultClient.UnwrapKey.
-type KeyVaultClientUnwrapKeyResponse struct {
+// UnwrapKeyResponse contains the response from method Client.UnwrapKey.
+type UnwrapKeyResponse struct {
 	// The key operation result.
 	KeyOperationResult
 }
 
-// KeyVaultClientUpdateKeyResponse contains the response from method KeyVaultClient.UpdateKey.
-type KeyVaultClientUpdateKeyResponse struct {
+// UpdateKeyResponse contains the response from method Client.UpdateKey.
+type UpdateKeyResponse struct {
 	// A KeyBundle consisting of a WebKey plus its attributes.
 	KeyBundle
 }
 
-// KeyVaultClientUpdateKeyRotationPolicyResponse contains the response from method KeyVaultClient.UpdateKeyRotationPolicy.
-type KeyVaultClientUpdateKeyRotationPolicyResponse struct {
+// UpdateKeyRotationPolicyResponse contains the response from method Client.UpdateKeyRotationPolicy.
+type UpdateKeyRotationPolicyResponse struct {
 	// Management policy for a key.
 	KeyRotationPolicy
 }
 
-// KeyVaultClientVerifyResponse contains the response from method KeyVaultClient.Verify.
-type KeyVaultClientVerifyResponse struct {
+// VerifyResponse contains the response from method Client.Verify.
+type VerifyResponse struct {
 	// The key verify result.
 	KeyVerifyResult
 }
 
-// KeyVaultClientWrapKeyResponse contains the response from method KeyVaultClient.WrapKey.
-type KeyVaultClientWrapKeyResponse struct {
+// WrapKeyResponse contains the response from method Client.WrapKey.
+type WrapKeyResponse struct {
 	// The key operation result.
 	KeyOperationResult
 }

--- a/packages/typespec-go/test/tsp/KeyVault.Keys/client.tsp
+++ b/packages/typespec-go/test/tsp/KeyVault.Keys/client.tsp
@@ -2,10 +2,80 @@ import "./main.tsp";
 import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
+using TypeSpec.Versioning;
+using TypeSpec.Http;
+
+@versioned(KeyVault.Versions)
+namespace Customizations;
 
 @@clientName(KeyVault, "Client", "go");
 
 using KeyVault;
+
+/**
+ * The full key identifier, attributes, and tags are provided in the response.
+ * This operation requires the keys/list permission.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
+#suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name is already established"
+@summary("Retrieves a list of individual key versions with the same key name.")
+@route("/keys/{key-name}/versions")
+@get
+op listKeyPropertiesVersions is Azure.Core.Foundations.Operation<
+  {
+    /**
+     * The name of the key.
+     */
+    @path("key-name")
+    keyName: string;
+  },
+  KeyListResult,
+  {},
+  KeyVaultError
+>;
+
+/**s
+ * Retrieves a list of the keys in the Key Vault as JSON Web Key structures that
+ * contain the public part of a stored key. The LIST operation is applicable to
+ * all key types, however only the base key identifier, attributes, and tags are
+ * provided in the response. Individual versions of a key are not listed in the
+ * response. This operation requires the keys/list permission.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
+#suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name is already established"
+@summary("List keys in the specified vault.")
+@route("/keys")
+@get
+op listKeyProperties is Azure.Core.Foundations.Operation<
+  {},
+  KeyListResult,
+  {},
+  KeyVaultError
+>;
+
+/**
+ * Retrieves a list of the keys in the Key Vault as JSON Web Key structures that
+ * contain the public part of a deleted key. This operation includes
+ * deletion-specific information. The Get Deleted Keys operation is applicable for
+ * vaults enabled for soft-delete. While the operation can be invoked on any
+ * vault, it will return an error if invoked on a non soft-delete enabled vault.
+ * This operation requires the keys/list permission.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
+#suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name is already established"
+@summary("Lists the deleted keys in the specified vault.")
+@route("/deletedkeys")
+@get
+op listDeletedKeyProperties is Azure.Core.Foundations.Operation<
+  {},
+  DeletedKeyListResult,
+  {},
+  KeyVaultError
+>;
+
+@@override(getKeyVersions, listKeyPropertiesVersions, "go");
+@@override(getKeys, listKeyProperties, "go");
+@@override(getDeletedKeys, listDeletedKeyProperties, "go");
 
 @@clientName(KeyCreateParameters, "CreateKeyParameters", "go");
 @@clientName(KeyExportParameters, "ExportKeyParameters", "go");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,19 +248,19 @@ importers:
     devDependencies:
       '@azure-tools/azure-http-specs':
         specifier: 0.1.0-alpha.18
-        version: 0.1.0-alpha.18(400913b4214d342927b259c2fec4fae4)
+        version: 0.1.0-alpha.18(882b74cc411a0095ad4350f9969ac9b6)
       '@azure-tools/typespec-autorest':
         specifier: 0.56.0
-        version: 0.56.0(ed2c9a0495c45c3ea3f145ae59693d71)
+        version: 0.56.0(0589a6e33cd39313450ce6b4afe6efbc)
       '@azure-tools/typespec-azure-core':
         specifier: 0.56.0
-        version: 0.56.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))
+        version: 0.56.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))
       '@azure-tools/typespec-azure-resource-manager':
         specifier: 0.56.2
-        version: 0.56.2(a74ba9764c2492841aa14a90f838face)
+        version: 0.56.2(23ce14bc97208cc4e9b374aaec729836)
       '@azure-tools/typespec-client-generator-core':
-        specifier: 0.56.2
-        version: 0.56.2(f9ea4af644c584c071ae00e2bd278144)
+        specifier: 0.56.4
+        version: 0.56.4(4b5038180de6730788d2dec3f0b2c56b)
       '@types/node':
         specifier: 'catalog:'
         version: 20.17.40
@@ -271,23 +271,23 @@ importers:
         specifier: 0.70.0
         version: 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))
       '@typespec/http':
-        specifier: 1.0.0
-        version: 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
+        specifier: 1.0.1
+        version: 1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
       '@typespec/http-specs':
         specifier: 0.1.0-alpha.22
-        version: 0.1.0-alpha.22(@types/node@20.17.40)(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))(@typespec/versioning@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))(@typespec/xml@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
+        version: 0.1.0-alpha.22(@types/node@20.17.40)(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))(@typespec/versioning@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))(@typespec/xml@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
       '@typespec/openapi':
         specifier: 1.0.0
-        version: 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
+        version: 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
       '@typespec/rest':
         specifier: 0.70.0
-        version: 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
+        version: 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
       '@typespec/spector':
         specifier: 0.1.0-alpha.13
         version: 0.1.0-alpha.13(@types/node@20.17.40)(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
       '@typespec/sse':
         specifier: 0.70.0
-        version: 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/events@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
+        version: 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/events@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
       '@typespec/streams':
         specifier: 0.70.0
         version: 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))
@@ -405,8 +405,8 @@ packages:
       '@typespec/rest': ^0.70.0
       '@typespec/versioning': ^0.70.0
 
-  '@azure-tools/typespec-client-generator-core@0.56.2':
-    resolution: {integrity: sha512-KplQWeC/iyUTaPfBAdKynCRon8BH15yc34NBXWsjllRz+X+ZwxCQeU3vxzHQnrUPTXtNKhjXpu/les1fdd/rDQ==}
+  '@azure-tools/typespec-client-generator-core@0.56.4':
+    resolution: {integrity: sha512-034mF63l1/a9zkspO+a6e0Iiqnbo67TP2LQXg0OBpDbsDq3/2o4T3DXxf14QX59k4QtZOCDHW9kVI7+eDgGBZQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@azure-tools/typespec-azure-core': ^0.56.0
@@ -1466,16 +1466,6 @@ packages:
       '@typespec/rest': ^0.70.0
       '@typespec/versioning': ^0.70.0
       '@typespec/xml': ^0.70.0
-
-  '@typespec/http@1.0.0':
-    resolution: {integrity: sha512-Uy0UnnGxA+pgvakM5IOhA89GBKTxf1vVylXZuA2aWrIHefki4BswcQxYBObzCq1hA7FYJsxDQVAMOSRrhUsbPg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@typespec/compiler': ^1.0.0
-      '@typespec/streams': ^0.70.0
-    peerDependenciesMeta:
-      '@typespec/streams':
-        optional: true
 
   '@typespec/http@1.0.1':
     resolution: {integrity: sha512-J5tqBWlmkvI/W+kJn4EFuN0laGxbY8qT68jzEQEiYeAXSfNyFGRSoCwn8Ex6dJphq4IozOMdVTNtOZWIJlwmfw==}
@@ -4682,12 +4672,12 @@ snapshots:
       '@azure-tools/tasks': 3.0.255
       proper-lockfile: 2.0.1
 
-  '@azure-tools/azure-http-specs@0.1.0-alpha.18(400913b4214d342927b259c2fec4fae4)':
+  '@azure-tools/azure-http-specs@0.1.0-alpha.18(882b74cc411a0095ad4350f9969ac9b6)':
     dependencies:
-      '@azure-tools/typespec-azure-core': 0.56.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))
+      '@azure-tools/typespec-azure-core': 0.56.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))
       '@typespec/compiler': 1.0.0(@types/node@20.17.40)
-      '@typespec/http': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
-      '@typespec/rest': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
+      '@typespec/http': 1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
+      '@typespec/rest': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
       '@typespec/spec-api': 0.1.0-alpha.6
       '@typespec/spector': 0.1.0-alpha.14(@types/node@20.17.40)(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
       '@typespec/versioning': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))
@@ -4713,43 +4703,43 @@ snapshots:
 
   '@azure-tools/tasks@3.0.255': {}
 
-  '@azure-tools/typespec-autorest@0.56.0(ed2c9a0495c45c3ea3f145ae59693d71)':
+  '@azure-tools/typespec-autorest@0.56.0(0589a6e33cd39313450ce6b4afe6efbc)':
     dependencies:
-      '@azure-tools/typespec-azure-core': 0.56.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))
-      '@azure-tools/typespec-azure-resource-manager': 0.56.2(a74ba9764c2492841aa14a90f838face)
-      '@azure-tools/typespec-client-generator-core': 0.56.2(f9ea4af644c584c071ae00e2bd278144)
+      '@azure-tools/typespec-azure-core': 0.56.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))
+      '@azure-tools/typespec-azure-resource-manager': 0.56.2(23ce14bc97208cc4e9b374aaec729836)
+      '@azure-tools/typespec-client-generator-core': 0.56.4(4b5038180de6730788d2dec3f0b2c56b)
       '@typespec/compiler': 1.0.0(@types/node@20.17.40)
-      '@typespec/http': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
-      '@typespec/openapi': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
-      '@typespec/rest': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
+      '@typespec/http': 1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
+      '@typespec/openapi': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
+      '@typespec/rest': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
       '@typespec/versioning': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))
 
-  '@azure-tools/typespec-azure-core@0.56.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))':
+  '@azure-tools/typespec-azure-core@0.56.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))':
     dependencies:
       '@typespec/compiler': 1.0.0(@types/node@20.17.40)
-      '@typespec/http': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
-      '@typespec/rest': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
+      '@typespec/http': 1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
+      '@typespec/rest': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
 
-  '@azure-tools/typespec-azure-resource-manager@0.56.2(a74ba9764c2492841aa14a90f838face)':
+  '@azure-tools/typespec-azure-resource-manager@0.56.2(23ce14bc97208cc4e9b374aaec729836)':
     dependencies:
-      '@azure-tools/typespec-azure-core': 0.56.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))
+      '@azure-tools/typespec-azure-core': 0.56.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))
       '@typespec/compiler': 1.0.0(@types/node@20.17.40)
-      '@typespec/http': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
-      '@typespec/openapi': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
-      '@typespec/rest': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
+      '@typespec/http': 1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
+      '@typespec/openapi': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
+      '@typespec/rest': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
       '@typespec/versioning': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))
       change-case: 5.4.4
       pluralize: 8.0.0
 
-  '@azure-tools/typespec-client-generator-core@0.56.2(f9ea4af644c584c071ae00e2bd278144)':
+  '@azure-tools/typespec-client-generator-core@0.56.4(4b5038180de6730788d2dec3f0b2c56b)':
     dependencies:
-      '@azure-tools/typespec-azure-core': 0.56.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))
+      '@azure-tools/typespec-azure-core': 0.56.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))
       '@typespec/compiler': 1.0.0(@types/node@20.17.40)
       '@typespec/events': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))
-      '@typespec/http': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
-      '@typespec/openapi': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
-      '@typespec/rest': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
-      '@typespec/sse': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/events@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
+      '@typespec/http': 1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
+      '@typespec/openapi': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
+      '@typespec/rest': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
+      '@typespec/sse': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/events@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
       '@typespec/streams': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))
       '@typespec/versioning': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))
       '@typespec/xml': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))
@@ -5996,11 +5986,11 @@ snapshots:
     dependencies:
       '@typespec/compiler': 1.0.0(@types/node@20.17.40)
 
-  '@typespec/http-specs@0.1.0-alpha.22(@types/node@20.17.40)(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))(@typespec/versioning@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))(@typespec/xml@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))':
+  '@typespec/http-specs@0.1.0-alpha.22(@types/node@20.17.40)(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))(@typespec/versioning@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))(@typespec/xml@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))':
     dependencies:
       '@typespec/compiler': 1.0.0(@types/node@20.17.40)
-      '@typespec/http': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
-      '@typespec/rest': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
+      '@typespec/http': 1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
+      '@typespec/rest': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
       '@typespec/spec-api': 0.1.0-alpha.6
       '@typespec/spector': 0.1.0-alpha.13(@types/node@20.17.40)(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
       '@typespec/versioning': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))
@@ -6011,32 +6001,21 @@ snapshots:
       - '@typespec/streams'
       - supports-color
 
-  '@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))':
-    dependencies:
-      '@typespec/compiler': 1.0.0(@types/node@20.17.40)
-    optionalDependencies:
-      '@typespec/streams': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))
-
   '@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))':
     dependencies:
       '@typespec/compiler': 1.0.0(@types/node@20.17.40)
     optionalDependencies:
       '@typespec/streams': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))
 
-  '@typespec/openapi@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))':
+  '@typespec/openapi@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))':
     dependencies:
       '@typespec/compiler': 1.0.0(@types/node@20.17.40)
-      '@typespec/http': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
+      '@typespec/http': 1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
 
-  '@typespec/rest@0.69.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))':
+  '@typespec/rest@0.69.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))':
     dependencies:
       '@typespec/compiler': 1.0.0(@types/node@20.17.40)
-      '@typespec/http': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
-
-  '@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))':
-    dependencies:
-      '@typespec/compiler': 1.0.0(@types/node@20.17.40)
-      '@typespec/http': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
+      '@typespec/http': 1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
 
   '@typespec/rest@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))':
     dependencies:
@@ -6064,8 +6043,8 @@ snapshots:
       '@azure/identity': 4.8.0
       '@types/js-yaml': 4.0.9
       '@typespec/compiler': 1.0.0(@types/node@20.17.40)
-      '@typespec/http': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
-      '@typespec/rest': 0.69.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
+      '@typespec/http': 1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
+      '@typespec/rest': 0.69.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))
       '@typespec/spec-api': 0.1.0-alpha.6
       '@typespec/spec-coverage-sdk': 0.1.0-alpha.6
       '@typespec/versioning': 0.69.0(@typespec/compiler@1.0.0(@types/node@20.17.40))
@@ -6115,11 +6094,11 @@ snapshots:
       - '@typespec/streams'
       - supports-color
 
-  '@typespec/sse@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/events@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))(@typespec/http@1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))':
+  '@typespec/sse@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/events@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))(@typespec/http@1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))':
     dependencies:
       '@typespec/compiler': 1.0.0(@types/node@20.17.40)
       '@typespec/events': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))
-      '@typespec/http': 1.0.0(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
+      '@typespec/http': 1.0.1(@typespec/compiler@1.0.0(@types/node@20.17.40))(@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40)))
       '@typespec/streams': 0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))
 
   '@typespec/streams@0.70.0(@typespec/compiler@1.0.0(@types/node@20.17.40))':


### PR DESCRIPTION
tcgc now allows the removal of optional parameters with the `override` decorator.

Upgrading to the newest version of tcgc and expanding the Key Vault test to use this new feature. I also fixed the test so it will actually use the client.tsp file.