### PR TITLE
Refactor code model method types

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -34,27 +34,27 @@ export function adaptClients(m4CodeModel: m4.CodeModel, codeModel: go.CodeModel)
 
       if (helpers.isLROOperation(op) && helpers.isPageableOperation(op)) {
         method = new go.LROPageableMethod(op.language.go!.name, client, httpPath, httpMethod, getStatusCodes(op), naming);
-        (<go.LROPageableMethod>method).finalStateVia = (op.extensions?.['x-ms-long-running-operation-options']?.['final-state-via']);
-        (<go.LROPageableMethod>method).nextLinkName = op.language.go!.paging.nextLinkName;
+        method.finalStateVia = (op.extensions?.['x-ms-long-running-operation-options']?.['final-state-via']);
+        method.nextLinkName = op.language.go!.paging.nextLinkName;
         if (op.language.go!.paging.nextLinkOperation) {
           // adapt the next link operation
           const nextPageMethod = new go.NextPageMethod(op.language.go!.paging.nextLinkOperation.language.go.name, client, httpPath, httpMethod, getStatusCodes(op.language.go!.paging.nextLinkOperation));
           populateMethod(op.language.go!.paging.nextLinkOperation, nextPageMethod, m4CodeModel, codeModel);
-          (<go.LROPageableMethod>method).nextPageMethod = nextPageMethod;
+          method.nextPageMethod = nextPageMethod;
         }
       } else if (helpers.isLROOperation(op)) {
         method = new go.LROMethod(op.language.go!.name, client, httpPath, httpMethod, getStatusCodes(op), naming);
-        (<go.LROMethod>method).finalStateVia = (op.extensions?.['x-ms-long-running-operation-options']?.['final-state-via']);
+        method.finalStateVia = (op.extensions?.['x-ms-long-running-operation-options']?.['final-state-via']);
       } else if (helpers.isPageableOperation(op)) {
         if (op.language.go!.paging.isNextOp) {
           continue;
         }
         method = new go.PageableMethod(op.language.go!.name, client, httpPath, httpMethod, getStatusCodes(op), naming);
-        (<go.PageableMethod>method).nextLinkName = op.language.go!.paging.nextLinkName;
+        method.nextLinkName = op.language.go!.paging.nextLinkName;
         if (op.language.go!.paging.nextLinkOperation) {
           // adapt the next link operation
           const nextPageMethod = adaptNextPageMethod(op, m4CodeModel, client, codeModel);
-          (<go.PageableMethod>method).nextPageMethod = nextPageMethod;
+          method.nextPageMethod = nextPageMethod;
         }
       } else {
         method = new go.Method(op.language.go!.name, client, httpPath, httpMethod, getStatusCodes(op), naming);

--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -29,7 +29,7 @@ export function adaptClients(m4CodeModel: m4.CodeModel, codeModel: go.CodeModel)
     for (const op of values(group.operations)) {
       const httpPath = <string>op.requests![0].protocol.http!.path;
       const httpMethod = op.requests![0].protocol.http!.method;
-      let method: go.Method | go.LROMethod | go.LROPageableMethod | go.PageableMethod;
+      let method: go.MethodType;
       const naming = adaptMethodNaming(op);
 
       if (helpers.isLROOperation(op) && helpers.isPageableOperation(op)) {

--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -97,8 +97,8 @@ function adaptNextPageMethod(op: m4.Operation, m4CodeModel: m4.CodeModel, client
   return nextPageMethod;
 }
 
-function populateMethod(op: m4.Operation, method: go.Method | go.NextPageMethod, m4CodeModel: m4.CodeModel, codeModel: go.CodeModel) {
-  if (go.isMethod(method)) {
+function populateMethod(op: m4.Operation, method: go.MethodType | go.NextPageMethod, m4CodeModel: m4.CodeModel, codeModel: go.CodeModel) {
+  if (method.kind !== 'nextPageMethod') {
     if (hasDescription(op.language.go!)) {
       method.docs.description = op.language.go!.description;
     }
@@ -186,7 +186,7 @@ function adaptMethodLocation(location?: m4.ImplementationLocation): go.Parameter
   }
 }
 
-function adaptMethodParameters(op: m4.Operation, method: go.Method | go.NextPageMethod) {
+function adaptMethodParameters(op: m4.Operation, method: go.MethodType | go.NextPageMethod) {
   if (!op.parameters) {
     return;
   }
@@ -197,7 +197,7 @@ function adaptMethodParameters(op: m4.Operation, method: go.Method | go.NextPage
   }
 }
 
-function adaptResponseEnvelope(m4CodeModel: m4.CodeModel, codeModel: go.CodeModel, op: m4.Operation, forMethod: go.Method): go.ResponseEnvelope {
+function adaptResponseEnvelope(m4CodeModel: m4.CodeModel, codeModel: go.CodeModel, op: m4.Operation, forMethod: go.MethodType): go.ResponseEnvelope {
   const respEnvSchema = <m4.ObjectSchema>op.language.go!.responseEnv;
   const respEnv = new go.ResponseEnvelope(respEnvSchema.language.go!.name, {description: respEnvSchema.language.go!.description}, forMethod);
 

--- a/packages/codegen.go/src/example.ts
+++ b/packages/codegen.go/src/example.ts
@@ -140,29 +140,36 @@ export async function generateExamples(codeModel: go.CodeModel): Promise<Array<E
           methodOptionalParametersText += `}`;
         }
 
-        if (go.isLROMethod(method)) {
-          exampleText += `\tpoller, err := ${clientRef}.${fixUpMethodName(method)}(ctx, ${methodParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, helpers.parameterByValue(p.parameter)).slice(1)).join(', ')}${methodParameters.length > 0 ? ', ' : ''}${methodOptionalParametersText.split('\n').join('\n\t')})\n`
-          exampleText += `\tif err != nil {\n`;
-          exampleText += `\t\tlog.Fatalf("failed to finish the request: %v", err)\n`;
-          exampleText += `\t}\n`;
+        switch (method.kind) {
+          case 'lroMethod':
+          case 'lroPageableMethod':
+            exampleText += `\tpoller, err := ${clientRef}.${fixUpMethodName(method)}(ctx, ${methodParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, helpers.parameterByValue(p.parameter)).slice(1)).join(', ')}${methodParameters.length > 0 ? ', ' : ''}${methodOptionalParametersText.split('\n').join('\n\t')})\n`;
+            exampleText += `\tif err != nil {\n`;
+            exampleText += `\t\tlog.Fatalf("failed to finish the request: %v", err)\n`;
+            exampleText += `\t}\n`;
 
-          exampleText += `\t${checkResponse ? 'res' : '_'}, err ${checkResponse ? ':=' : '='} poller.PollUntilDone(ctx, nil)\n`
-          exampleText += `\tif err != nil {\n`;
-          exampleText += `\t\tlog.Fatalf("failed to pull the result: %v", err)\n`;
-          exampleText += `\t}\n`;
-        } else if (go.isPageableMethod(method)) {
-          exampleText += `\tpager := ${clientRef}.${fixUpMethodName(method)}(${methodParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, helpers.parameterByValue(p.parameter)).slice(1)).join(', ')}${methodParameters.length > 0 ? ', ' : ''}${methodOptionalParametersText.split('\n').join('\n\t')})\n`
-        } else {
-          exampleText += `\t${checkResponse ? 'res' : '_'}, err ${checkResponse ? ':=' : '='} ${clientRef}.${fixUpMethodName(method)}(ctx, ${methodParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, helpers.parameterByValue(p.parameter)).slice(1)).join(', ')}${methodParameters.length > 0 ? ', ' : ''}${methodOptionalParametersText.split('\n').join('\n\t')})\n`
-          exampleText += `\tif err != nil {\n`;
-          exampleText += `\t\tlog.Fatalf("failed to finish the request: %v", err)\n`;
-          exampleText += `\t}\n`;
+            exampleText += `\t${checkResponse ? 'res' : '_'}, err ${checkResponse ? ':=' : '='} poller.PollUntilDone(ctx, nil)\n`
+            exampleText += `\tif err != nil {\n`;
+            exampleText += `\t\tlog.Fatalf("failed to pull the result: %v", err)\n`;
+            exampleText += `\t}\n`;
+            break;
+          case 'method':
+            exampleText += `\t${checkResponse ? 'res' : '_'}, err ${checkResponse ? ':=' : '='} ${clientRef}.${fixUpMethodName(method)}(ctx, ${methodParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, helpers.parameterByValue(p.parameter)).slice(1)).join(', ')}${methodParameters.length > 0 ? ', ' : ''}${methodOptionalParametersText.split('\n').join('\n\t')})\n`;
+            exampleText += `\tif err != nil {\n`;
+            exampleText += `\t\tlog.Fatalf("failed to finish the request: %v", err)\n`;
+            exampleText += `\t}\n`;
+            break;
+          case 'pageableMethod':
+            exampleText += `\tpager := ${clientRef}.${fixUpMethodName(method)}(${methodParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, helpers.parameterByValue(p.parameter)).slice(1)).join(', ')}${methodParameters.length > 0 ? ', ' : ''}${methodOptionalParametersText.split('\n').join('\n\t')})\n`;
+            break;
+          default:
+            method satisfies never;
         }
 
         // check response
-        if (go.isPageableMethod(method)) {
+        if (method.kind === 'lroPageableMethod' || method.kind === 'pageableMethod') {
           let resultName = 'pager';
-          if (go.isLROMethod(method)) {
+          if (method.kind === 'lroPageableMethod') {
             resultName = 'res';
           }
           const itemType = ((method as go.PageableMethod).responseEnvelope.result as go.ModelResult).modelType.fields.find(f => go.isSliceType(f.type))!;

--- a/packages/codegen.go/src/fake/servers.ts
+++ b/packages/codegen.go/src/fake/servers.ts
@@ -734,7 +734,7 @@ function getMethodStatusCodes(method: go.MethodType): Array<number> {
   return statusCodes;
 }
 
-function dispatchForLROBody(clientPkg: string, receiverName: string, method: go.MethodType, imports: ImportManager): string {
+function dispatchForLROBody(clientPkg: string, receiverName: string, method: go.LROMethod | go.LROPageableMethod, imports: ImportManager): string {
   const operationName = fixUpMethodName(method);
   const localVarName = uncapitalize(operationName);
   const operationStateMachine = `${receiverName}.${uncapitalize(operationName)}`;

--- a/packages/codegen.go/src/helpers.ts
+++ b/packages/codegen.go/src/helpers.ts
@@ -98,7 +98,7 @@ export function sortParametersByRequired(a: go.Parameter | go.ParameterGroup, b:
 
 // returns the parameters for the internal request creator method.
 // e.g. "i int, s string"
-export function getCreateRequestParametersSig(method: go.Method | go.NextPageMethod): string {
+export function getCreateRequestParametersSig(method: go.MethodType | go.NextPageMethod): string {
   const methodParams = getMethodParameters(method);
   const params = new Array<string>();
   params.push('ctx context.Context');
@@ -116,7 +116,7 @@ export function getCreateRequestParametersSig(method: go.Method | go.NextPageMet
 
 // returns the parameter names for an operation (excludes the param types).
 // e.g. "i, s"
-export function getCreateRequestParameters(method: go.Method): string {
+export function getCreateRequestParameters(method: go.MethodType): string {
   // NOTE: keep in sync with getCreateRequestParametersSig
   const methodParams = getMethodParameters(method);
   const params = new Array<string>();
@@ -128,7 +128,7 @@ export function getCreateRequestParameters(method: go.Method): string {
 }
 
 // returns the complete collection of method parameters
-export function getMethodParameters(method: go.Method | go.NextPageMethod, paramsFilter?: (p: Array<go.Parameter>) => Array<go.Parameter>): Array<go.Parameter | go.ParameterGroup> {
+export function getMethodParameters(method: go.MethodType | go.NextPageMethod, paramsFilter?: (p: Array<go.Parameter>) => Array<go.Parameter>): Array<go.Parameter | go.ParameterGroup> {
   const params = new Array<go.Parameter>();
   const paramGroups = new Array<go.ParameterGroup>();
   let methodParams = method.parameters;
@@ -167,7 +167,7 @@ export function getMethodParameters(method: go.Method | go.NextPageMethod, param
     return 1;
   });
   // add the optional param group last if it's not already in the list.
-  if (go.isMethod(method)) {
+  if (method.kind !== 'nextPageMethod') {
     if (!values(paramGroups).any(gp => { return gp.groupName === method.optionalParamsGroup.groupName; })) {
       paramGroups.push(method.optionalParamsGroup);
     }
@@ -359,7 +359,7 @@ export function formatLiteralValue(value: go.LiteralValue, withCast: boolean): s
 }
 
 // returns true if at least one of the responses has a schema
-export function hasSchemaResponse(method: go.Method): boolean {
+export function hasSchemaResponse(method: go.MethodType): boolean {
   const result = method.responseEnvelope.result;
   if (!result) {
     return false;
@@ -368,7 +368,7 @@ export function hasSchemaResponse(method: go.Method): boolean {
 }
 
 // returns the name of the response field within the response envelope
-export function getResultFieldName(method: go.Method): string {
+export function getResultFieldName(method: go.MethodType): string {
   const result = method.responseEnvelope.result;
   if (!result) {
     throw new CodegenError('InternalError', `missing result for method ${method.name}`);

--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -1070,7 +1070,7 @@ function generateResponseUnmarshaller(method: go.MethodType, type: go.PossibleTy
   return unmarshallerText;
 }
 
-function createProtocolResponse(client: go.Client, method: go.MethodType, imports: ImportManager): string {
+function createProtocolResponse(client: go.Client, method: go.Method | go.LROPageableMethod | go.PageableMethod, imports: ImportManager): string {
   if (!needsResponseHandler(method)) {
     return '';
   }

--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -142,7 +142,7 @@ export async function generateOperations(codeModel: go.CodeModel): Promise<Array
       }
       opText += generateOperation(client, method, imports, codeModel.options.injectSpans, codeModel.options.generateFakes);
       opText += createProtocolRequest(azureARM, client, method, imports);
-      if (!go.isLROMethod(method) || go.isPageableMethod(method)) {
+      if (method.kind !== 'lroMethod') {
         // LRO responses are handled elsewhere, with the exception of pageable LROs
         opText += createProtocolResponse(client, method, imports);
       }
@@ -325,7 +325,7 @@ function formatHeaderResponseValue(headerResp: go.HeaderResponse | go.HeaderMapR
   return text;
 }
 
-function getZeroReturnValue(method: go.Method, apiType: 'api' | 'op' | 'handler'): string {
+function getZeroReturnValue(method: go.MethodType, apiType: 'api' | 'op' | 'handler'): string {
   let returnType = `${method.responseEnvelope.name}{}`;
   if (go.isLROMethod(method)) {
     if (apiType === 'api' || apiType === 'op') {
@@ -337,7 +337,7 @@ function getZeroReturnValue(method: go.Method, apiType: 'api' | 'op' | 'handler'
   return returnType;
 }
 
-function emitPagerDefinition(client: go.Client, method: go.PageableMethod, imports: ImportManager, injectSpans: boolean, generateFakes: boolean): string {
+function emitPagerDefinition(client: go.Client, method: go.LROPageableMethod | go.PageableMethod, imports: ImportManager, injectSpans: boolean, generateFakes: boolean): string {
   imports.add('context');
   let text = `runtime.NewPager(runtime.PagingHandler[${method.responseEnvelope.name}]{\n`;
   text += `\t\tMore: func(page ${method.responseEnvelope.name}) bool {\n`;
@@ -356,7 +356,7 @@ function emitPagerDefinition(client: go.Client, method: go.PageableMethod, impor
   }
   if (method.nextLinkName) {
     let nextLinkVar: string;
-    if (!go.isLROMethod(method)) {
+    if (method.kind === 'pageableMethod') {
       text += '\t\t\tnextLink := ""\n';
       nextLinkVar = 'nextLink';
       text += '\t\t\tif page != nil {\n';
@@ -418,7 +418,7 @@ function genApiVersionDoc(apiVersions: Array<string>): string {
   return `//\n// Generated from API version ${apiVersions.join(', ')}\n`;
 }
 
-function genRespErrorDoc(method: go.Method): string {
+function genRespErrorDoc(method: go.MethodType): string {
   if (!(method.responseEnvelope.result && go.isHeadAsBooleanResult(method.responseEnvelope.result)) && !go.isPageableMethod(method)) {
     // when head-as-boolean is enabled, no error is returned for 4xx status codes.
     // pager constructors don't return an error
@@ -427,11 +427,11 @@ function genRespErrorDoc(method: go.Method): string {
   return '';
 }
 
-function generateOperation(client: go.Client, method: go.Method, imports: ImportManager, injectSpans: boolean, generateFakes: boolean): string {
+function generateOperation(client: go.Client, method: go.MethodType, imports: ImportManager, injectSpans: boolean, generateFakes: boolean): string {
   const params = getAPIParametersSig(method, imports);
   const returns = generateReturnsInfo(method, 'op');
   let methodName = method.name;
-  if(go.isPageableMethod(method) && !go.isLROMethod(method)) {
+  if(method.kind === 'pageableMethod') {
     methodName = fixUpMethodName(method);
   }
   let text = '';
@@ -456,7 +456,7 @@ function generateOperation(client: go.Client, method: go.Method, imports: Import
   }
   text += `func (client *${client.name}) ${methodName}(${params}) (${returns.join(', ')}) {\n`;
   const reqParams = helpers.getCreateRequestParameters(method);
-  if (go.isPageableMethod(method) && !go.isLROMethod(method)) {
+  if (method.kind === 'pageableMethod') {
     text += '\treturn ';
     text += emitPagerDefinition(client, method, imports, injectSpans, generateFakes);
     text += '}\n\n';
@@ -508,9 +508,9 @@ function generateOperation(client: go.Client, method: go.Method, imports: Import
   return text;
 }
 
-function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.Method | go.NextPageMethod, imports: ImportManager): string {
+function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.MethodType | go.NextPageMethod, imports: ImportManager): string {
   let name = method.name;
-  if (go.isMethod(method)) {
+  if (method.kind !== 'nextPageMethod') {
     name = method.naming.requestMethod;
   }
 
@@ -710,7 +710,7 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
     imports.add('strings');
     text += '\treq.Raw().URL.RawQuery = strings.Join(unencodedParams, "&")\n';
   }
-  if (go.isMethod(method) && method.responseEnvelope.result && go.isBinaryResult(method.responseEnvelope.result)) {
+  if (method.kind !== 'nextPageMethod' && method.responseEnvelope.result && go.isBinaryResult(method.responseEnvelope.result)) {
     // skip auto-body downloading for binary stream responses
     text += '\truntime.SkipBodyDownload(req)\n';
   }
@@ -1000,11 +1000,11 @@ function isArrayOfDateTimeForMarshalling(paramType: go.PossibleType): { format: 
 
 // returns true if the method requires a response handler.
 // this is used to unmarshal the response body, parse response headers, or both.
-function needsResponseHandler(method: go.Method): boolean {
+function needsResponseHandler(method: go.MethodType): boolean {
   return helpers.hasSchemaResponse(method) || method.responseEnvelope.headers.length > 0;
 }
 
-function generateResponseUnmarshaller(method: go.Method, type: go.PossibleType, format: go.ResultFormat, unmarshalTarget: string): string {
+function generateResponseUnmarshaller(method: go.MethodType, type: go.PossibleType, format: go.ResultFormat, unmarshalTarget: string): string {
   let unmarshallerText = '';
   const zeroValue = getZeroReturnValue(method, 'handler');
   if (go.isTimeType(type)) {
@@ -1070,7 +1070,7 @@ function generateResponseUnmarshaller(method: go.Method, type: go.PossibleType, 
   return unmarshallerText;
 }
 
-function createProtocolResponse(client: go.Client, method: go.Method, imports: ImportManager): string {
+function createProtocolResponse(client: go.Client, method: go.MethodType, imports: ImportManager): string {
   if (!needsResponseHandler(method)) {
     return '';
   }
@@ -1165,10 +1165,10 @@ function isMapOfDateTime(paramType: go.PossibleType): string | undefined {
 
 // returns the parameters for the public API
 // e.g. "ctx context.Context, i int, s string"
-function getAPIParametersSig(method: go.Method, imports: ImportManager, pkgName?: string): string {
+function getAPIParametersSig(method: go.MethodType, imports: ImportManager, pkgName?: string): string {
   const methodParams = helpers.getMethodParameters(method);
   const params = new Array<string>();
-  if (!go.isPageableMethod(method) || go.isLROMethod(method)) {
+  if (method.kind !== 'pageableMethod') {
     imports.add('context');
     params.push('ctx context.Context');
   }
@@ -1184,39 +1184,43 @@ function getAPIParametersSig(method: go.Method, imports: ImportManager, pkgName?
 //   api - for the API definition
 //    op - for the operation
 // handler - for the response handler
-function generateReturnsInfo(method: go.Method, apiType: 'api' | 'op' | 'handler'): Array<string> {
+function generateReturnsInfo(method: go.MethodType, apiType: 'api' | 'op' | 'handler'): Array<string> {
   let returnType = method.responseEnvelope.name;
-  if (go.isLROMethod(method)) {
-    switch (apiType) {
-      case 'api':
-        if (go.isPageableMethod(method)) {
-          returnType = `*runtime.Poller[*runtime.Pager[${returnType}]]`;
-        } else {
-          returnType = `*runtime.Poller[${returnType}]`;
-        }
-        break;
-      case 'handler':
-        // we only have a handler for operations that return a schema
-        if (!go.isPageableMethod(method)) {
-          throw new CodegenError('InternalError', `handler being generated for non-pageable LRO ${method.name} which is unexpected`);
-        }
-        break;
-      case 'op':
-        returnType = '*http.Response';
-        break;
-    }
-  } else if (go.isPageableMethod(method)) {
-    switch (apiType) {
-      case 'api':
-      case 'op':
-        // pager operations don't return an error
-        return [`*runtime.Pager[${returnType}]`];
-    }
+  switch (method.kind) {
+    case 'lroMethod':
+    case 'lroPageableMethod':
+      switch (apiType) {
+        case 'api':
+          if (method.kind === 'lroPageableMethod') {
+            returnType = `*runtime.Poller[*runtime.Pager[${returnType}]]`;
+          } else {
+            returnType = `*runtime.Poller[${returnType}]`;
+          }
+          break;
+        case 'handler':
+          // we only have a handler for operations that return a schema
+          if (method.kind !== 'lroPageableMethod') {
+            throw new CodegenError('InternalError', `handler being generated for non-pageable LRO ${method.name} which is unexpected`);
+          }
+          break;
+        case 'op':
+          returnType = '*http.Response';
+          break;
+      }
+      break;
+    case 'pageableMethod':
+      switch (apiType) {
+        case 'api':
+        case 'op':
+          // pager operations don't return an error
+          return [`*runtime.Pager[${returnType}]`];
+      }
+      break;
   }
   return [returnType, 'error'];
 }
 
-function generateLROBeginMethod(client: go.Client, method: go.LROMethod, imports: ImportManager, injectSpans: boolean, generateFakes: boolean): string {
+function generateLROBeginMethod(client: go.Client, method: go.LROMethod | go.LROPageableMethod, imports: ImportManager, injectSpans: boolean, generateFakes: boolean): string {
   const params = getAPIParametersSig(method, imports);
   const returns = generateReturnsInfo(method, 'api');
   imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime');
@@ -1234,7 +1238,7 @@ function generateLROBeginMethod(client: go.Client, method: go.LROMethod, imports
   text += `func (client *${client.name}) ${fixUpMethodName(method)}(${params}) (${returns.join(', ')}) {\n`;
   let pollerType = 'nil';
   let pollerTypeParam = `[${method.responseEnvelope.name}]`;
-  if (go.isPageableMethod(method)) {
+  if (method.kind === 'lroPageableMethod') {
     // for paged LROs, we construct a pager and pass it to the LRO ctor.
     pollerTypeParam = `[*runtime.Pager${pollerTypeParam}]`;
     pollerType = '&pager';
@@ -1329,21 +1333,24 @@ function generateLROBeginMethod(client: go.Client, method: go.LROMethod, imports
   return text;
 }
 
-export function fixUpMethodName(method: go.Method): string {
-  if (go.isLROMethod(method)) {
-    return `Begin${method.name}`;
-  }
-  if (go.isPageableMethod(method)) {
-    let N = 'N';
-    let name = method.name;
-    if (method.name[0] !== method.name[0].toUpperCase()) {
-      // the method isn't exported; don't export the pager ctor
-      N = 'n';
-      // ensure correct casing of the emitted function name e.g.,
-      // "listThings" -> "newListThingsPager"
-      name = name[0].toUpperCase() + name.substring(1);
+export function fixUpMethodName(method: go.MethodType): string {
+  switch (method.kind) {
+    case 'lroMethod':
+    case 'lroPageableMethod':
+      return `Begin${method.name}`;
+    case 'pageableMethod': {
+      let N = 'N';
+      let name = method.name;
+      if (method.name[0] !== method.name[0].toUpperCase()) {
+        // the method isn't exported; don't export the pager ctor
+        N = 'n';
+        // ensure correct casing of the emitted function name e.g.,
+        // "listThings" -> "newListThingsPager"
+        name = name[0].toUpperCase() + name.substring(1);
+      }
+      return `${N}ew${name}Pager`;
     }
-    return `${N}ew${name}Pager`;
+    case 'method':
+      return method.name;
   }
-  return method.name;
 }

--- a/packages/codemodel.go/src/client.ts
+++ b/packages/codemodel.go/src/client.ts
@@ -230,7 +230,7 @@ export class Constructor implements Constructor {
   }
 }
 
-export class LROMethod extends MethodBase implements LROMethodBase {
+export class LROMethod extends MethodBase implements LROMethod {
   constructor(name: string, client: Client, httpPath: string, httpMethod: HTTPMethod, statusCodes: Array<number>, naming: MethodNaming) {
     super(name, client, httpPath, httpMethod, statusCodes, naming);
     this.kind = 'lroMethod';
@@ -275,7 +275,7 @@ export class NextPageMethod implements NextPageMethod {
   }
 }
 
-export class PageableMethod extends MethodBase implements PageableMethodBase {
+export class PageableMethod extends MethodBase implements PageableMethod {
   constructor(name: string, client: Client, httpPath: string, httpMethod: HTTPMethod, statusCodes: Array<number>, naming: MethodNaming) {
     super(name, client, httpPath, httpMethod, statusCodes, naming);
     this.kind = 'pageableMethod';

--- a/packages/codemodel.go/src/client.ts
+++ b/packages/codemodel.go/src/client.ts
@@ -10,121 +10,145 @@ import * as param from './param.js';
 import * as result from './result.js';
 import * as type from './type.js';
 
-// Client is an SDK client
+/** an SDK client */
 export interface Client {
+  /** the name of the client */
   name: string;
 
+  /** any docs for the client */
   docs: type.Docs;
 
-  // the client options type. for ARM, this will be a QualifiedType (arm.ClientOptions)
+  /** the client options type. for ARM, this will be a QualifiedType (arm.ClientOptions) */
   options: ClientOptions;
 
-  // constructor params that are persisted as fields on the client, can be empty
+  /** constructor params that are persisted as fields on the client, can be empty */
   parameters: Array<param.Parameter>;
 
-  // all the constructors for this client, can be empty
+  /** all the constructors for this client, can be empty */
   constructors: Array<Constructor>;
 
-  // contains client methods. can be empty
+  /** contains client methods. can be empty */
   methods: Array<MethodType>;
 
-  // contains any client accessor methods. can be empty
+  /** contains any client accessor methods. can be empty */
   clientAccessors: Array<ClientAccessor>;
 
-  // client has a statically defined or templated host
+  /** client has a statically defined or templated host */
   host?: string;
 
-  // templatedHost indicates that there's one or more URIParameters
-  // required to construct the complete host. the parameters can
-  // be solely on the client or span client and method params.
+  /**
+   * templatedHost indicates that there's one or more URIParameters
+   * required to construct the complete host. the parameters can
+   * be solely on the client or span client and method params.
+   */
   templatedHost: boolean;
 
-  // the parent client in a hierarchical client
+  /** the parent client in a hierarchical client */
   parent?: Client;
 }
 
+/** the possible types used for the client options type */
 export type ClientOptions = param.ParameterGroup | param.Parameter;
 
-// ClientAccessor is a client method that returns a sub-client instance.
+/** a client method that returns a sub-client instance */
 export interface ClientAccessor {
-  // the name of the client accessor method
+  /** the name of the client accessor method */
   name: string;
 
-  // the client returned by the accessor method
+  /** the client returned by the accessor method */
   subClient: Client;
 }
 
-// represents a client constructor function
+/** a client constructor function */
 export interface Constructor {
+  /** the name of the constructor function */
   name: string;
 
-  // the modeled parameters. can be empty
+  /** the modeled parameters. can be empty */
   parameters: Array<param.Parameter>;
 }
 
+/** the possible values defining the "final state via" behavior for LROs */
 export type FinalStateVia = 'azure-async-operation' | 'location' | 'operation-location' | 'original-uri';
 
+/** the supported HTTP verbs */
 export type HTTPMethod = 'delete' | 'get' | 'head' | 'patch' | 'post' | 'put';
 
+/** the possible method types */
 export type MethodType = LROMethod | LROPageableMethod | Method | PageableMethod;
 
+/** a long-running operation method */
 export interface LROMethod extends LROMethodBase {
   kind: 'lroMethod';
 }
 
+/** a long-running operation method that returns pages of responses */
 export interface LROPageableMethod extends LROMethodBase, PageableMethodBase {
   kind: 'lroPageableMethod';
 }
 
-// Method is a method on a client
+/** a synchronous method */
 export interface Method extends MethodBase {
   kind: 'method';
 }
 
+/** contains the names of the helper methods used to create a complete method implementation */
 export interface MethodNaming {
-  // this is the name of the internal method for consumption by LROs/paging methods.
+  /** the name of the internal method for consumption by LROs/paging methods */
   internalMethod: string;
 
+  /** the name of the internal method that creates the HTTP request */
   requestMethod: string;
 
+  /** the name of the internal method that handles the HTTP response */
   responseMethod: string;
 }
 
-// NextPageMethod is the internal method used for fetching the next page for a PageableMethod.
-// It's unique from a regular Method as it's not exported and has no optional params/response envelope.
-// thus, it's not included in the array of methods for a client.
+/**
+ * the internal method used for fetching the next page for a PageableMethod.
+ * It's unique from a regular Method as it's not exported and has no optional params/response envelope.
+ * thus, it's not included in the array of methods for a client.
+ */
 export interface NextPageMethod {
   kind: 'nextPageMethod';
 
+  /** the name of the next page method */
   name: string;
  
+  /** the HTTP path used when creating the request */
   httpPath: string;
 
+  /** the HTTP verb used when creating the request */
   httpMethod: HTTPMethod;
 
-  // any modeled parameters
+  /** any modeled parameters */
   parameters: Array<param.Parameter>;
 
-  // the complete list of successful HTTP status codes
+  /** the complete list of successful HTTP status codes */
   httpStatusCodes: Array<number>;
 
+  /** the client to which the method belongs */
   client: Client;
 
   apiVersions: Array<string>;
 }
 
+/** a synchronous method that returns pages of responses */
 export interface PageableMethod extends PageableMethodBase {
   kind: 'pageableMethod';
 }
 
+/** narrows method to a LRO method type within the conditional block */
 export function isLROMethod(method: MethodType): method is LROMethod | LROPageableMethod {
   return method.kind === 'lroMethod' || method.kind === 'lroPageableMethod';
 }
 
+/** narrows method to a pageable method type within the conditional block */
 export function isPageableMethod(method: MethodType): method is LROPageableMethod | PageableMethod {
   return method.kind === 'lroPageableMethod' || method.kind === 'pageableMethod';
 }
 
+/** creates the ClientOptions type from the specified input */
 export function newClientOptions(modelType: pkg.CodeModelType, clientName: string): ClientOptions {
   let options: ClientOptions;
   if (modelType === 'azure-arm') {
@@ -149,30 +173,39 @@ interface LROMethodBase extends MethodBase {
 }
 
 interface MethodBase {
+  /** the name of the method */
   name: string;
 
+  /** any docs for the method */
   docs: type.Docs;
 
+  /** the HTTP path used when creating the request */
   httpPath: string;
 
+  /** the HTTP verb used when creating the request */
   httpMethod: HTTPMethod;
 
-  // any modeled parameters. the ones we add to the generated code (context.Context etc) aren't included here
+  /** any modeled parameters. the ones we add to the generated code (context.Context etc) aren't included here */
   parameters: Array<param.Parameter>;
 
+  /** the method options type for this methoid */
   optionalParamsGroup: param.ParameterGroup;
 
+  /** the response type for this method */
   responseEnvelope: result.ResponseEnvelope;
 
-  // the complete list of successful HTTP status codes
+  /** the complete list of successful HTTP status codes */
   httpStatusCodes: Array<number>;
 
+  /** the client to which the method belongs */
   client: Client;
 
+  /** naming info for the internal hepler methods for which this method depends */
   naming: MethodNaming;
 
   apiVersions: Array<string>;
 
+  /** any examples for this method */
   examples: Array<MethodExample>;
 }
 

--- a/packages/codemodel.go/src/client.ts
+++ b/packages/codemodel.go/src/client.ts
@@ -176,6 +176,12 @@ interface MethodBase {
   examples: Array<MethodExample>;
 }
 
+interface PageableMethodBase extends MethodBase {
+  nextLinkName?: string;
+
+  nextPageMethod?: NextPageMethod;
+}
+
 class MethodBase implements MethodBase {
   constructor(name: string, client: Client, httpPath: string, httpMethod: HTTPMethod, statusCodes: Array<number>, naming: MethodNaming) {
     if (statusCodes.length === 0) {
@@ -192,12 +198,6 @@ class MethodBase implements MethodBase {
     this.examples = [];
     this.docs = {};
   }
-}
-
-interface PageableMethodBase extends MethodBase {
-  nextLinkName?: string;
-
-  nextPageMethod?: NextPageMethod;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/codemodel.go/src/package.ts
+++ b/packages/codemodel.go/src/package.ts
@@ -142,7 +142,7 @@ export class CodeModel implements CodeModel {
   
     this.clients.sort((a: client.Client, b: client.Client) => { return sortAscending(a.name, b.name); });
     for (const client of this.clients) {
-      client.methods.sort((a: client.Method, b: client.Method) => { return sortAscending(a.name, b.name); });
+      client.methods.sort((a: client.MethodType, b: client.MethodType) => { return sortAscending(a.name, b.name); });
       client.clientAccessors.sort((a: client.ClientAccessor, b: client.ClientAccessor) => { return sortAscending(a.name, b.name); });
       for (const method of client.methods) {
         method.httpStatusCodes.sort();

--- a/packages/codemodel.go/src/result.ts
+++ b/packages/codemodel.go/src/result.ts
@@ -142,7 +142,7 @@ export interface ResponseEnvelope {
   // any modeled response headers
   headers: Array<HeaderResponse | HeaderMapResponse>;
 
-  method: client.Method | client.LROMethod | client.PageableMethod | client.LROPageableMethod;
+  method: client.MethodType;
 }
 
 export type ResultFormat = 'JSON' | 'XML' | 'Text';
@@ -272,7 +272,7 @@ export class PolymorphicResult implements PolymorphicResult {
 }
 
 export class ResponseEnvelope implements ResponseEnvelope {
-  constructor(name: string, docs: type.Docs, forMethod: client.Method) {
+  constructor(name: string, docs: type.Docs, forMethod: client.MethodType) {
     this.docs = docs;
     this.headers = new Array<HeaderResponse | HeaderMapResponse>();
     this.method = forMethod;

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -212,17 +212,17 @@ export class clientAdapter {
       method = new go.PageableMethod(methodName, goClient, sdkMethod.operation.path, sdkMethod.operation.verb, statusCodes, naming);
       if (sdkMethod.nextLinkPath) {
         // TODO: handle nested next link
-        (<go.PageableMethod>method).nextLinkName = capitalize(ensureNameCase(sdkMethod.nextLinkPath));
+        method.nextLinkName = capitalize(ensureNameCase(sdkMethod.nextLinkPath));
       }
     } else if (sdkMethod.kind === 'lro') {
       method = new go.LROMethod(methodName, goClient, sdkMethod.operation.path, sdkMethod.operation.verb, statusCodes, naming);
       const lroOptions = this.hasDecorator('Azure.Core.@useFinalStateVia', sdkMethod.decorators);
       if (lroOptions) {
-        (<go.LROMethod>method).finalStateVia = <go.FinalStateVia>lroOptions['finalState'];
+        method.finalStateVia = <go.FinalStateVia>lroOptions['finalState'];
       }
       if (sdkMethod.lroMetadata.finalResponse?.resultSegments) {
         // 'resultSegments' is designed for furture extensibility, currently only has one segment
-        (<go.LROMethod>method).operationLocationResultPath = sdkMethod.lroMetadata.finalResponse.resultSegments.map((segment) => {
+        method.operationLocationResultPath = sdkMethod.lroMetadata.finalResponse.resultSegments.map((segment) => {
           return (<tcgc.SdkBodyModelPropertyType>segment).serializationOptions.json?.name;
         }).join('.');
       }
@@ -246,33 +246,33 @@ export class clientAdapter {
     return undefined;
   }
 
-  private populateMethod(sdkMethod: tcgc.SdkServiceMethod<tcgc.SdkHttpOperation>, method: go.Method | go.NextPageMethod) {
-    if (go.isMethod(method)) {
-      let prefix = method.client.name;
-      if (this.opts['single-client']) {
-        prefix = '';
-      }
-      if (go.isLROMethod(method)) {
-        prefix += 'Begin';
-      }
-      let optionalParamsGroupName = `${prefix}${method.name}Options`;
-      if (sdkMethod.access === 'internal') {
-        optionalParamsGroupName = uncapitalize(optionalParamsGroupName);
-      }
-      let optsGroupName = 'options';
-      // if there's an existing parameter with the name options then pick something else
-      for (const param of sdkMethod.parameters) {
-        if (param.name === optsGroupName) {
-          optsGroupName = 'opts';
-          break;
-        }
-      }
-      method.optionalParamsGroup = new go.ParameterGroup(optsGroupName, optionalParamsGroupName, false, 'method');
-      method.optionalParamsGroup.docs.summary = createOptionsTypeDescription(optionalParamsGroupName, this.getMethodNameForDocComment(method));
-      method.responseEnvelope = this.adaptResponseEnvelope(sdkMethod, method);
-    } else {
+  private populateMethod(sdkMethod: tcgc.SdkServiceMethod<tcgc.SdkHttpOperation>, method: go.MethodType | go.NextPageMethod) {
+    if (method.kind === 'nextPageMethod') {
       throw new AdapterError('UnsupportedTsp', `unsupported method kind ${sdkMethod.kind}`, sdkMethod.__raw?.node ?? NoTarget);
     }
+
+    let prefix = method.client.name;
+    if (this.opts['single-client']) {
+      prefix = '';
+    }
+    if (go.isLROMethod(method)) {
+      prefix += 'Begin';
+    }
+    let optionalParamsGroupName = `${prefix}${method.name}Options`;
+    if (sdkMethod.access === 'internal') {
+      optionalParamsGroupName = uncapitalize(optionalParamsGroupName);
+    }
+    let optsGroupName = 'options';
+    // if there's an existing parameter with the name options then pick something else
+    for (const param of sdkMethod.parameters) {
+      if (param.name === optsGroupName) {
+        optsGroupName = 'opts';
+        break;
+      }
+    }
+    method.optionalParamsGroup = new go.ParameterGroup(optsGroupName, optionalParamsGroupName, false, 'method');
+    method.optionalParamsGroup.docs.summary = createOptionsTypeDescription(optionalParamsGroupName, this.getMethodNameForDocComment(method));
+    method.responseEnvelope = this.adaptResponseEnvelope(sdkMethod, method);
 
     // find the api version param to use for the doc comment.
     // we can't use sdkMethod.apiVersions as that includes all
@@ -294,11 +294,11 @@ export class clientAdapter {
     }
   }
 
-  private adaptMethodParameters(sdkMethod: tcgc.SdkServiceMethod<tcgc.SdkHttpOperation>, method: go.Method | go.NextPageMethod): Map<tcgc.SdkHttpParameter, Array<go.Parameter>> {
+  private adaptMethodParameters(sdkMethod: tcgc.SdkServiceMethod<tcgc.SdkHttpOperation>, method: go.MethodType | go.NextPageMethod): Map<tcgc.SdkHttpParameter, Array<go.Parameter>> {
     const paramMapping = new Map<tcgc.SdkHttpParameter, Array<go.Parameter>>();
 
     let optionalGroup: go.ParameterGroup | undefined;
-    if (go.isMethod(method)) {
+    if (method.kind !== 'nextPageMethod') {
       // NextPageMethods don't have optional params
       optionalGroup = method.optionalParamsGroup;
       if (go.isLROMethod(method)) {
@@ -570,17 +570,24 @@ export class clientAdapter {
     return adaptedParam;
   }
 
-  private getMethodNameForDocComment(method: go.Method): string {
-    let methodName = method.name;
-    if (go.isLROMethod(method)) {
-      methodName = `Begin${methodName}`;
-    } else if (go.isPageableMethod(method)) {
-      methodName = `New${methodName}Pager`;
+  private getMethodNameForDocComment(method: go.MethodType): string {
+    let methodName: string;
+    switch (method.kind) {
+      case 'lroMethod':
+      case 'lroPageableMethod':
+        methodName = `Begin${method.name}`;
+        break;
+      case 'method':
+        methodName = method.name;
+        break;
+      case 'pageableMethod':
+        methodName = `New${method.name}Pager`;
+        break;
     }
     return `${method.client.name}.${methodName}`;
   }
 
-  private adaptResponseEnvelope(sdkMethod: tcgc.SdkServiceMethod<tcgc.SdkHttpOperation>, method: go.Method): go.ResponseEnvelope {
+  private adaptResponseEnvelope(sdkMethod: tcgc.SdkServiceMethod<tcgc.SdkHttpOperation>, method: go.MethodType): go.ResponseEnvelope {
     // TODO: add Envelope suffix if name collides with existing type
     let prefix = method.client.name;
     if (this.opts['single-client']) {
@@ -828,7 +835,7 @@ export class clientAdapter {
     }
   }
 
-  private adaptHttpOperationExamples(sdkMethod: tcgc.SdkServiceMethod<tcgc.SdkHttpOperation>, method: go.Method, paramMapping: Map<tcgc.SdkHttpParameter, Array<go.Parameter>>) {
+  private adaptHttpOperationExamples(sdkMethod: tcgc.SdkServiceMethod<tcgc.SdkHttpOperation>, method: go.MethodType, paramMapping: Map<tcgc.SdkHttpParameter, Array<go.Parameter>>) {
     if (sdkMethod.operation.examples) {
       for (const example of sdkMethod.operation.examples) {
         const goExample = new go.MethodExample(example.name, {summary: example.doc}, example.filePath);

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -176,7 +176,7 @@ export class clientAdapter {
   }
 
   private adaptMethod(sdkMethod: tcgc.SdkServiceMethod<tcgc.SdkHttpOperation>, goClient: go.Client) {
-    let method: go.Method | go.LROMethod | go.LROPageableMethod | go.PageableMethod;
+    let method: go.MethodType;
     const naming = new go.MethodNaming(getEscapedReservedName(uncapitalize(ensureNameCase(sdkMethod.name)), 'Operation'), ensureNameCase(`${sdkMethod.name}CreateRequest`, true),
       ensureNameCase(`${sdkMethod.name}HandleResponse`, true));
 


### PR DESCRIPTION
Switch to using discriminated unions to distinguish method types. Switch on method.kind instead of if/else chains where appropriate.