### PR TITLE
Don't run gogetu in CI

### DIFF
--- a/eng/pipelines/templates/steps/build-test-typespec.yaml
+++ b/eng/pipelines/templates/steps/build-test-typespec.yaml
@@ -31,7 +31,6 @@ steps:
 
   - script: |
       pnpm tspcompile --emitter-installed --verbose
-      pnpm -w gogetu $pwd 2>&1
       pnpm -w modtidy $pwd 2>&1
       git add -A .
       git diff --staged -w 1>&2


### PR DESCRIPTION
This adds a lot of noise to PRs as the relevant changes get lost in the sea of go.mod updates.