### PR TITLE
Refactor code model parameter types

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -19,7 +19,7 @@ import { OperationNaming } from '../transform/namer.js';
 // track all of the client and parameter group params across all operations
 // as not every option might contain them, and parameter groups can be shared
 // across multiple operations
-const clientParams = new Map<string, go.Parameter>();
+const clientParams = new Map<string, go.MethodParameter>();
 const paramGroups = new Map<string, go.ParameterGroup>();
 
 export function adaptClients(m4CodeModel: m4.CodeModel, codeModel: go.CodeModel) {
@@ -120,7 +120,7 @@ function populateMethod(op: m4.Operation, method: go.MethodType | go.NextPageMet
   }
 }
 
-function adaptHeaderType(schema: m4.Schema, forParam: boolean): go.HeaderType {
+function adaptHeaderScalarType(schema: m4.Schema, forParam: boolean): go.HeaderScalarType {
   // for header params, we never pass the element type by pointer
   const type = adaptPossibleType(schema, forParam);
   if (go.isInterfaceType(type) || go.isMapType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type) || go.isQualifiedType(type)) {
@@ -129,7 +129,7 @@ function adaptHeaderType(schema: m4.Schema, forParam: boolean): go.HeaderType {
   return type;
 }
 
-function adaptPathParameterType(schema: m4.Schema): go.PathParameterType {
+function adaptPathScalarParameterType(schema: m4.Schema): go.PathScalarParameterType {
   const type = adaptPossibleType(schema);
   if (go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type)  || go.isQualifiedType(type)) {
     throw new Error(`unexpected path parameter type ${schema.type}`);
@@ -137,7 +137,7 @@ function adaptPathParameterType(schema: m4.Schema): go.PathParameterType {
   return type;
 }
 
-function adaptQueryParameterType(schema: m4.Schema): go.QueryParameterType {
+function adaptQueryScalarParameterType(schema: m4.Schema): go.QueryScalarParameterType {
   const type = adaptPossibleType(schema);
   if (go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type)  || go.isQualifiedType(type)) {
     throw new Error(`unexpected query parameter type ${schema.type}`);
@@ -212,7 +212,7 @@ function adaptResponseEnvelope(m4CodeModel: m4.CodeModel, codeModel: go.CodeMode
         }
         headerResp = new go.HeaderMapResponse(prop.language.go!.name, headerType, prop.schema.language.go!.headerCollectionPrefix, prop.language.go!.fromHeader, prop.language.go!.byValue);
       } else {
-        headerResp = new go.HeaderResponse(prop.language.go!.name, adaptHeaderType(prop.schema, false), prop.language.go!.fromHeader, prop.language.go!.byValue);
+        headerResp = new go.HeaderResponse(prop.language.go!.name, adaptHeaderScalarType(prop.schema, false), prop.language.go!.fromHeader, prop.language.go!.byValue);
       }
       if (hasDescription(prop.language.go!)) {
         headerResp.docs.description = prop.language.go!.description;
@@ -302,8 +302,8 @@ function getStatusCodes(op: m4.Operation): Array<number> {
   return statusCodes;
 }
 
-function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.Parameter {
-  let adaptedParam: go.Parameter;
+function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.MethodParameter {
+  let adaptedParam: go.MethodParameter;
   let location: go.ParameterLocation = 'method';
   if (param.implementation === m4.ImplementationLocation.Client) {
     // check if we've already adapted this client parameter
@@ -341,14 +341,14 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.Paramet
           }
           adaptedParam = new go.FormBodyCollectionParameter(param.language.go!.name, param.language.go!.serializedName, bodyType, collectionFormat, style, param.language.go!.byValue);
         } else {
-          adaptedParam = new go.FormBodyParameter(param.language.go!.name, param.language.go!.serializedName, bodyType, style, param.language.go!.byValue);
+          adaptedParam = new go.FormBodyScalarParameter(param.language.go!.name, param.language.go!.serializedName, bodyType, style, param.language.go!.byValue);
         }
       } else if (op.requests![0].protocol.http!.knownMediaType === KnownMediaType.Multipart) {
         adaptedParam = new go.MultipartFormBodyParameter(param.language.go!.name, bodyType, style, param.language.go!.byValue);
       } else {
         const format = adaptBodyFormat(op.requests![0].protocol);
         adaptedParam = new go.BodyParameter(param.language.go!.name, format, contentType, bodyType, style, param.language.go!.byValue);
-        (<go.BodyParameter>adaptedParam).xml = adaptXMLInfo(param.schema);
+        adaptedParam.xml = adaptXMLInfo(param.schema);
       }
 
       break;
@@ -370,7 +370,7 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.Paramet
         adaptedParam = new go.HeaderCollectionParameter(param.language.go!.name, param.language.go!.serializedName, headerType, collectionFormat, style,
           param.language.go!.byValue, location);
       } else {
-        adaptedParam = new go.HeaderParameter(param.language.go!.name, param.language.go!.serializedName, adaptHeaderType(param.schema, true),
+        adaptedParam = new go.HeaderScalarParameter(param.language.go!.name, param.language.go!.serializedName, adaptHeaderScalarType(param.schema, true),
           style, param.language.go!.byValue, location);
       }
       break;
@@ -385,8 +385,8 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.Paramet
         adaptedParam = new go.PathCollectionParameter(param.language.go!.name, param.language.go!.serializedName, !skipURLEncoding(param),
           pathType, collectionFormat, style, param.language.go!.byValue, location);
       } else {
-        adaptedParam = new go.PathParameter(param.language.go!.name, param.language.go!.serializedName, !skipURLEncoding(param),
-          adaptPathParameterType(param.schema), style, param.language.go!.byValue, location);
+        adaptedParam = new go.PathScalarParameter(param.language.go!.name, param.language.go!.serializedName, !skipURLEncoding(param),
+          adaptPathScalarParameterType(param.schema), style, param.language.go!.byValue, location);
       }
       break;
     }
@@ -400,8 +400,8 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.Paramet
         adaptedParam = new go.QueryCollectionParameter(param.language.go!.name, param.language.go!.serializedName, !skipURLEncoding(param),
           queryType, collectionFormat, style, param.language.go!.byValue, location);
       } else {
-        adaptedParam = new go.QueryParameter(param.language.go!.name, param.language.go!.serializedName, !skipURLEncoding(param),
-          adaptQueryParameterType(param.schema), style, param.language.go!.byValue, location);
+        adaptedParam = new go.QueryScalarParameter(param.language.go!.name, param.language.go!.serializedName, !skipURLEncoding(param),
+          adaptQueryScalarParameterType(param.schema), style, param.language.go!.byValue, location);
       }
       break;
     }
@@ -417,9 +417,7 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.Paramet
       if (param.language.go!.isResumeToken) {
         adaptedParam = new go.ResumeTokenParameter();
       } else {
-        const type = adaptPossibleType(param.schema);
-        const paramLoc = adaptParameterlocation(param);
-        adaptedParam = new go.Parameter(param.language.go!.name, type, style, param.language.go!.byValue, paramLoc);
+        throw new Error(`unknown parameter in operation ${op.language.go!.name}`);
       }
     }
   }
@@ -436,7 +434,7 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.Paramet
   if (param.language.go!.paramGroup) {
     const paramGroup = findOrAdaptParamsGroup(param);
     // parameter groups can be shared across methods so don't add any duplicate parameters
-    if (values(paramGroup.params).where((each: go.Parameter) => { return each.name === adaptedParam.name; }).count() === 0) {
+    if (values(paramGroup.params).where((each: go.MethodParameter) => { return each.name === adaptedParam.name; }).count() === 0) {
       paramGroup.params.push(adaptedParam);
     }
     if (adaptedParam.style === 'required') {

--- a/packages/codegen.go/src/clientFactory.ts
+++ b/packages/codegen.go/src/clientFactory.ts
@@ -19,14 +19,14 @@ export async function generateClientFactory(codeModel: go.CodeModel): Promise<st
   // the list of packages to import
   const imports = new ImportManager();
 
-  let clientFactoryParams:  Array<go.Parameter>;
+  let clientFactoryParams:  Array<go.ClientParameter>;
   if (codeModel.options.factoryGatherAllParams) {
     clientFactoryParams =  helpers.getAllClientParameters(codeModel);
   } else {
     clientFactoryParams = helpers.getCommonClientParameters(codeModel);
   }
 
-  const clientFactoryParamsMap = new Map<string, go.Parameter>();
+  const clientFactoryParamsMap = new Map<string, go.ClientParameter>();
   for (const param of clientFactoryParams) {
     clientFactoryParamsMap.set(param.name, param);
   }
@@ -67,8 +67,8 @@ export async function generateClientFactory(codeModel: go.CodeModel): Promise<st
 
   // add new sub client method for all operation groups
   for (const client of codeModel.clients) {
-    const clientPrivateParams = new Array<go.Parameter>();
-    const clientCommonParams = new Array<go.Parameter>();
+    const clientPrivateParams = new Array<go.ClientParameter>();
+    const clientCommonParams = new Array<go.ClientParameter>();
     for (const param of client.parameters) {
       if (clientFactoryParamsMap.has(param.name)) {
         clientCommonParams.push(param);

--- a/packages/codegen.go/src/example.ts
+++ b/packages/codegen.go/src/example.ts
@@ -43,13 +43,13 @@ export async function generateExamples(codeModel: go.CodeModel): Promise<Array<E
       imports.add(codeModel.options.module!.name);
     }
 
-    let clientFactoryParams = new Array<go.Parameter>();
+    let clientFactoryParams = new Array<go.ClientParameter>();
     if (codeModel.options.factoryGatherAllParams) {
       clientFactoryParams =  helpers.getAllClientParameters(codeModel);
     } else {
       clientFactoryParams = helpers.getCommonClientParameters(codeModel);
     }
-    const clientFactoryParamsMap = new Map<string, go.Parameter>();
+    const clientFactoryParamsMap = new Map<string, go.ClientParameter>();
     for (const param of clientFactoryParams) {
       clientFactoryParamsMap.set(param.name, param);
     }

--- a/packages/codegen.go/src/fake/servers.ts
+++ b/packages/codegen.go/src/fake/servers.ts
@@ -434,11 +434,12 @@ function generateServerTransportMethods(codeModel: go.CodeModel, serverTransport
 }
 
 function dispatchForOperationBody(clientPkg: string, receiverName: string, method: go.MethodType, imports: ImportManager): string {
-  const numPathParams = values(method.parameters).where((each: go.Parameter) => { return go.isPathParameter(each) && !go.isLiteralParameter(each); }).count();
+  const methodParamGroups = helpers.getMethodParamGroups(method);
+  const numPathParams = values(methodParamGroups.pathParams).where((each: go.PathParameter) => { return !go.isLiteralParameter(each); }).count();
   let content = '';
   if (numPathParams > 0) {
     imports.add('regexp');
-    content += `\tconst regexStr = \`${createPathParamsRegex(method)}\`\n`;
+    content += `\tconst regexStr = \`${createPathParamsRegex(method, methodParamGroups.pathParams)}\`\n`;
     content += '\tregex := regexp.MustCompile(regexStr)\n';
     content += '\tmatches := regex.FindStringSubmatch(req.URL.EscapedPath())\n';
     // the total number of matches is the number of capture groups
@@ -446,31 +447,69 @@ function dispatchForOperationBody(clientPkg: string, receiverName: string, metho
     content += `\tif len(matches) < ${numPathParams + 1} {\n`;
     content += '\t\treturn nil, fmt.Errorf("failed to parse path %s", req.URL.Path)\n\t}\n';
   }
-  if (values(method.parameters).where((each: go.Parameter) => { return go.isQueryParameter(each) && each.location === 'method' && !go.isLiteralParameter(each); }).any()) {
+
+  const allQueryParams = methodParamGroups.encodedQueryParams.concat(methodParamGroups.unencodedQueryParams);
+  if (values(allQueryParams).where((each: go.QueryParameter) => { return each.location === 'method' && !go.isLiteralParameter(each); }).any()) {
     content += '\tqp := req.URL.Query()\n';
   }
 
-  const bodyParam = <go.BodyParameter | undefined>values(method.parameters).where((each: go.Parameter) => {
-    return go.isBodyParameter(each) || go.isFormBodyParameter(each) || go.isMultipartFormBodyParameter(each) || go.isPartialBodyParameter(each);
-  }).first();
+  // note that these are mutually exclusive
+  const bodyParam = methodParamGroups.bodyParam;
+  const formBodyParams = methodParamGroups.formBodyParams;
+  const multipartBodyParams = methodParamGroups.multipartBodyParams;
+  const partialBodyParams = methodParamGroups.partialBodyParams;
 
-  if (!bodyParam) {
-    // no body, just headers and/or query params
-  } else if (go.isMultipartFormBodyParameter(bodyParam)) {
+  if (bodyParam) {
+    switch (bodyParam.bodyFormat) {
+      case 'JSON':
+      case 'XML':
+        if (bodyParam && !go.isLiteralParameter(bodyParam)) {
+          imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/fake', 'azfake');
+          if (go.isBytesType(bodyParam.type)) {
+            content += `\tbody, err := server.UnmarshalRequestAsByteArray(req, runtime.Base64${bodyParam.type.encoding}Format)\n`;
+            content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
+          } else if (go.isSliceType(bodyParam.type) && bodyParam.type.rawJSONAsBytes) {
+            content += '\tbody, err := io.ReadAll(req.Body)\n';
+            content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
+            content += '\treq.Body.Close()\n';
+          } else if (go.isInterfaceType(bodyParam.type)) {
+            requiredHelpers.readRequestBody = true;
+            content += '\traw, err := readRequestBody(req)\n';
+            content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
+            content += `\tbody, err := unmarshal${bodyParam.type.name}(raw)\n`;
+            content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
+          } else {
+            let bodyTypeName = go.getTypeDeclaration(bodyParam.type, clientPkg);
+            if (go.isTimeType(bodyParam.type)) {
+              bodyTypeName = bodyParam.type.dateTimeFormat;
+            }
+            content += `\tbody, err := server.UnmarshalRequestAs${bodyParam.bodyFormat}[${bodyTypeName}](req)\n`;
+            content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
+          }
+        }
+        break;
+      case 'Text':
+        if (bodyParam && !go.isLiteralParameter(bodyParam)) {
+          imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/fake', 'azfake');
+          content += '\tbody, err := server.UnmarshalRequestAsText(req)\n';
+          content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
+        }
+        break;
+    }
+    // nothing to do for binary media type
+  } else if (multipartBodyParams.length > 0) {
     imports.add('io');
     imports.add('mime');
     imports.add('mime/multipart');
     content += '\t_, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))\n';
     content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
     content += '\treader := multipart.NewReader(req.Body, params["boundary"])\n';
-    for (const param of values(method.parameters)) {
-      if (go.isMultipartFormBodyParameter(param)) {
-        let pkgPrefix = '';
-        if (go.isConstantType(param.type) || go.isModelType(param.type)) {
-          pkgPrefix = clientPkg + '.';
-        }
-        content += `\tvar ${param.name} ${pkgPrefix}${go.getTypeDeclaration(param.type)}\n`;
+    for (const param of multipartBodyParams) {
+      let pkgPrefix = '';
+      if (go.isConstantType(param.type) || go.isModelType(param.type)) {
+        pkgPrefix = clientPkg + '.';
       }
+      content += `\tvar ${param.name} ${pkgPrefix}${go.getTypeDeclaration(param.type)}\n`;
     }
 
     content += '\tfor {\n';
@@ -605,94 +644,52 @@ function dispatchForOperationBody(clientPkg: string, receiverName: string, metho
       return caseContent;
     };
 
-    for (const param of values(method.parameters)) {
-      if (go.isMultipartFormBodyParameter(param)) {
-        if (go.isModelType(param.type)) {
-          for (const field of param.type.fields) {
-            content += emitCase(field.serializedName, `${param.name}.${field.name}`, field.type);
-          }
-        } else {
-          content += emitCase(param.name, param.name, param.type);
+    for (const param of multipartBodyParams) {
+      if (go.isModelType(param.type)) {
+        for (const field of param.type.fields) {
+          content += emitCase(field.serializedName, `${param.name}.${field.name}`, field.type);
         }
+      } else {
+        content += emitCase(param.name, param.name, param.type);
       }
     }
 
     content += '\t\tdefault:\n\t\t\treturn nil, fmt.Errorf("unexpected part %s", fn)\n';
     content += '\t\t}\n'; // end switch
     content += '\t}\n'; // end for
-  } else if (go.isFormBodyParameter(bodyParam)) {
-    for (const param of values(method.parameters)) {
-      if (go.isFormBodyParameter(param)) {
-        let pkgPrefix = '';
-        if (go.isConstantType(param.type)) {
-          pkgPrefix = clientPkg + '.';
-        }
-        content += `\tvar ${param.name} ${pkgPrefix}${go.getTypeDeclaration(param.type)}\n`;
+  } else if (formBodyParams.length > 0) {
+    for (const param of formBodyParams) {
+      let pkgPrefix = '';
+      if (go.isConstantType(param.type)) {
+        pkgPrefix = clientPkg + '.';
       }
+      content += `\tvar ${param.name} ${pkgPrefix}${go.getTypeDeclaration(param.type)}\n`;
     }
     content += '\tif err := req.ParseForm(); err != nil {\n\t\treturn nil, &nonRetriableError{fmt.Errorf("failed parsing form data: %v", err)}\n\t}\n';
     content += '\tfor key := range req.Form {\n';
     content += '\t\tswitch key {\n';
-    for (const param of values(method.parameters)) {
-      if (go.isFormBodyParameter(param)) {
-        content += `\t\tcase "${param.formDataName}":\n`;
-        let assignedValue: string;
-        if (go.isConstantType(param.type)) {
-          assignedValue = `${go.getTypeDeclaration(param.type, clientPkg)}(req.FormValue(key))`;
-        } else if (go.isPrimitiveType(param.type) && param.type.typeName === 'string') {
-          assignedValue = 'req.FormValue(key)';
-        } else {
-          throw new CodegenError('InternalError', `uhandled form parameter type ${go.getTypeDeclaration(param.type)}`);
-        }
-        content += `\t\t\t${param.name} = ${assignedValue}\n`;
+    for (const param of formBodyParams) {
+      content += `\t\tcase "${param.formDataName}":\n`;
+      let assignedValue: string;
+      if (go.isConstantType(param.type)) {
+        assignedValue = `${go.getTypeDeclaration(param.type, clientPkg)}(req.FormValue(key))`;
+      } else if (go.isPrimitiveType(param.type) && param.type.typeName === 'string') {
+        assignedValue = 'req.FormValue(key)';
+      } else {
+        throw new CodegenError('InternalError', `uhandled form parameter type ${go.getTypeDeclaration(param.type)}`);
       }
+      content += `\t\t\t${param.name} = ${assignedValue}\n`;
     }
     content += '\t\t}\n'; // end switch
     content += '\t}\n'; // end for
-  } else if (bodyParam.bodyFormat === 'binary') {
-    // nothing to do for binary media type
-  } else if (bodyParam.bodyFormat === 'Text') {
-    if (bodyParam && !go.isLiteralParameter(bodyParam)) {
-      imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/fake', 'azfake');
-      content += '\tbody, err := server.UnmarshalRequestAsText(req)\n';
-      content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
-    }
-  } else if (bodyParam.bodyFormat === 'JSON' || bodyParam.bodyFormat === 'XML') {
-    if (bodyParam && !go.isLiteralParameter(bodyParam)) {
-      imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/fake', 'azfake');
-      if (go.isBytesType(bodyParam.type)) {
-        content += `\tbody, err := server.UnmarshalRequestAsByteArray(req, runtime.Base64${bodyParam.type.encoding}Format)\n`;
-        content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
-      } else if (go.isSliceType(bodyParam.type) && bodyParam.type.rawJSONAsBytes) {
-        content += '\tbody, err := io.ReadAll(req.Body)\n';
-        content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
-        content += '\treq.Body.Close()\n';
-      } else if (go.isInterfaceType(bodyParam.type)) {
-        requiredHelpers.readRequestBody = true;
-        content += '\traw, err := readRequestBody(req)\n';
-        content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
-        content += `\tbody, err := unmarshal${bodyParam.type.name}(raw)\n`;
-        content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
-      } else {
-        let bodyTypeName = go.getTypeDeclaration(bodyParam.type, clientPkg);
-        if (go.isTimeType(bodyParam.type)) {
-          bodyTypeName = bodyParam.type.dateTimeFormat;
-        }
-        content += `\tbody, err := server.UnmarshalRequestAs${bodyParam.bodyFormat}[${bodyTypeName}](req)\n`;
-        content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
-      }
-    }
-  }
-
-  const partialBodyParams = values(method.parameters).where((param: go.Parameter) => { return go.isPartialBodyParameter(param); }).toArray();
-  if (partialBodyParams.length > 0) {
+  } else if (partialBodyParams.length > 0) {
     // construct the partial body params type and unmarshal it
     content += '\ttype partialBodyParams struct {\n';
-    for (const partialBodyParam of <Array<go.PartialBodyParameter>>partialBodyParams) {
+    for (const partialBodyParam of partialBodyParams) {
       content += `\t\t${capitalize(partialBodyParam.name)} ${helpers.star(partialBodyParam)}${go.getTypeDeclaration(partialBodyParam.type)} \`json:"${partialBodyParam.serializedName}"\`\n`;
     }
     content += '\t}\n';
-    content += `\tbody, err := server.UnmarshalRequestAs${(<Array<go.PartialBodyParameter>>partialBodyParams)[0].format}[partialBodyParams](req)\n`;
+    content += `\tbody, err := server.UnmarshalRequestAs${partialBodyParams[0].format}[partialBodyParams](req)\n`;
     content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
   }
 
@@ -700,7 +697,7 @@ function dispatchForOperationBody(clientPkg: string, receiverName: string, metho
   content += result.content;
 
   // translate each partial body param to its field within the unmarshalled body
-  for (const partialBodyParam of <Array<go.PartialBodyParameter>>partialBodyParams) {
+  for (const partialBodyParam of partialBodyParams) {
     result.params.set(partialBodyParam.name, `${helpers.star(partialBodyParam)}body.${capitalize(partialBodyParam.name)}`);
   }
 
@@ -794,7 +791,7 @@ function sanitizeRegexpCaptureGroupName(name: string): string {
   return name.replace('-', '_');
 }
 
-function createPathParamsRegex(method: go.MethodType): string {
+function createPathParamsRegex(method: go.MethodType, pathParams: Array<go.PathParameter>): string {
   // "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}"
   // each path param will replaced with a regex capture.
   // note that some path params are optional.
@@ -803,10 +800,7 @@ function createPathParamsRegex(method: go.MethodType): string {
   // per RFC3986, these are the pchars that also double as regex tokens
   // . $ * + ()
   urlPath = urlPath.replace(/([.$*+()])/g, '\\$1');
-  for (const param of values(method.parameters)) {
-    if (!go.isPathParameter(param)) {
-      continue;
-    }
+  for (const param of pathParams) {
     const toReplace = `{${param.pathSegment}}`;
     let replaceWith = `(?P<${sanitizeRegexpCaptureGroupName(param.pathSegment)}>[!#&$-;=?-\\[\\]_a-zA-Z0-9~%@]+)`;
     if (param.style === 'optional' || param.style === 'flag') {
@@ -832,7 +826,7 @@ function parseHeaderPathQueryParams(clientPkg: string, method: go.MethodType, im
   let content = '';
   const paramValues = new Map<string, string>();
 
-  const createLocalVariableName = function (param: go.Parameter, suffix: string): string {
+  const createLocalVariableName = function (param: go.MethodParameter, suffix: string): string {
     const paramName = `${uncapitalize(param.name)}${suffix}`;
     paramValues.set(param.name, paramName);
     return paramName;
@@ -855,14 +849,14 @@ function parseHeaderPathQueryParams(clientPkg: string, method: go.MethodType, im
 
   // track the param groups that need to be instantiated/populated.
   // we track the params separately as it might be a subset of ParameterGroup.params
-  const paramGroups = new Map<go.ParameterGroup, Array<go.Parameter>>();
+  const paramGroups = new Map<go.ParameterGroup, Array<go.MethodParameter>>();
 
   for (const param of values(consolidateHostParams(method.parameters))) {
     if (param.location === 'client' || go.isLiteralParameter(param)) {
       // client params and parameter literals aren't passed to APIs
       continue;
     }
-    if (go.isResumeTokenParameter(param)) {
+    if (param.kind === 'resumeTokenParam') {
       // skip the ResumeToken param as we don't send that back to the caller
       continue;
     }
@@ -870,16 +864,22 @@ function parseHeaderPathQueryParams(clientPkg: string, method: go.MethodType, im
     // NOTE: param group check must happen before skipping body params.
     // this is to handle the case where the body param is grouped/optional
     if (param.group) {
-      if (!paramGroups.has(param.group)) {
-        paramGroups.set(param.group, new Array<go.Parameter>());
+      let params = paramGroups.get(param.group);
+      if (!params) {
+        params = new Array<go.MethodParameter>();
+        paramGroups.set(param.group, params);
       }
-      const params = paramGroups.get(param.group);
-      params!.push(param);
+      params.push(param);
     }
 
-    if (go.isBodyParameter(param) || go.isFormBodyParameter(param) || go.isMultipartFormBodyParameter(param) || go.isPartialBodyParameter(param)) {
-      // body params will be unmarshalled, no need for parsing.
-      continue;
+    switch (param.kind) {
+      case 'bodyParam':
+      case 'formBodyCollectionParam':
+      case 'formBodyScalarParam':
+      case 'multipartFormBodyParam':
+      case 'partialBodyParam':
+        // body params will be unmarshalled, no need for parsing.
+        continue;
     }
 
     // paramValue is initialized with the "raw" source value.
@@ -891,7 +891,7 @@ function parseHeaderPathQueryParams(clientPkg: string, method: go.MethodType, im
 
     // path/query params might be escaped, so we need to unescape them first.
     // must handle query collections first as it's a superset of query param.
-    if (go.isQueryCollectionParameter(param) && param.collectionFormat === 'multi') {
+    if (param.kind === 'queryCollectionParam' && param.collectionFormat === 'multi') {
       imports.add('net/url');
       const escapedParam = createLocalVariableName(param, 'Escaped');
       content += `\t${escapedParam} := ${paramValue}\n`;
@@ -941,7 +941,7 @@ function parseHeaderPathQueryParams(clientPkg: string, method: go.MethodType, im
     }
 
     // parse params as required
-    if (go.isHeaderCollectionParameter(param) || go.isPathCollectionParameter(param) || go.isQueryCollectionParameter(param)) {
+    if (param.kind === 'headerCollectionParam' || param.kind === 'pathCollectionParam' || param.kind === 'queryCollectionParam') {
       // any element type other than string will require some form of conversion/parsing
       if (!(go.isPrimitiveType(param.type.elementType) && param.type.elementType.typeName === 'string')) {
         if (param.collectionFormat !== 'multi') {
@@ -1098,7 +1098,7 @@ function parseHeaderPathQueryParams(clientPkg: string, method: go.MethodType, im
         content += `\t${createLocalVariableName(param, 'Param')}, err := ${emitNumericConversion(paramValue, param.type.typeName)}\n`;
       }
       content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
-    } else if (go.isHeaderMapParameter(param)) {
+    } else if (param.kind === 'headerMapParam') {
       imports.add('strings');
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/to');
       const localVar = createLocalVariableName(param, 'Param');
@@ -1162,7 +1162,7 @@ function parseHeaderPathQueryParams(clientPkg: string, method: go.MethodType, im
         // check array before body in case the body is just an array
         if (go.isSliceType(param.type)) {
           paramNilCheck.push(`len(${getFinalParamValue(clientPkg, param, paramValues)}) > 0`);
-        } else if (go.isBodyParameter(param)) {
+        } else if (param.kind === 'bodyParam') {
           if (param.bodyFormat === 'binary') {
             imports.add('io');
             paramNilCheck.push('req.Body != nil');
@@ -1170,7 +1170,7 @@ function parseHeaderPathQueryParams(clientPkg: string, method: go.MethodType, im
             imports.add('reflect');
             paramNilCheck.push('!reflect.ValueOf(body).IsZero()');
           }
-        } else if (go.isFormBodyParameter(param) || go.isMultipartFormBodyParameter(param)) {
+        } else if (go.isFormBodyParameter(param) || param.kind === 'multipartFormBodyParam') {
           imports.add('reflect');
           paramNilCheck.push(`!reflect.ValueOf(${param.name}).IsZero()`);
         } else {
@@ -1181,7 +1181,7 @@ function parseHeaderPathQueryParams(clientPkg: string, method: go.MethodType, im
       content += `\t\t${uncapitalize(paramGroup.name)} = &${clientPkg}.${paramGroup.groupName}{\n`;
       for (const param of values(params)) {
         let byRef = '&';
-        if (param.byValue || (!go.isRequiredParameter(param) && !go.isBodyParameter(param) && !go.isFormBodyParameter(param) && !go.isMultipartFormBodyParameter(param))) {
+        if (param.byValue || (!go.isRequiredParameter(param) && param.kind !== 'bodyParam' && !go.isFormBodyParameter(param) && param.kind !== 'multipartFormBodyParam')) {
           byRef = '';
         }
         content += `\t\t\t${capitalize(param.name)}: ${byRef}${getFinalParamValue(clientPkg, param, paramValues)},\n`;
@@ -1211,10 +1211,10 @@ function populateApiParams(clientPkg: string, method: go.MethodType, paramValues
 
   // now create the API call sig
   for (const param of values(helpers.getMethodParameters(method, consolidateHostParams))) {
-    if (helpers.isParameterGroup(param)) {
+    if (param.kind === 'paramGroup') {
       if (param.groupName === method.optionalParamsGroup.groupName) {
         // this is the optional params type. in some cases we just pass nil
-        const countParams = values(param.params).where((each: go.Parameter) => { return !go.isResumeTokenParameter(each); }).count();
+        const countParams = values(param.params).where((each: go.MethodParameter) => { return each.kind !== 'resumeTokenParam'; }).count();
         if (countParams === 0) {
           // if the options param is empty or only contains the resume token param just pass nil
           params.push('nil');
@@ -1235,43 +1235,48 @@ function populateApiParams(clientPkg: string, method: go.MethodType, paramValues
 
 // getRawParamValue returns the "raw" value for the specified parameter.
 // depending on the type, the value might require parsing before it can be passed to the fake.
-function getRawParamValue(param: go.Parameter): string {
-  if (go.isFormBodyParameter(param) || go.isMultipartFormBodyParameter(param) || go.isPartialBodyParameter(param)) {
-    // multipart form data values have been read and assigned
-    // to local params with the same name. must check this first
-    // as it's a superset of other cases that follow.
-    return param.name;
-  } else if (go.isPathParameter(param)) {
-    // path params are in the matches slice
-    return `matches[regex.SubexpIndex("${sanitizeRegexpCaptureGroupName(param.pathSegment)}")]`;
-  } else if (go.isQueryParameter(param)) {
-    // use qp
-    if (go.isQueryCollectionParameter(param) && param.collectionFormat === 'multi') {
-      return `qp["${param.queryParameter}"]`;
-    }
-    return `qp.Get("${param.queryParameter}")`;
-  } else if (go.isHeaderParameter(param)) {
-    if (go.isHeaderMapParameter(param)) {
+function getRawParamValue(param: go.MethodParameter): string {
+  switch (param.kind) {
+    case 'bodyParam':
+      if (param.bodyFormat === 'binary') {
+        return 'req.Body.(io.ReadSeekCloser)';
+      }
+      // JSON/XML/text bodies have been deserialized into a local named body
+      return 'body';
+    case 'formBodyCollectionParam':
+    case 'formBodyScalarParam':
+    case 'multipartFormBodyParam':
+    case 'partialBodyParam':
+      // multipart form data values have been read and assigned
+      // to local params with the same name.
+      return param.name;
+    case 'headerCollectionParam':
+    case 'headerScalarParam':
+      // use req
+      requiredHelpers.getHeaderValue = true;
+      return `getHeaderValue(req.Header, "${param.headerName}")`;
+    case 'headerMapParam':
       return 'req.Header';
-    }
-    // use req
-    requiredHelpers.getHeaderValue = true;
-    return `getHeaderValue(req.Header, "${param.headerName}")`;
-  } else if (go.isBodyParameter(param)) {
-    if (param.bodyFormat === 'binary') {
-      return 'req.Body.(io.ReadSeekCloser)';
-    }
-    // JSON/XML/text bodies have been deserialized into a local named body
-    return 'body';
-  } else if (go.isURIParameter(param)) {
-    return 'req.URL.Host';
-  } else {
-    throw new CodegenError('InternalError', `unhandled parameter ${param.name}`);
+    case 'pathCollectionParam':
+    case 'pathScalarParam':
+      // path params are in the matches slice
+      return `matches[regex.SubexpIndex("${sanitizeRegexpCaptureGroupName(param.pathSegment)}")]`;
+    case 'queryCollectionParam':
+    case 'queryScalarParam':
+      // use qp
+      if (param.kind === 'queryCollectionParam' && param.collectionFormat === 'multi') {
+        return `qp["${param.queryParameter}"]`;
+      }
+      return `qp.Get("${param.queryParameter}")`;
+    case 'uriParam':
+      return 'req.URL.Host';
+    default:
+      throw new CodegenError('InternalError', `unhandled parameter ${param.name}`);
   }
 }
 
 // getFinalParamValue returns the "final" value of param to be passed to the fake.
-function getFinalParamValue(clientPkg: string, param: go.Parameter, paramValues: Map<string, string>): string {
+function getFinalParamValue(clientPkg: string, param: go.MethodParameter, paramValues: Map<string, string>): string {
   let paramValue = paramValues.get(param.name);
   if (!paramValue) {
     // the param didn't require parsing so the "raw" value can be used
@@ -1280,12 +1285,12 @@ function getFinalParamValue(clientPkg: string, param: go.Parameter, paramValues:
 
   // there are a few corner-cases that require some fix-ups
 
-  if ((go.isBodyParameter(param) || go.isFormBodyParameter(param) || go.isFormBodyCollectionParameter(param) || go.isMultipartFormBodyParameter(param)) && go.isTimeType(param.type)) {
+  if ((param.kind === 'bodyParam' || go.isFormBodyParameter(param) || param.kind === 'multipartFormBodyParam') && go.isTimeType(param.type)) {
     // time types in the body have been unmarshalled into our time helpers thus require a cast to time.Time
     return `time.Time(${paramValue})`;
   } else if (go.isRequiredParameter(param)) {
     // optional params are always in their "final" form
-    if (go.isHeaderCollectionParameter(param) || go.isPathCollectionParameter(param) || go.isQueryCollectionParameter(param)) {
+    if (param.kind === 'headerCollectionParam' || param.kind === 'pathCollectionParam' || param.kind === 'queryCollectionParam') {
       // for required params that are collections of strings, we split them inline.
       // not necessary for optional params as they're already in slice format.
       if (param.collectionFormat !== 'multi' && go.isPrimitiveType(param.type.elementType) && param.type.elementType.typeName === 'string') {
@@ -1296,7 +1301,7 @@ function getFinalParamValue(clientPkg: string, param: go.Parameter, paramValues:
       // since headers aren't escaped, we cast required, string-based enums inline
       return `${go.getTypeDeclaration(param.type, clientPkg)}(${paramValue})`;
     }
-  } else if (go.isPartialBodyParameter(param)) {
+  } else if (param.kind === 'partialBodyParam') {
     // use the value from the unmarshaled, intermediate struct type
     return `body.${capitalize(param.name)}`;
   }
@@ -1309,17 +1314,17 @@ function getFinalParamValue(clientPkg: string, param: go.Parameter, paramValues:
 // e.g. host := "{vault}{secret}{dnsSuffix}" becomes http://contososecret.com
 // there's no way to reliably split the host back up into its constituent parameters.
 // so we just pass the full value as a single host parameter.
-function consolidateHostParams(params: Array<go.Parameter>): Array<go.Parameter> {
-  if (!values(params).where((each: go.Parameter) => { return go.isURIParameter(each); }).any()) {
+function consolidateHostParams(params: Array<go.MethodParameter>): Array<go.MethodParameter> {
+  if (!values(params).where((each: go.MethodParameter) => { return each.kind === 'uriParam'; }).any()) {
     // no host params
     return params;
   }
 
   // consolidate multiple host params into a single "host" param
-  const consolidatedParams = new Array<go.Parameter>();
+  const consolidatedParams = new Array<go.MethodParameter>();
   let hostParamAdded = false;
   for (const param of values(params)) {
-    if (!go.isURIParameter(param)) {
+    if (param.kind !== 'uriParam') {
       consolidatedParams.push(param);
     } else if (!hostParamAdded) {
       consolidatedParams.push(param);
@@ -1340,7 +1345,7 @@ function getAPIParametersSig(method: go.MethodType, imports: ImportManager, pkgN
   }
   for (const methodParam of values(methodParams)) {
     let paramName = uncapitalize(methodParam.name);
-    if (helpers.isParameter(methodParam) && go.isURIParameter(methodParam)) {
+    if (methodParam.kind === 'uriParam') {
       paramName = 'host';
     }
     params.push(`${paramName} ${helpers.formatParameterTypeName(methodParam, pkgName)}`);

--- a/packages/codegen.go/src/helpers.ts
+++ b/packages/codegen.go/src/helpers.ts
@@ -38,54 +38,54 @@ export function sortAscending(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
-export function isParameter(param: go.Parameter | go.ParameterGroup): param is go.Parameter {
-  return (<go.ParameterGroup>param).groupName === undefined;
-}
-
-export function isParameterGroup(param: go.Parameter | go.ParameterGroup): param is go.ParameterGroup {
-  return (<go.ParameterGroup>param).groupName !== undefined;
-}
-
 // returns the type name with possible * prefix
-export function formatParameterTypeName(param: go.Parameter | go.ParameterGroup, pkgName?: string): string {
+export function formatParameterTypeName(param: go.ClientParameter | go.ParameterGroup, pkgName?: string): string {
   let typeName: string;
-  if (isParameterGroup(param)) {
-    typeName = param.groupName;
-    if (pkgName) {
-      typeName = `${pkgName}.${typeName}`;
-    }
-    if (param.required) {
-      return typeName;
-    }
-  } else {
-    typeName = go.getTypeDeclaration(param.type, pkgName);
-    if (parameterByValue(param)) {
-      // client parameters with default values aren't emitted as pointer-to-type
-      return typeName;
-    }
+  switch (param.kind) {
+    case 'paramGroup':
+      typeName = param.groupName;
+      if (pkgName) {
+        typeName = `${pkgName}.${typeName}`;
+      }
+      if (param.required) {
+        return typeName;
+      }
+      break;
+    default:
+      typeName = go.getTypeDeclaration(param.type, pkgName);
+      if (parameterByValue(param)) {
+        // client parameters with default values aren't emitted as pointer-to-type
+        return typeName;
+      }
   }
   return `*${typeName}`;
 }
 
-export function parameterByValue(param: go.Parameter): boolean {
+export function parameterByValue(param: go.ClientParameter): boolean {
   return go.isRequiredParameter(param) || (param.location === 'client' && go.isClientSideDefault(param.style))
 }
 
 // sorts parameters by their required state, ordering required before optional
-export function sortParametersByRequired(a: go.Parameter | go.ParameterGroup, b: go.Parameter | go.ParameterGroup): number {
+export function sortParametersByRequired(a: go.ClientParameter | go.ParameterGroup, b: go.ClientParameter | go.ParameterGroup): number {
   let aRequired = false;
   let bRequired = false;
 
-  if (isParameter(a)) {
-    aRequired = go.isRequiredParameter(a);
-  } else {
-    aRequired = a.required;
+  switch (a.kind) {
+    case 'paramGroup':
+      aRequired = a.required;
+      break;
+    default:
+      aRequired = go.isRequiredParameter(a);
+      break;
   }
 
-  if (isParameter(b)) {
-    bRequired = go.isRequiredParameter(b);
-  } else {
-    bRequired = b.required;
+  switch (b.kind) {
+    case 'paramGroup':
+      bRequired = b.required;
+      break;
+    default:
+      bRequired = go.isRequiredParameter(b);
+      break;
   }
 
   if (aRequired === bRequired) {
@@ -106,7 +106,7 @@ export function getCreateRequestParametersSig(method: go.MethodType | go.NextPag
     let paramName = uncapitalize(methodParam.name);
     // when creating the method sig for fooCreateRequest, if the options type is empty
     // or only contains the ResumeToken param use _ for the param name to quiet the linter
-    if (isParameterGroup(methodParam) && (methodParam.params.length === 0 || (methodParam.params.length === 1 && go.isResumeTokenParameter(methodParam.params[0])))) {
+    if (methodParam.kind === 'paramGroup' && (methodParam.params.length === 0 || (methodParam.params.length === 1 && methodParam.params[0].kind === 'resumeTokenParam'))) {
       paramName = '_';
     }
     params.push(`${paramName} ${formatParameterTypeName(methodParam)}`);
@@ -128,8 +128,8 @@ export function getCreateRequestParameters(method: go.MethodType): string {
 }
 
 // returns the complete collection of method parameters
-export function getMethodParameters(method: go.MethodType | go.NextPageMethod, paramsFilter?: (p: Array<go.Parameter>) => Array<go.Parameter>): Array<go.Parameter | go.ParameterGroup> {
-  const params = new Array<go.Parameter>();
+export function getMethodParameters(method: go.MethodType | go.NextPageMethod, paramsFilter?: (p: Array<go.MethodParameter>) => Array<go.MethodParameter>): Array<go.MethodParameter | go.ParameterGroup> {
+  const params = new Array<go.MethodParameter>();
   const paramGroups = new Array<go.ParameterGroup>();
   let methodParams = method.parameters;
   if (paramsFilter) {
@@ -172,7 +172,7 @@ export function getMethodParameters(method: go.MethodType | go.NextPageMethod, p
       paramGroups.push(method.optionalParamsGroup);
     }
   }
-  const combined = new Array<go.Parameter | go.ParameterGroup>();
+  const combined = new Array<go.MethodParameter | go.ParameterGroup>();
   for (const param of params) {
     combined.push(param);
   }
@@ -184,7 +184,7 @@ export function getMethodParameters(method: go.MethodType | go.NextPageMethod, p
 
 // returns the fully-qualified parameter name.  this is usually just the name
 // but will include the client or optional param group name prefix as required.
-export function getParamName(param: go.Parameter): string {
+export function getParamName(param: go.MethodParameter): string {
   let paramName = param.name;
   // must check paramGroup first as client params can also be grouped
   if (param.group) {
@@ -194,7 +194,7 @@ export function getParamName(param: go.Parameter): string {
     paramName = `client.${paramName}`;
   }
   // client parameters with default values aren't emitted as pointer-to-type
-  if (!go.isRequiredParameter(param) && !(param.location === 'client' && go.isClientSideDefault(param.style)) && !(isParameter(param) && param.byValue)) {
+  if (!go.isRequiredParameter(param) && !(param.location === 'client' && go.isClientSideDefault(param.style)) && !param.byValue) {
     paramName = `*${paramName}`;
   }
   return paramName;
@@ -208,39 +208,46 @@ export function formatBytesEncoding(enc: go.BytesEncoding): string {
   return 'Std';
 }
 
-export function formatParamValue(param: go.FormBodyParameter | go.HeaderParameter | go.PathParameter | go.QueryParameter, imports: ImportManager): string {
+export function formatParamValue(param: go.MethodParameter, imports: ImportManager): string {
   let paramName = getParamName(param);
-  if (go.isFormBodyCollectionParameter(param) || go.isHeaderCollectionParameter(param) || go.isPathCollectionParameter(param) || go.isQueryCollectionParameter(param)) {
-    if (param.collectionFormat === 'multi') {
-      throw new CodegenError('InternalError', 'multi collection format should have been previously handled');
+  switch (param.kind) {
+    case 'formBodyCollectionParam':
+    case 'headerCollectionParam':
+    case 'pathCollectionParam':
+    case 'queryCollectionParam': {
+      if (param.collectionFormat === 'multi') {
+        throw new CodegenError('InternalError', 'multi collection format should have been previously handled');
+      }
+      const emitConvertOver = function(paramName: string, format: string): string {
+        const encodedVar = `encoded${capitalize(paramName)}`;
+        let content = 'strings.Join(func() []string {\n';
+        content += `\t\t${encodedVar} := make([]string, len(${paramName}))\n`;
+        content += `\t\tfor i := 0; i < len(${paramName}); i++ {\n`;
+        content += `\t\t\t${encodedVar}[i] = ${format}\n\t\t}\n`;
+        content += `\t\treturn ${encodedVar}\n`;
+        content += `\t}(), "${separator}")`;
+        return content;
+      }
+      const separator = getDelimiterForCollectionFormat(param.collectionFormat);
+      if (go.isPrimitiveType(param.type.elementType) && param.type.elementType.typeName === 'string') {
+        imports.add('strings');
+        return `strings.Join(${paramName}, "${separator}")`;
+      } else if (go.isBytesType(param.type.elementType)) {
+        imports.add('encoding/base64');
+        imports.add('strings');
+        return emitConvertOver(param.name, `base64.${formatBytesEncoding(param.type.elementType.encoding)}Encoding.EncodeToString(${param.name}[i])`);
+      } else if (go.isTimeType(param.type.elementType)) {
+        imports.add('strings');
+        return emitConvertOver(param.name, `${param.type.elementType.dateTimeFormat}(${param.name}[i]).String()`);
+      } else {
+        imports.add('fmt');
+        imports.add('strings');
+        return `strings.Join(strings.Fields(strings.Trim(fmt.Sprint(${paramName}), "[]")), "${separator}")`;
+      }
     }
-    const emitConvertOver = function(paramName: string, format: string): string {
-      const encodedVar = `encoded${capitalize(paramName)}`;
-      let content = 'strings.Join(func() []string {\n';
-      content += `\t\t${encodedVar} := make([]string, len(${paramName}))\n`;
-      content += `\t\tfor i := 0; i < len(${paramName}); i++ {\n`;
-      content += `\t\t\t${encodedVar}[i] = ${format}\n\t\t}\n`;
-      content += `\t\treturn ${encodedVar}\n`;
-      content += `\t}(), "${separator}")`;
-      return content;
-    }
-    const separator = getDelimiterForCollectionFormat(param.collectionFormat);
-    if (go.isPrimitiveType(param.type.elementType) && param.type.elementType.typeName === 'string') {
-      imports.add('strings');
-      return `strings.Join(${paramName}, "${separator}")`;
-    } else if (go.isBytesType(param.type.elementType)) {
-      imports.add('encoding/base64');
-      imports.add('strings');
-      return emitConvertOver(param.name, `base64.${formatBytesEncoding(param.type.elementType.encoding)}Encoding.EncodeToString(${param.name}[i])`);
-    } else if (go.isTimeType(param.type.elementType)) {
-      imports.add('strings');
-      return emitConvertOver(param.name, `${param.type.elementType.dateTimeFormat}(${param.name}[i]).String()`);
-    } else {
-      imports.add('fmt');
-      imports.add('strings');
-      return `strings.Join(strings.Fields(strings.Trim(fmt.Sprint(${paramName}), "[]")), "${separator}")`;
-    }
-  } else if (go.isTimeType(param.type) && param.type.dateTimeFormat !== 'timeUnix') {
+  }
+
+  if (go.isTimeType(param.type) && param.type.dateTimeFormat !== 'timeUnix') {
     // for most time types we call methods on time.Time which is why we remove the dereference.
     // however, for unix time, we cast to our unixTime helper first so we must keep the dereference.
     if (!go.isRequiredParameter(param) && paramName[0] === '*') {
@@ -641,7 +648,7 @@ export function recursiveUnwrapMapSlice(item: go.PossibleType): go.PossibleType 
 }
 
 // returns a * for optional params
-export function star(param: go.Parameter): string {
+export function star(param: go.MethodParameter): string {
   return go.isRequiredParameter(param) || param.byValue ? '' : '*';
 }
 
@@ -689,7 +696,7 @@ export function getSerDeFormat(model: go.ModelType | go.PolymorphicType, codeMod
   for (const client of codeModel.clients) {
     for (const method of client.methods) {
       for (const param of method.parameters) {
-        if (!go.isBodyParameter(param) || (param.bodyFormat !== 'JSON' && param.bodyFormat !== 'XML')) {
+        if (param.kind !== 'bodyParam' || (param.bodyFormat !== 'JSON' && param.bodyFormat !== 'XML')) {
           continue;
         }
 
@@ -727,8 +734,8 @@ export function getSerDeFormat(model: go.ModelType | go.PolymorphicType, codeMod
 }
 
 // return combined client parameters for all the clients
-export function getAllClientParameters(codeModel: go.CodeModel): Array<go.Parameter> {
-  const allClientParams = new Array<go.Parameter>();
+export function getAllClientParameters(codeModel: go.CodeModel): Array<go.ClientParameter> {
+  const allClientParams = new Array<go.ClientParameter>();
   for (const clients of codeModel.clients) {
     for (const clientParam of values(clients.parameters)) {
       if (values(allClientParams).where(param => param.name === clientParam.name).any()) {
@@ -742,8 +749,8 @@ export function getAllClientParameters(codeModel: go.CodeModel): Array<go.Parame
 }
 
 // returns common client parameters for all the clients
-export function getCommonClientParameters(codeModel: go.CodeModel): Array<go.Parameter> {
-  const paramCount = new Map<string, { uses: number, param: go.Parameter }>();
+export function getCommonClientParameters(codeModel: go.CodeModel): Array<go.ClientParameter> {
+  const paramCount = new Map<string, { uses: number, param: go.ClientParameter }>();
   let numClients = 0; // track client count since we might skip some
   for (const clients of codeModel.clients) {
     // special cases: some ARM clients always don't contain any parameters (OperationsClient will be depracated in the future)
@@ -765,7 +772,7 @@ export function getCommonClientParameters(codeModel: go.CodeModel): Array<go.Par
 
   // for each param, if its usage count is equal to the
   // number of clients, then it's common to all clients
-  const commonClientParams = new Array<go.Parameter>();
+  const commonClientParams = new Array<go.ClientParameter>();
   for (const entry of paramCount.values()) {
     if (entry.uses === numClients) {
       commonClientParams.push(entry.param);
@@ -773,4 +780,97 @@ export function getCommonClientParameters(codeModel: go.CodeModel): Array<go.Par
   }
 
   return commonClientParams.sort(sortParametersByRequired);
+}
+
+/**
+ * groups method parameters based on their kind.
+ * note that the body param kinds are mutually exclusive.
+ */
+export interface MethodParamGroups {
+  /** the body parameter if applicable */
+  bodyParam?: go.BodyParameter;
+
+  /** encoded query params. can be empty */
+  encodedQueryParams: Array<go.QueryParameter>;
+
+  /** form body params. can be empty */
+  formBodyParams: Array<go.FormBodyParameter>;
+
+  /** head params. can be empty */
+  headerParams: Array<go.HeaderParameter>;
+
+  /** multipart-form body params. can be empty */
+  multipartBodyParams: Array<go.MultipartFormBodyParameter>;
+
+  /** path params. can be empty */
+  pathParams: Array<go.PathParameter>;
+
+  /** partial body params. can be empty */
+  partialBodyParams: Array<go.PartialBodyParameter>;
+
+  /** unencoded query params. can be empty */
+  unencodedQueryParams: Array<go.QueryParameter>;
+}
+
+/**
+ * enumerates method parameters and returns them based on kinds
+ * 
+ * @param method the method containing the parameters to group
+ * @returns the groups of parameters
+ */
+export function getMethodParamGroups(method: go.MethodType | go.NextPageMethod): MethodParamGroups {
+  let bodyParam: go.BodyParameter | undefined;
+  const encodedQueryParams = new Array<go.QueryParameter>();
+  const formBodyParams = new Array<go.FormBodyParameter>();
+  const headerParams = new Array<go.HeaderParameter>();
+  const multipartBodyParams = new Array<go.MultipartFormBodyParameter>();
+  const pathParams = new Array<go.PathParameter>();
+  const partialBodyParams = new Array<go.PartialBodyParameter>();
+  const unencodedQueryParams = new Array<go.QueryParameter>();
+
+  for (const param of method.parameters) {
+    switch (param.kind) {
+      case 'bodyParam':
+        bodyParam = param;
+        break;
+      case 'formBodyCollectionParam':
+      case 'formBodyScalarParam':
+        formBodyParams.push(param);
+        break;
+      case 'headerCollectionParam':
+      case 'headerMapParam':
+      case 'headerScalarParam':
+        headerParams.push(param);
+        break;
+      case 'multipartFormBodyParam':
+        multipartBodyParams.push(param);
+        break;
+      case 'partialBodyParam':
+        partialBodyParams.push(param);
+        break;
+      case 'pathCollectionParam':
+      case 'pathScalarParam':
+        pathParams.push(param);
+        break;
+      case 'queryCollectionParam':
+      case 'queryScalarParam':
+        if (param.isEncoded) {
+          encodedQueryParams.push(param);
+        } else {
+          unencodedQueryParams.push(param);
+        }
+        break;
+    }
+  }
+
+  return {
+    bodyParam,
+    encodedQueryParams,
+    formBodyParams,
+    headerParams,
+    multipartBodyParams,
+    pathParams,
+    partialBodyParams,
+    unencodedQueryParams,
+  }
 }

--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -75,9 +75,9 @@ export async function generateOperations(codeModel: go.CodeModel): Promise<Array
     clientText += `\tinternal *${clientPkg}.Client\n`;
 
     // check for any optional host params
-    const optionalParams = new Array<go.Parameter>();
+    const optionalParams = new Array<go.ClientParameter>();
 
-    const isParamPointer = function(param: go.Parameter): boolean {
+    const isParamPointer = function(param: go.ClientParameter): boolean {
       // for client params, only optional and flag types are passed by pointer
       return param.style === 'flag' || param.style === 'optional';
     };
@@ -146,7 +146,7 @@ export async function generateOperations(codeModel: go.CodeModel): Promise<Array
         // LRO responses are handled elsewhere, with the exception of pageable LROs
         opText += createProtocolResponse(client, method, imports);
       }
-      if (go.isPageableMethod(method) && method.nextPageMethod && !nextPageMethods.includes(method.nextPageMethod)) {
+      if ((method.kind === 'lroPageableMethod' || method.kind === 'pageableMethod') && method.nextPageMethod && !nextPageMethods.includes(method.nextPageMethod)) {
         // track the next page methods to generate as multiple operations can use the same next page operation
         nextPageMethods.push(method.nextPageMethod);
       }
@@ -527,7 +527,7 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
 
   const hostParams = new Array<go.URIParameter>();
   for (const parameter of client.parameters) {
-    if (go.isURIParameter(parameter)) {
+    if (parameter.kind === 'uriParam') {
       hostParams.push(parameter);
     }
   }
@@ -541,11 +541,11 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
     text += `\thost := "${client.host!}"\n`;
     // get all the host params on the client
     for (const hostParam of hostParams) {
-      text += `\thost = strings.ReplaceAll(host, "{${hostParam.uriPathSegment}}", ${helpers.formatValue(`client.${(<string>hostParam.name)}`, hostParam.type, imports)})\n`;
+      text += `\thost = strings.ReplaceAll(host, "{${hostParam.uriPathSegment}}", ${helpers.formatValue(`client.${hostParam.name}`, hostParam.type, imports)})\n`;
     }
     // check for any method local host params
     for (const param of values(method.parameters)) {
-      if (param.location === 'method' && go.isURIParameter(param)) {
+      if (param.location === 'method' && param.kind === 'uriParam') {
         text += `\thost = strings.ReplaceAll(host, "{${param.uriPathSegment}}", ${helpers.formatValue(helpers.getParamName(param), param.type, imports)})\n`;
       }
     }
@@ -559,7 +559,10 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
   } else {
     throw new CodegenError('InternalError', `no host or endpoint defined for method ${client.name}.${method.name}`);
   }
-  const hasPathParams = values(method.parameters).where((each: go.Parameter) => { return go.isPathParameter(each); }).any();
+
+  const methodParamGroups = helpers.getMethodParamGroups(method);
+  const hasPathParams = methodParamGroups.pathParams.length > 0;
+
   // storage needs the client.u to be the source-of-truth for the full path.
   // however, swagger requires that all operations specify a path, which is at odds with storage.
   // to work around this, storage specifies x-ms-path paths with path params but doesn't
@@ -572,23 +575,22 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
     text += `\turlPath := "${method.httpPath}"\n`;
     hostParam = `runtime.JoinPaths(${hostParam}, urlPath)`;
   }
+
   if (hasPathParams) {
     // swagger defines path params, emit path and replace tokens
     imports.add('strings');
     // replace path parameters
-    for (const pp of values(method.parameters)) {
-      if (!go.isPathParameter(pp)) {
-        continue;
-      }
+    for (const pp of methodParamGroups.pathParams) {
       // emit check to ensure path param isn't an empty string.  we only need
       // to do this for params that have an underlying type of string.
-      const choiceIsString = function (type: go.PathParameterType): boolean {
+      const choiceIsString = function (type: go.PathScalarParameterType): boolean {
         if (!go.isConstantType(type)) {
           return false;
         }
         return type.type === 'string';
       };
-      if (((go.isPrimitiveType(pp.type) && pp.type.typeName === 'string') || choiceIsString(pp.type)) && pp.isEncoded) {
+      // TODO: https://github.com/Azure/autorest.go/issues/1593
+      if (pp.kind === 'pathScalarParam' && ((go.isPrimitiveType(pp.type) && pp.type.typeName === 'string' || choiceIsString(pp.type)) && pp.isEncoded)) {
         const paramName = helpers.getParamName(pp);
         imports.add('errors');
         text += `\tif ${paramName} == "" {\n`;
@@ -603,12 +605,14 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
       text += `\turlPath = strings.ReplaceAll(urlPath, "{${pp.pathSegment}}", ${paramValue})\n`;
     }
   }
+
   text += `\treq, err := runtime.NewRequest(ctx, http.Method${capitalize(method.httpMethod)}, ${hostParam})\n`;
   text += '\tif err != nil {\n';
   text += '\t\treturn nil, err\n';
   text += '\t}\n';
+
   // helper to build nil checks for param groups
-  const emitParamGroupCheck = function (param: go.Parameter): string {
+  const emitParamGroupCheck = function (param: go.MethodParameter): string {
     if (!param.group) {
       throw new CodegenError('InternalError', `emitParamGroupCheck called for ungrouped parameter ${param.name}`);
     }
@@ -623,19 +627,11 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
     }
     return `\tif ${optionalParamGroupCheck}${client}${paramGroupName}.${capitalize(param.name)} != nil {\n`;
   };
+
   // add query parameters
-  const encodedParams = new Array<go.QueryParameter>();
-  const unencodedParams = new Array<go.QueryParameter>();
-  for (const qp of values(method.parameters)) {
-    if (!go.isQueryParameter(qp)) {
-      continue;
-    }
-    if (qp.isEncoded) {
-      encodedParams.push(qp);
-    } else {
-      unencodedParams.push(qp);
-    }
-  }
+  const encodedParams = methodParamGroups.encodedQueryParams;
+  const unencodedParams = methodParamGroups.unencodedQueryParams;
+
   const emitQueryParam = function (qp: go.QueryParameter, setter: string): string {
     let qpText = '';
     if (qp.location === 'method' && go.isClientSideDefault(qp.style)) {
@@ -654,12 +650,13 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
     }
     return qpText;
   };
+
   // emit encoded params first
   if (encodedParams.length > 0) {
     text += '\treqQP := req.Raw().URL.Query()\n';
     for (const qp of values(encodedParams.sort((a: go.QueryParameter, b: go.QueryParameter) => { return helpers.sortAscending(a.queryParameter, b.queryParameter); }))) {
       let setter: string;
-      if (go.isQueryCollectionParameter(qp) && qp.collectionFormat === 'multi') {
+      if (qp.kind === 'queryCollectionParam' && qp.collectionFormat === 'multi') {
         setter = `\tfor _, qv := range ${helpers.getParamName(qp)} {\n`;
         // emit a type conversion for the qv based on the array's element type
         let queryVal: string;
@@ -689,6 +686,7 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
     }
     text += '\treq.Raw().URL.RawQuery = reqQP.Encode()\n';
   }
+
   // tack on any unencoded params to the end
   if (unencodedParams.length > 0) {
     if (encodedParams.length > 0) {
@@ -698,7 +696,7 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
     }
     for (const qp of values(unencodedParams.sort((a: go.QueryParameter, b: go.QueryParameter) => { return helpers.sortAscending(a.queryParameter, b.queryParameter); }))) {
       let setter: string;
-      if (go.isQueryCollectionParameter(qp) && qp.collectionFormat === 'multi') {
+      if (qp.kind === 'queryCollectionParam' && qp.collectionFormat === 'multi') {
         setter = `\tfor _, qv := range ${helpers.getParamName(qp)} {\n`;
         setter += `\t\tunencodedParams = append(unencodedParams, "${qp.queryParameter}="+qv)\n`;
         setter += '\t}';
@@ -710,36 +708,32 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
     imports.add('strings');
     text += '\treq.Raw().URL.RawQuery = strings.Join(unencodedParams, "&")\n';
   }
+
   if (method.kind !== 'nextPageMethod' && method.responseEnvelope.result && go.isBinaryResult(method.responseEnvelope.result)) {
     // skip auto-body downloading for binary stream responses
     text += '\truntime.SkipBodyDownload(req)\n';
   }
+
   // add specific request headers
   const emitHeaderSet = function (headerParam: go.HeaderParameter, prefix: string): string {
-    if (headerParam.location === 'method' && go.isClientSideDefault(headerParam.style)) {
-      return emitClientSideDefault(headerParam, headerParam.style, (name, val) => {
-        return `${prefix}req.Raw().Header[${name}] = []string{${val}}`;
-      }, imports);
-    } else if (go.isHeaderMapParameter(headerParam)) {
+    if (headerParam.kind === 'headerMapParam') {
       let headerText = `${prefix}for k, v := range ${helpers.getParamName(headerParam)} {\n`;
       headerText += `${prefix}\tif v != nil {\n`;
       headerText += `${prefix}\t\treq.Raw().Header["${headerParam.collectionPrefix}"+k] = []string{*v}\n`;
       headerText += `${prefix}}\n`;
       headerText += `${prefix}}\n`;
       return headerText;
+    } else if (headerParam.location === 'method' && go.isClientSideDefault(headerParam.style)) {
+      return emitClientSideDefault(headerParam, headerParam.style, (name, val) => {
+        return `${prefix}req.Raw().Header[${name}] = []string{${val}}`;
+      }, imports);
     } else {
       return `${prefix}req.Raw().Header["${headerParam.headerName}"] = []string{${helpers.formatParamValue(headerParam, imports)}}\n`;
     }
   };
-  const headerParams = new Array<go.HeaderParameter>();
-  for (const param of values(method.parameters)) {
-    if (go.isHeaderParameter(param)) {
-      headerParams.push(param);
-    }
-  }
 
   let contentType: string | undefined;
-  for (const param of headerParams.sort((a: go.HeaderParameter, b: go.HeaderParameter) => { return helpers.sortAscending(a.headerName, b.headerName);})) {
+  for (const param of methodParamGroups.headerParams.sort((a: go.HeaderParameter, b: go.HeaderParameter) => { return helpers.sortAscending(a.headerName, b.headerName);})) {
     if (param.headerName.match(/^content-type$/)) {
       // canonicalize content-type as req.SetBody checks for it via its canonicalized name :(
       param.headerName = 'Content-Type';
@@ -765,8 +759,12 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
     }
   }
 
-  const partialBodyParams = values(method.parameters).where((param: go.Parameter) => { return go.isPartialBodyParameter(param); }).toArray();
-  const bodyParam = <go.BodyParameter | undefined>values(method.parameters).where((each: go.Parameter) => { return go.isBodyParameter(each) || go.isFormBodyParameter(each) || go.isMultipartFormBodyParameter(each); }).first();
+  // note that these are mutually exclusive
+  const bodyParam = methodParamGroups.bodyParam;
+  const formBodyParams = methodParamGroups.formBodyParams;
+  const multipartBodyParams = methodParamGroups.multipartBodyParams;
+  const partialBodyParams = methodParamGroups.partialBodyParams;
+
   const emitSetBodyWithErrCheck = function(setBodyParam: string, contentType?: string): string {
     let content = `if err := ${setBodyParam}; err != nil {\n\treturn nil, err\n}\n;`;
     if (contentType) {
@@ -775,23 +773,117 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
     return content;
   };
 
-  if (partialBodyParams.length > 0) {
+  if (bodyParam) {
+    if (bodyParam.bodyFormat === 'JSON' || bodyParam.bodyFormat === 'XML') {
+      // default to the body param name
+      let body = helpers.getParamName(bodyParam);
+      if (go.isLiteralValue(bodyParam.type)) {
+        // if the value is constant, embed it directly
+        body = helpers.formatLiteralValue(bodyParam.type, true);
+      } else if (bodyParam.bodyFormat === 'XML' && go.isSliceType(bodyParam.type)) {
+        // for XML payloads, create a wrapper type if the payload is an array
+        imports.add('encoding/xml');
+        text += '\ttype wrapper struct {\n';
+        let tagName = go.getTypeDeclaration(bodyParam.type);
+        if (bodyParam.xml?.name) {
+          tagName = bodyParam.xml.name;
+        }
+        text += `\t\tXMLName xml.Name \`xml:"${tagName}"\`\n`;
+        const fieldName = capitalize(bodyParam.name);
+        let tag = go.getTypeDeclaration(bodyParam.type.elementType);
+        if (go.isModelType(bodyParam.type.elementType) && bodyParam.type.elementType.xml?.name) {
+          tag = bodyParam.type.elementType.xml.name;
+        }
+        text += `\t\t${fieldName} *${go.getTypeDeclaration(bodyParam.type)} \`xml:"${tag}"\`\n`;
+        text += '\t}\n';
+        let addr = '&';
+        if (!go.isRequiredParameter(bodyParam) && !bodyParam.byValue) {
+          addr = '';
+        }
+        body = `wrapper{${fieldName}: ${addr}${body}}`;
+      } else if (go.isTimeType(bodyParam.type) && bodyParam.type.dateTimeFormat !== 'dateTimeRFC3339') {
+        // wrap the body in the internal time type
+        // no need for dateTimeRFC3339 as the JSON marshaler defaults to that.
+        body = `${bodyParam.type.dateTimeFormat}(${body})`;
+      } else if (isArrayOfDateTimeForMarshalling(bodyParam.type)) {
+        const timeInfo = isArrayOfDateTimeForMarshalling(bodyParam.type);
+        let elementPtr = '*';
+        if (timeInfo?.elemByVal) {
+          elementPtr = '';
+        }
+        text += `\taux := make([]${elementPtr}${timeInfo?.format}, len(${body}))\n`;
+        text += `\tfor i := 0; i < len(${body}); i++ {\n`;
+        text += `\t\taux[i] = (${elementPtr}${timeInfo?.format})(${body}[i])\n`;
+        text += '\t}\n';
+        body = 'aux';
+      } else if (isMapOfDateTime(bodyParam.type)) {
+        const timeType = isMapOfDateTime(bodyParam.type);
+        text += `\taux := map[string]*${timeType}{}\n`;
+        text += `\tfor k, v := range ${body} {\n`;
+        text += `\t\taux[k] = (*${timeType})(v)\n`;
+        text += '\t}\n';
+        body = 'aux';
+      }
+      let setBody = `runtime.MarshalAs${getMediaFormat(bodyParam.type, bodyParam.bodyFormat, `req, ${body}`)}`;
+      if (go.isSliceType(bodyParam.type) && bodyParam.type.rawJSONAsBytes) {
+        imports.add('bytes');
+        imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
+        setBody = `req.SetBody(streaming.NopCloser(bytes.NewReader(${body})), "application/${bodyParam.bodyFormat.toLowerCase()}")`;
+      }
+      if (go.isRequiredParameter(bodyParam) || go.isLiteralParameter(bodyParam)) {
+        text += `\t${emitSetBodyWithErrCheck(setBody, contentType)}`;
+        text += '\treturn req, nil\n';
+      } else {
+        text += emitParamGroupCheck(bodyParam);
+        text += `\t${emitSetBodyWithErrCheck(setBody, contentType)}`;
+        text += '\t\treturn req, nil\n';
+        text += '\t}\n';
+        text += '\treturn req, nil\n';
+      }
+    } else if (bodyParam.bodyFormat === 'binary') {
+      if (go.isRequiredParameter(bodyParam)) {
+        text += `\t${emitSetBodyWithErrCheck(`req.SetBody(${bodyParam.name}, ${bodyParam.contentType})`, contentType)}`;
+        text += '\treturn req, nil\n';
+      } else {
+        text += emitParamGroupCheck(bodyParam);
+        text += `\t${emitSetBodyWithErrCheck(`req.SetBody(${helpers.getParamName(bodyParam)}, ${bodyParam.contentType})`, contentType)}`;
+        text += '\treturn req, nil\n';
+        text += '\t}\n';
+        text += '\treturn req, nil\n';
+      }
+    } else if (bodyParam.bodyFormat === 'Text') {
+      imports.add('strings');
+      imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
+      if (go.isRequiredParameter(bodyParam)) {
+        text += `\tbody := streaming.NopCloser(strings.NewReader(${bodyParam.name}))\n`;
+        text += `\t${emitSetBodyWithErrCheck(`req.SetBody(body, ${bodyParam.contentType})`, contentType)}`;
+        text += '\treturn req, nil\n';
+      } else {
+        text += emitParamGroupCheck(bodyParam);
+        text += `\tbody := streaming.NopCloser(strings.NewReader(${helpers.getParamName(bodyParam)}))\n`;
+        text += `\t${emitSetBodyWithErrCheck(`req.SetBody(body, ${bodyParam.contentType})`, contentType)}`;
+        text += '\treturn req, nil\n';
+        text += '\t}\n';
+        text += '\treturn req, nil\n';
+      }
+    }
+  } else if (partialBodyParams.length > 0) {
     // partial body params are discrete params that are all fields within an internal struct.
     // define and instantiate an instance of the wire type, using the values from each param.
     text += '\tbody := struct {\n';
-    for (const partialBodyParam of <Array<go.PartialBodyParameter>>partialBodyParams) {
+    for (const partialBodyParam of partialBodyParams) {
       text += `\t\t${capitalize(partialBodyParam.serializedName)} ${helpers.star(partialBodyParam)}${go.getTypeDeclaration(partialBodyParam.type)} \`${partialBodyParam.format.toLowerCase()}:"${partialBodyParam.serializedName}"\`\n`;
     }
     text += '\t}{\n';
     // required params are emitted as initializers in the struct literal
-    for (const partialBodyParam of <Array<go.PartialBodyParameter>>partialBodyParams) {
+    for (const partialBodyParam of partialBodyParams) {
       if (go.isRequiredParameter(partialBodyParam)) {
         text += `\t\t${capitalize(partialBodyParam.serializedName)}: ${uncapitalize(partialBodyParam.name)},\n`;
       }
     }
     text += '\t}\n';
     // now populate any optional params from the options type
-    for (const partialBodyParam of <Array<go.PartialBodyParameter>>partialBodyParams) {
+    for (const partialBodyParam of partialBodyParams) {
       if (!go.isRequiredParameter(partialBodyParam)) {
         text += emitParamGroupCheck(partialBodyParam);
         text += `\t\tbody.${capitalize(partialBodyParam.serializedName)} = options.${capitalize(partialBodyParam.name)}\n\t}\n`;
@@ -801,111 +893,13 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
     text += '\treq.Raw().Header["Content-Type"] = []string{"application/json"}\n';
     text += '\tif err := runtime.MarshalAsJSON(req, body); err != nil {\n\t\treturn nil, err\n\t}\n';
     text += '\treturn req, nil\n';
-  } else if (!bodyParam) {
-    text += '\treturn req, nil\n';
-  } else if (bodyParam.bodyFormat === 'JSON' || bodyParam.bodyFormat === 'XML') {
-    // default to the body param name
-    let body = helpers.getParamName(bodyParam);
-    if (go.isLiteralValue(bodyParam.type)) {
-      // if the value is constant, embed it directly
-      body = helpers.formatLiteralValue(bodyParam.type, true);
-    } else if (bodyParam.bodyFormat === 'XML' && go.isSliceType(bodyParam.type)) {
-      // for XML payloads, create a wrapper type if the payload is an array
-      imports.add('encoding/xml');
-      text += '\ttype wrapper struct {\n';
-      let tagName = go.getTypeDeclaration(bodyParam.type);
-      if (bodyParam.xml?.name) {
-        tagName = bodyParam.xml.name;
-      }
-      text += `\t\tXMLName xml.Name \`xml:"${tagName}"\`\n`;
-      const fieldName = capitalize(bodyParam.name);
-      let tag = go.getTypeDeclaration(bodyParam.type.elementType);
-      if (go.isModelType(bodyParam.type.elementType) && bodyParam.type.elementType.xml?.name) {
-        tag = bodyParam.type.elementType.xml.name;
-      }
-      text += `\t\t${fieldName} *${go.getTypeDeclaration(bodyParam.type)} \`xml:"${tag}"\`\n`;
-      text += '\t}\n';
-      let addr = '&';
-      if (!go.isRequiredParameter(bodyParam) && !bodyParam.byValue) {
-        addr = '';
-      }
-      body = `wrapper{${fieldName}: ${addr}${body}}`;
-    } else if (go.isTimeType(bodyParam.type) && bodyParam.type.dateTimeFormat !== 'dateTimeRFC3339') {
-      // wrap the body in the internal time type
-      // no need for dateTimeRFC3339 as the JSON marshaler defaults to that.
-      body = `${bodyParam.type.dateTimeFormat}(${body})`;
-    } else if (isArrayOfDateTimeForMarshalling(bodyParam.type)) {
-      const timeInfo = isArrayOfDateTimeForMarshalling(bodyParam.type);
-      let elementPtr = '*';
-      if (timeInfo?.elemByVal) {
-        elementPtr = '';
-      }
-      text += `\taux := make([]${elementPtr}${timeInfo?.format}, len(${body}))\n`;
-      text += `\tfor i := 0; i < len(${body}); i++ {\n`;
-      text += `\t\taux[i] = (${elementPtr}${timeInfo?.format})(${body}[i])\n`;
-      text += '\t}\n';
-      body = 'aux';
-    } else if (isMapOfDateTime(bodyParam.type)) {
-      const timeType = isMapOfDateTime(bodyParam.type);
-      text += `\taux := map[string]*${timeType}{}\n`;
-      text += `\tfor k, v := range ${body} {\n`;
-      text += `\t\taux[k] = (*${timeType})(v)\n`;
-      text += '\t}\n';
-      body = 'aux';
-    }
-    let setBody = `runtime.MarshalAs${getMediaFormat(bodyParam.type, bodyParam.bodyFormat, `req, ${body}`)}`;
-    if (go.isSliceType(bodyParam.type) && bodyParam.type.rawJSONAsBytes) {
-      imports.add('bytes');
-      imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
-      setBody = `req.SetBody(streaming.NopCloser(bytes.NewReader(${body})), "application/${bodyParam.bodyFormat.toLowerCase()}")`;
-    }
-    if (go.isRequiredParameter(bodyParam) || go.isLiteralParameter(bodyParam)) {
-      text += `\t${emitSetBodyWithErrCheck(setBody, contentType)}`;
-      text += '\treturn req, nil\n';
-    } else {
-      text += emitParamGroupCheck(bodyParam);
-      text += `\t${emitSetBodyWithErrCheck(setBody, contentType)}`;
-      text += '\t\treturn req, nil\n';
-      text += '\t}\n';
-      text += '\treturn req, nil\n';
-    }
-  } else if (bodyParam.bodyFormat === 'binary') {
-    if (go.isRequiredParameter(bodyParam)) {
-      text += `\t${emitSetBodyWithErrCheck(`req.SetBody(${bodyParam.name}, ${bodyParam.contentType})`, contentType)}`;
-      text += '\treturn req, nil\n';
-    } else {
-      text += emitParamGroupCheck(bodyParam);
-      text += `\t${emitSetBodyWithErrCheck(`req.SetBody(${helpers.getParamName(bodyParam)}, ${bodyParam.contentType})`, contentType)}`;
-      text += '\treturn req, nil\n';
-      text += '\t}\n';
-      text += '\treturn req, nil\n';
-    }
-  } else if (bodyParam.bodyFormat === 'Text') {
-    imports.add('strings');
-    imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
-    const bodyParam = <go.BodyParameter>values(method.parameters).where((each: go.Parameter) => { return go.isBodyParameter(each); }).first();
-    if (go.isRequiredParameter(bodyParam)) {
-      text += `\tbody := streaming.NopCloser(strings.NewReader(${bodyParam.name}))\n`;
-      text += `\t${emitSetBodyWithErrCheck(`req.SetBody(body, ${bodyParam.contentType})`, contentType)}`;
-      text += '\treturn req, nil\n';
-    } else {
-      text += emitParamGroupCheck(bodyParam);
-      text += `\tbody := streaming.NopCloser(strings.NewReader(${helpers.getParamName(bodyParam)}))\n`;
-      text += `\t${emitSetBodyWithErrCheck(`req.SetBody(body, ${bodyParam.contentType})`, contentType)}`;
-      text += '\treturn req, nil\n';
-      text += '\t}\n';
-      text += '\treturn req, nil\n';
-    }
-  } else if (go.isMultipartFormBodyParameter(bodyParam)) {
-    if (go.isModelType(bodyParam.type) && bodyParam.type.annotations.multipartFormData) {
-      text += `\tformData, err := ${bodyParam.name}.toMultipartFormData()\n`;
+  } else if (multipartBodyParams.length > 0) {
+    if (multipartBodyParams.length === 1 && go.isModelType(multipartBodyParams[0].type) && multipartBodyParams[0].type.annotations.multipartFormData) {
+      text += `\tformData, err := ${multipartBodyParams[0].name}.toMultipartFormData()\n`;
       text += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
     } else {
       text += '\tformData := map[string]any{}\n';
-      for (const param of values(method.parameters)) {
-        if (!go.isMultipartFormBodyParameter(param)) {
-          continue;
-        }
+      for (const param of multipartBodyParams) {
         const setter = `formData["${param.name}"] = ${helpers.getParamName(param)}`;
         if (go.isRequiredParameter(param)) {
           text += `\t${setter}\n`;
@@ -917,8 +911,8 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
     }
     text += '\tif err := runtime.SetMultipartFormData(req, formData); err != nil {\n\t\treturn nil, err\n\t}\n';
     text += '\treturn req, nil\n';
-  } else if (go.isFormBodyParameter(bodyParam)) {
-    const emitFormData = function (param: go.Parameter, setter: string): string {
+  } else if (formBodyParams.length > 0) {
+    const emitFormData = function (param: go.FormBodyParameter, setter: string): string {
       let formDataText = '';
       if (go.isRequiredParameter(param)) {
         formDataText = `\t${setter}\n`;
@@ -934,11 +928,9 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
     imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
     text += '\tformData := url.Values{}\n';
     // find all the form body params
-    for (const param of values(method.parameters)) {
-      if (go.isFormBodyParameter(param)) {
-        const setter = `formData.Set("${param.formDataName}", ${helpers.formatParamValue(param, imports)})`;
-        text += emitFormData(param, setter);
-      }
+    for (const param of formBodyParams) {
+      const setter = `formData.Set("${param.formDataName}", ${helpers.formatParamValue(param, imports)})`;
+      text += emitFormData(param, setter);
     }
     text += '\tbody := streaming.NopCloser(strings.NewReader(formData.Encode()))\n';
     text += `\t${emitSetBodyWithErrCheck('req.SetBody(body, "application/x-www-form-urlencoded")')}`;
@@ -950,18 +942,25 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
   return text;
 }
 
-function emitClientSideDefault(param: go.HeaderParameter | go.QueryParameter, csd: go.ClientSideDefault, setterFormat: (name: string, val: string) => string, imports: ImportManager): string {
+function emitClientSideDefault(param: go.HeaderCollectionParameter | go.HeaderScalarParameter | go.QueryParameter, csd: go.ClientSideDefault, setterFormat: (name: string, val: string) => string, imports: ImportManager): string {
   const defaultVar = uncapitalize(param.name) + 'Default';
   let text = `\t${defaultVar} := ${helpers.formatLiteralValue(csd.defaultValue, true)}\n`;
   text += `\tif options != nil && options.${capitalize(param.name)} != nil {\n`;
   text += `\t\t${defaultVar} = *options.${capitalize(param.name)}\n`;
   text += '}\n';
+
   let serializedName: string;
-  if (go.isHeaderParameter(param)) {
-    serializedName = param.headerName;
-  } else {
-    serializedName = param.queryParameter;
+  switch (param.kind) {
+    case 'headerCollectionParam':
+    case 'headerScalarParam':
+      serializedName = param.headerName;
+      break;
+    case 'queryCollectionParam':
+    case 'queryScalarParam':
+      serializedName = param.queryParameter;
+      break;
   }
+
   text += setterFormat(`"${serializedName}"`, helpers.formatValue(defaultVar, param.type, imports)) + '\n';
   return text;
 }

--- a/packages/codegen.go/src/time.ts
+++ b/packages/codegen.go/src/time.ts
@@ -69,7 +69,7 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
           // for header/path/query params, the conversion happens in place. the only
           // exceptions are for timeRFC3339 and timeUnix
           // TODO: clean this up when moving to DateTime type in azcore
-          if (go.isBodyParameter(param) || unwrappedParam.dateTimeFormat === 'timeRFC3339' || unwrappedParam.dateTimeFormat === 'timeUnix') {
+          if (param.kind === 'bodyParam' || unwrappedParam.dateTimeFormat === 'timeRFC3339' || unwrappedParam.dateTimeFormat === 'timeUnix') {
             setHelper(unwrappedParam.dateTimeFormat);
           }
         }
@@ -106,7 +106,7 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
     for (const client of codeModel.clients) {
       for (const method of client.methods) {
         for (const param of method.parameters) {
-          if (go.isBodyParameter(param) && go.isTimeType(param.type)) {
+          if (param.kind === 'bodyParam' && go.isTimeType(param.type)) {
             setHelper(param.type.dateTimeFormat);
           }
         }

--- a/packages/codemodel.go/src/client.ts
+++ b/packages/codemodel.go/src/client.ts
@@ -22,7 +22,7 @@ export interface Client {
   options: ClientOptions;
 
   /** constructor params that are persisted as fields on the client, can be empty */
-  parameters: Array<param.Parameter>;
+  parameters: Array<ClientParameter>;
 
   /** all the constructors for this client, can be empty */
   constructors: Array<Constructor>;
@@ -50,6 +50,9 @@ export interface Client {
 /** the possible types used for the client options type */
 export type ClientOptions = param.ParameterGroup | param.Parameter;
 
+/** the possible client parameter types */
+export type ClientParameter = param.MethodParameter | param.Parameter;
+
 /** a client method that returns a sub-client instance */
 export interface ClientAccessor {
   /** the name of the client accessor method */
@@ -65,7 +68,7 @@ export interface Constructor {
   name: string;
 
   /** the modeled parameters. can be empty */
-  parameters: Array<param.Parameter>;
+  parameters: Array<ClientParameter>;
 }
 
 /** the possible values defining the "final state via" behavior for LROs */
@@ -122,7 +125,7 @@ export interface NextPageMethod {
   httpMethod: HTTPMethod;
 
   /** any modeled parameters */
-  parameters: Array<param.Parameter>;
+  parameters: Array<param.MethodParameter>;
 
   /** the complete list of successful HTTP status codes */
   httpStatusCodes: Array<number>;
@@ -186,7 +189,7 @@ interface MethodBase {
   httpMethod: HTTPMethod;
 
   /** any modeled parameters. the ones we add to the generated code (context.Context etc) aren't included here */
-  parameters: Array<param.Parameter>;
+  parameters: Array<param.MethodParameter>;
 
   /** the method options type for this methoid */
   optionalParamsGroup: param.ParameterGroup;
@@ -227,7 +230,7 @@ class MethodBase implements MethodBase {
     this.httpStatusCodes = statusCodes;
     this.name = name;
     this.naming = naming;
-    this.parameters = new Array<param.Parameter>();
+    this.parameters = new Array<param.MethodParameter>();
     this.examples = [];
     this.docs = {};
   }
@@ -244,7 +247,7 @@ export class Client implements Client {
     this.docs = docs;
     this.methods = new Array<MethodType>();
     this.clientAccessors = new Array<ClientAccessor>();
-    this.parameters = new Array<param.Parameter>();
+    this.parameters = new Array<ClientParameter>();
     this.options = options;
   }
 }
@@ -259,7 +262,7 @@ export class ClientAccessor implements ClientAccessor {
 export class Constructor implements Constructor {
   constructor(name: string) {
     this.name = name;
-    this.parameters = new Array<param.Parameter>();
+    this.parameters = new Array<ClientParameter>();
   }
 }
 
@@ -304,7 +307,7 @@ export class NextPageMethod implements NextPageMethod {
     this.httpPath = httpPath;
     this.httpStatusCodes = statusCodes;
     this.name = name;
-    this.parameters = new Array<param.Parameter>();
+    this.parameters = new Array<param.MethodParameter>();
   }
 }
 

--- a/packages/codemodel.go/src/examples.ts
+++ b/packages/codemodel.go/src/examples.ts
@@ -3,6 +3,7 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
+import * as client from './client.js';
 import * as param from './param.js';
 import * as result from './result.js';
 import { BytesType, ConstantType, Docs, LiteralValue, MapType, ModelType, PolymorphicType, PossibleType, PrimitiveType, QualifiedType, SliceType, TimeType } from './type.js';
@@ -61,7 +62,7 @@ export interface NumberExample {
 }
 
 export interface ParameterExample {
-  parameter: param.Parameter;
+  parameter: client.ClientParameter;
   value: ExampleType;
 }
 
@@ -156,7 +157,7 @@ export class NumberExample implements NumberExample {
 }
 
 export class ParameterExample implements ParameterExample {
-  constructor(parameter: param.Parameter, value: ExampleType) {
+  constructor(parameter: param.MethodParameter, value: ExampleType) {
     this.parameter = parameter;
     this.value = value;
   }

--- a/packages/codemodel.go/src/param.ts
+++ b/packages/codemodel.go/src/param.ts
@@ -5,240 +5,293 @@
 
 import * as type from './type.js';
 
+/** indicates the wire format for request bodies */
 export type BodyFormat = 'JSON' | 'XML' | 'Text' | 'binary';
 
-// parameter is sent in the HTTP request body
-export interface BodyParameter extends Parameter {
+/** the union of all form body parameter types */
+export type FormBodyParameter = FormBodyCollectionParameter | FormBodyScalarParameter;
+
+/** the union of all header parameter types */
+export type HeaderParameter = HeaderCollectionParameter | HeaderMapParameter | HeaderScalarParameter;
+
+/** the union of all path parameter types */
+export type PathParameter = PathCollectionParameter | PathScalarParameter;
+
+/** the union of all query parameter types */
+export type QueryParameter = QueryCollectionParameter | QueryScalarParameter;
+
+/** defines the possible method parameter types */
+export type MethodParameter = BodyParameter | FormBodyParameter | HeaderParameter | MultipartFormBodyParameter 
+  | PartialBodyParameter | PathParameter | QueryParameter | ResumeTokenParameter | URIParameter;
+
+/** parameter is sent in the HTTP request body */
+export interface BodyParameter extends ParameterBase {
+  kind: 'bodyParam';
+
+  /** the wire format of the request body */
   bodyFormat: BodyFormat;
 
-  // "application/text" etc...
+  /** value used for the Content-Type header */
   contentType: string;
 
+  /** optional XML schema metadata */
   xml?: type.XMLInfo;
 }
 
-// ClientSideDefault is used to represent parameters that have a default value on the client side
+/** represents parameters that have a default value on the client side */
 export interface ClientSideDefault {
+  /** the literal used for the client-side default value */
   defaultValue: type.LiteralValue;
 }
 
+/** indicates how a collection is formatted on the wire */
 export type CollectionFormat = 'csv' | 'ssv' | 'tsv' | 'pipes';
 
+/** includes additional wire formats */
 export type ExtendedCollectionFormat = CollectionFormat | 'multi';
 
-export interface FormBodyCollectionParameter extends Parameter {
+/** a collection that's placed in form body data */
+export interface FormBodyCollectionParameter extends ParameterBase {
+  kind: 'formBodyCollectionParam';
+
+  /** the form data name for this parameter */
   formDataName: string;
 
+  /** the type of the parameter */
   type: type.SliceType;
 
+  /** the format of the collection */
   collectionFormat: ExtendedCollectionFormat;
 }
 
-export interface FormBodyParameter extends Parameter {
+/** parameter that's placed in form body data */
+export interface FormBodyScalarParameter extends ParameterBase {
+  kind: 'formBodyScalarParam';
+
+  /** the form data name for this parameter */
   formDataName: string;
 }
 
-export interface HeaderCollectionParameter extends Parameter {
+/** a collection that goes in a HTTP header */
+export interface HeaderCollectionParameter extends ParameterBase {
+  kind: 'headerCollectionParam';
+
+  /** the header in the HTTP request */
   headerName: string;
 
+  /** the collection of header param values */
   type: type.SliceType;
 
+  /** the format of the collection */
   collectionFormat: CollectionFormat;
 }
 
-// this is a special type to support x-ms-header-collection-prefix (i.e. storage)
-export interface HeaderMapParameter extends Parameter {
+/**
+ * parameter map collection that goes in a HTTP header.
+ * NOTE: this is a specialized parameter type to support storage.
+ */
+export interface HeaderMapParameter extends ParameterBase {
+  kind: 'headerMapParam';
+
+  /** the header in the HTTP request */
   headerName: string;
 
+  /** the type of the param */
   type: type.MapType;
 
+  /** the header prefix for each header name in type */
   collectionPrefix: string;
 }
 
-// parameter is sent via an HTTP header
-export interface HeaderParameter extends Parameter {
+/** a value that goes in a HTTP header */
+export interface HeaderScalarParameter extends ParameterBase {
+  kind: 'headerScalarParam';
+
+  /** the header in the HTTP request */
   headerName: string;
 
-  type: HeaderType;
+  /** the type of the parameter */
+  type: HeaderScalarType;
 }
 
-export type HeaderType = type.BytesType | type.ConstantType | type.PrimitiveType | type.TimeType | type.LiteralValue;
+/** defines the possible types for a scalar header */
+export type HeaderScalarType = type.BytesType | type.ConstantType | type.PrimitiveType | type.TimeType | type.LiteralValue;
 
-export interface MultipartFormBodyParameter extends Parameter {
-  multipartForm: true;
+/** parameter goes in multipart/form body */
+export interface MultipartFormBodyParameter extends ParameterBase {
+  kind: 'multipartFormBodyParam';
 }
 
-// Parameter is a parameter for a client method
-export interface Parameter {
-  name: string;
-
-  docs: type.Docs;
-
-  // NOTE: if the type is a LiteralValue the paramType will either be literal or flag
-  type: type.PossibleType;
-
-  // style will have value literal or flag when type is a LiteralValue (see above comment).
-  style: ParameterStyle;
-
-  byValue: boolean;
-
-  group?: ParameterGroup;
-
-  location: ParameterLocation;
-}
-
-// required - the parameter is required
-// optional - the parameter is optional
-// literal - there is no formal parameter, the value is emitted directly in the code (e.g. the Accept header parameter)
-// flag - the value is a literal and emitted in the code, but sent IFF the flag param is not nil (i.e. an optional LiteralValue)
-// ClientSideDefault - the parameter has an emitted default value that's sent if one isn't specified (implies optional)
+/**
+ * defines the style of a parameter.
+ * 
+ * required - the parameter is required
+ * optional - the parameter is optional
+ * literal - there is no formal parameter, the value is emitted directly in the code (e.g. the Accept header parameter)
+ * flag - the value is a literal and emitted in the code, but sent IFF the flag param is not nil (i.e. an optional LiteralValue)
+ * ClientSideDefault - the parameter has an emitted default value that's sent if one isn't specified (implies optional)
+ */
 export type ParameterStyle = 'required' | 'optional' | 'literal' | 'flag' | ClientSideDefault;
 
+/** indicates where the value of a parameter originates */
 export type ParameterLocation = 'client' | 'method';
 
-export interface ParameterGroup {
-  // name is the name of the parameter
-  name: string;
-
-  docs: type.Docs;
-
-  // groupName is the name of the param group (i.e. the struct name)
-  groupName: string;
-
-  required: boolean;
-
-  location: ParameterLocation;
-
-  // the params that belong to this group
-  params: Array<Parameter>;
+/** a parameter that's not used for creating HTTP requests (e.g. a credential parameter) */
+export interface Parameter extends ParameterBase {
+  kind: 'parameter';
 }
 
-// PartialBodyParameter is a field within a struct type sent in the body
-export interface PartialBodyParameter extends Parameter {
-  // the name of the field over the wire
+/** a struct that contains a grouping of parameters */
+export interface ParameterGroup {
+  kind: 'paramGroup';
+
+  /** the name of the parameter */
+  name: string;
+
+  /** any docs for the parameter */
+  docs: type.Docs;
+
+  /** the name of the parameter group (i.e. the struct name) */
+  groupName: string;
+
+  /** indicates if the parameter is required */
+  required: boolean;
+
+  /** the location of the parameter */
+  location: ParameterLocation;
+
+  /** the parameters that belong to this group */
+  params: Array<MethodParameter>;
+}
+
+/** a parameter that's a field within a type passed via the HTTP request body */
+export interface PartialBodyParameter extends ParameterBase {
+  kind: 'partialBodyParam';
+
+  /** the name of the field within the type sent in the request body */
   serializedName: string;
 
+  /** the wire format of the underlying type */
   format: 'JSON' | 'XML';
 
+  /** optional XML schema metadata */
   xml?: type.XMLInfo;
 }
 
-export interface PathCollectionParameter extends Parameter {
+/** a collection of values that go in the HTTP path */
+export interface PathCollectionParameter extends ParameterBase {
+  kind: 'pathCollectionParam';
+
+  /** the segment name to be replaced with the values */
   pathSegment: string;
 
+  /** the type of the parameter */
   type: type.SliceType;
 
+  /** indicates if the values must be URL encoded */
   isEncoded: boolean;
 
+  /** the format of the collection */
   collectionFormat: CollectionFormat;
 }
 
-// parameter is a segment in a path
-export interface PathParameter extends Parameter {
+/** a value that goes in the HTTP path */
+export interface PathScalarParameter extends ParameterBase {
+  kind: 'pathScalarParam';
+
+  /** the segment name to be replaced with the value */
   pathSegment: string;
 
-  type: PathParameterType;
+  /** the type of the parameter */
+  type: PathScalarParameterType;
 
+  /** indicates if the values must be URL encoded */
   isEncoded: boolean;
 }
 
-export type PathParameterType = type.BytesType | type.ConstantType | type.PrimitiveType | type.TimeType | type.LiteralValue;
+/** defines the possible types for a PathScalarParameter */
+export type PathScalarParameterType = type.BytesType | type.ConstantType | type.PrimitiveType | type.TimeType | type.LiteralValue;
 
-export interface QueryCollectionParameter extends Parameter {
+/** a collection of values that go in the HTTP query string */
+export interface QueryCollectionParameter extends ParameterBase {
+  kind: 'queryCollectionParam';
+
+  /** the query string's key name */
   queryParameter: string;
 
+  /** the type of the parameter */
   type: type.SliceType;
 
+  /** indicates if the values must be URL encoded */
   isEncoded: boolean;
 
+  /** the format of the collection */
   collectionFormat: ExtendedCollectionFormat;
 }
 
-// parameter is sent via an HTTP query parameter
-export interface QueryParameter extends Parameter {
+/** a scalar value that goes in the HTTP query string */
+export interface QueryScalarParameter extends ParameterBase {
+  kind: 'queryScalarParam';
+
+  /** the query string's key name */
   queryParameter: string;
 
-  type: QueryParameterType;
+   /** the type of the parameter */
+  type: QueryScalarParameterType;
 
+  /** indicates if the value must be URL encoded */
   isEncoded: boolean;
 }
 
-export type QueryParameterType = type.BytesType | type.ConstantType | type.PrimitiveType | type.TimeType | type.LiteralValue;
+/** defines the possible types for a QueryScalarParameter */
+export type QueryScalarParameterType = type.BytesType | type.ConstantType | type.PrimitiveType | type.TimeType | type.LiteralValue;
 
-export interface ResumeTokenParameter extends Parameter {
-  isResumeToken: true;
+/** the synthesized resume token parameter for LROs */
+export interface ResumeTokenParameter extends ParameterBase {
+  kind: 'resumeTokenParam';
 }
 
-// parameter is a segment in the host
-export interface URIParameter extends Parameter {
+/** a segment of the host's URI */
+export interface URIParameter extends ParameterBase {
+  kind: 'uriParam';
+
+  /** the segment name to be replaced with the value */
   uriPathSegment: string;
 
+  /** the type of the parameter */
   type: URIParameterType;
 }
 
+/** defines the possible types for a URIParameter */
 export type URIParameterType = type.ConstantType | type.PrimitiveType;
 
-export function isBodyParameter(param: Parameter): param is BodyParameter {
-  return (<BodyParameter>param).bodyFormat !== undefined;
-}
-
+/** narrows style to a ClientSideDefault within the conditional block */
 export function isClientSideDefault(style: ParameterStyle): style is ClientSideDefault {
   return (<ClientSideDefault>style).defaultValue !== undefined;
 }
 
-export function isPartialBodyParameter(param: Parameter): param is PartialBodyParameter {
-  return (<PartialBodyParameter>param).serializedName !== undefined;
+/** narrows param to a FormBodyParameter within the conditional block */
+export function isFormBodyParameter(param: MethodParameter): param is FormBodyParameter {
+  return param.kind === 'formBodyCollectionParam' || param.kind === 'formBodyScalarParam';
 }
 
-export function isFormBodyParameter(param: Parameter): param is FormBodyParameter {
-  return (<FormBodyParameter>param).formDataName !== undefined;
+/** narrows param to a HeaderParameter within the conditional block */
+export function isHeaderParameter(param: MethodParameter): param is HeaderParameter {
+  return param.kind === 'headerCollectionParam' || param.kind === 'headerMapParam' || param.kind === 'headerScalarParam';
 }
 
-export function isFormBodyCollectionParameter(param: Parameter): param is FormBodyCollectionParameter {
-  return (<FormBodyCollectionParameter>param).formDataName !== undefined && (<FormBodyCollectionParameter>param).collectionFormat !== undefined;
+/** narrows param to a PathParameter within the conditional block */
+export function isPathParameter(param: MethodParameter): param is PathParameter {
+  return param.kind === 'pathCollectionParam' || param.kind === 'pathScalarParam';
 }
 
-export function isMultipartFormBodyParameter(param: Parameter): param is MultipartFormBodyParameter {
-  return (<MultipartFormBodyParameter>param).multipartForm !== undefined;
+/** narrows param to a QueryParameter within the conditional block */
+export function isQueryParameter(param: MethodParameter): param is QueryParameter {
+  return param.kind === 'queryCollectionParam' || param.kind === 'queryScalarParam';
 }
 
-export function isHeaderParameter(param: Parameter): param is HeaderParameter {
-  return (<HeaderParameter>param).headerName !== undefined;
-}
-
-export function isHeaderCollectionParameter(param: Parameter): param is HeaderCollectionParameter {
-  return (<HeaderCollectionParameter>param).headerName !== undefined && (<HeaderCollectionParameter>param).collectionFormat !== undefined;
-}
-
-export function isHeaderMapParameter(param: Parameter): param is HeaderMapParameter {
-  return (<HeaderMapParameter>param).headerName !== undefined && (<HeaderMapParameter>param).collectionPrefix !== undefined;
-}
-
-export function isPathParameter(param: Parameter): param is PathParameter {
-  return (<PathParameter>param).pathSegment !== undefined;
-}
-
-export function isPathCollectionParameter(param: Parameter): param is PathCollectionParameter {
-  return (<PathCollectionParameter>param).pathSegment !== undefined && (<PathCollectionParameter>param).collectionFormat !== undefined;
-}
-
-export function isQueryParameter(param: Parameter): param is QueryParameter {
-  return (<QueryParameter>param).queryParameter !== undefined;
-}
-
-export function isQueryCollectionParameter(param: Parameter): param is QueryCollectionParameter {
-  return (<QueryCollectionParameter>param).queryParameter !== undefined && (<QueryCollectionParameter>param).collectionFormat !== undefined;
-}
-
-export function isURIParameter(param: Parameter): param is URIParameter {
-  return (<URIParameter>param).uriPathSegment !== undefined;
-}
-
-export function isResumeTokenParameter(param: Parameter): param is ResumeTokenParameter {
-  return (<ResumeTokenParameter>param).isResumeToken !== undefined;
-}
-
-export function isRequiredParameter(param: Parameter): boolean {
+/** returns true if the param is required */
+export function isRequiredParameter(param: MethodParameter | Parameter): boolean {
   // parameters with a client-side default value are always optional
   if (isClientSideDefault(param.style)) {
     return false;
@@ -246,7 +299,8 @@ export function isRequiredParameter(param: Parameter): boolean {
   return param.style === 'required';
 }
 
-export function isLiteralParameter(param: Parameter): boolean {
+/** returns true if the param is a literal */
+export function isLiteralParameter(param: MethodParameter | Parameter): boolean {
   if (isClientSideDefault(param.style)) {
     return false;
   }
@@ -257,7 +311,33 @@ export function isLiteralParameter(param: Parameter): boolean {
 // base types
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-export class Parameter implements Parameter {
+interface ParameterBase {
+  /** the name of the parameter */
+  name: string;
+
+  /** any docs for the parameter */
+  docs: type.Docs;
+
+  /**
+   * the parameter's type.
+   * NOTE: if the type is a LiteralValue the style will either be literal or flag
+   */
+  type: type.PossibleType;
+
+  /** kind will have value literal or flag when type is a LiteralValue (see above comment) */
+  style: ParameterStyle;
+
+  /** indicates if the parameter is passed by value or by pointer */
+  byValue: boolean;
+
+  /** indicates if the parameter belongs to a parameter group */
+  group?: ParameterGroup;
+
+  /** indicates if the parameter is part of the method signature or a value on the client */
+  location: ParameterLocation;
+}
+
+class ParameterBase implements ParameterBase {
   constructor(name: string, type: type.PossibleType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     this.name = name;
     this.type = type;
@@ -271,9 +351,10 @@ export class Parameter implements Parameter {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-export class BodyParameter extends Parameter implements BodyParameter {
+export class BodyParameter extends ParameterBase implements BodyParameter {
   constructor(name: string, bodyFormat: BodyFormat, contentType: string, type: type.PossibleType, style: ParameterStyle, byValue: boolean) {
     super(name, type, style, byValue, 'method');
+    this.kind = 'bodyParam';
     this.bodyFormat = bodyFormat;
     this.contentType = contentType;
   }
@@ -285,116 +366,135 @@ export class ClientSideDefault implements ClientSideDefault {
   }
 }
 
-export class FormBodyCollectionParameter extends Parameter implements FormBodyCollectionParameter {
+export class FormBodyCollectionParameter extends ParameterBase implements FormBodyCollectionParameter {
   constructor(name: string, formDataName: string, type: type.SliceType, collectionFormat: ExtendedCollectionFormat, style: ParameterStyle, byValue: boolean) {
     super(name, type, style, byValue, 'method');
+    this.kind = 'formBodyCollectionParam';
     this.formDataName = formDataName;
     this.collectionFormat = collectionFormat;
   }
 }
 
-export class FormBodyParameter extends Parameter implements FormBodyParameter {
+export class FormBodyScalarParameter extends ParameterBase implements FormBodyScalarParameter {
   constructor(name: string, formDataName: string, type: type.PossibleType, style: ParameterStyle, byValue: boolean) {
     super(name, type, style, byValue, 'method');
+    this.kind = 'formBodyScalarParam';
     this.formDataName = formDataName;
   }
 }
 
-export class HeaderCollectionParameter extends Parameter implements HeaderCollectionParameter {
+export class HeaderCollectionParameter extends ParameterBase implements HeaderCollectionParameter {
   constructor(name: string, headerName: string, type: type.SliceType, collectionFormat: CollectionFormat, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, style, byValue, location);
+    this.kind = 'headerCollectionParam';
     this.headerName = headerName;
     this.collectionFormat = collectionFormat;
   }
 }
 
-export class HeaderMapParameter extends Parameter implements HeaderMapParameter {
+export class HeaderMapParameter extends ParameterBase implements HeaderMapParameter {
   constructor(name: string, headerName: string, type: type.MapType, collectionPrefix: string, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, style, byValue, location);
+    this.kind = 'headerMapParam';
     this.headerName = headerName;
     this.collectionPrefix = collectionPrefix;
   }
 }
 
-export class HeaderParameter extends Parameter implements HeaderParameter {
-  constructor(name: string, headerName: string, type: HeaderType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
+export class HeaderScalarParameter extends ParameterBase implements HeaderScalarParameter {
+  constructor(name: string, headerName: string, type: HeaderScalarType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, style, byValue, location);
+    this.kind = 'headerScalarParam';
     this.headerName = headerName;
   }
 }
 
-export class MultipartFormBodyParameter extends Parameter implements MultipartFormBodyParameter {
+export class MultipartFormBodyParameter extends ParameterBase implements MultipartFormBodyParameter {
   constructor(name: string, type: type.PossibleType, style: ParameterStyle, byValue: boolean) {
     super(name, type, style, byValue, 'method');
-    this.multipartForm = true;
+    this.kind = 'multipartFormBodyParam';
+  }
+}
+
+export class Parameter extends ParameterBase implements Parameter {
+  constructor(name: string, type: type.PossibleType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
+    super(name, type, style, byValue, location);
+    this.kind = 'parameter';
   }
 }
 
 export class ParameterGroup implements ParameterGroup {
   constructor(name: string, groupName: string, required: boolean, location: ParameterLocation) {
+    this.kind = 'paramGroup';
     this.groupName = groupName;
     this.location = location;
     this.name = name;
     // params is required but must be populated post construction
-    this.params = new Array<Parameter>();
+    this.params = new Array<MethodParameter>();
     this.required = required;
     this.docs = {};
   }
 }
 
-export class PartialBodyParameter extends Parameter implements PartialBodyParameter{
+export class PartialBodyParameter extends ParameterBase implements PartialBodyParameter{
   constructor(name: string, serializedName: string, format: 'JSON' | 'XML', type: type.PossibleType, style: ParameterStyle, byValue: boolean) {
     super(name, type, style, byValue, 'method');
+    this.kind = 'partialBodyParam';
     this.format = format;
     this.serializedName = serializedName;
   }
 }
 
-export class PathCollectionParameter extends Parameter implements PathCollectionParameter {
+export class PathCollectionParameter extends ParameterBase implements PathCollectionParameter {
   constructor(name: string, pathSegment: string, isEncoded: boolean, type: type.SliceType, collectionFormat: CollectionFormat, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, style, byValue, location);
+    this.kind = 'pathCollectionParam';
     this.pathSegment = pathSegment;
     this.isEncoded = isEncoded;
     this.collectionFormat = collectionFormat;
   }
 }
 
-export class PathParameter extends Parameter implements PathParameter {
-  constructor(name: string, pathSegment: string, isEncoded: boolean, type: PathParameterType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
+export class PathScalarParameter extends ParameterBase implements PathScalarParameter {
+  constructor(name: string, pathSegment: string, isEncoded: boolean, type: PathScalarParameterType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, style, byValue, location);
+    this.kind = 'pathScalarParam';
     this.pathSegment = pathSegment;
     this.isEncoded = isEncoded;
   }
 }
 
-export class QueryCollectionParameter extends Parameter implements QueryCollectionParameter {
+export class QueryCollectionParameter extends ParameterBase implements QueryCollectionParameter {
   constructor(name: string, queryParam: string, isEncoded: boolean, type: type.SliceType, collectionFormat: ExtendedCollectionFormat, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, style, byValue, location);
+    this.kind = 'queryCollectionParam';
     this.queryParameter = queryParam;
     this.isEncoded = isEncoded;
     this.collectionFormat = collectionFormat;
   }
 }
 
-export class QueryParameter extends Parameter implements QueryParameter {
-  constructor(name: string, queryParam: string, isEncoded: boolean, type: QueryParameterType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
+export class QueryScalarParameter extends ParameterBase implements QueryScalarParameter {
+  constructor(name: string, queryParam: string, isEncoded: boolean, type: QueryScalarParameterType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, style, byValue, location);
+    this.kind = 'queryScalarParam';
     this.queryParameter = queryParam;
     this.isEncoded = isEncoded;
   }
 }
 
-export class ResumeTokenParameter extends Parameter implements ResumeTokenParameter {
+export class ResumeTokenParameter extends ParameterBase implements ResumeTokenParameter {
   constructor() {
     super('ResumeToken', new type.PrimitiveType('string'), 'optional', true, 'method');
-    this.isResumeToken = true;
+    this.kind = 'resumeTokenParam';
     this.docs.summary = 'Resumes the long-running operation from the provided token.';
   }
 }
 
-export class URIParameter extends Parameter implements URIParameter {
+export class URIParameter extends ParameterBase implements URIParameter {
   constructor(name: string, uriPathSegment: string, type: type.ConstantType | type.PrimitiveType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, style, byValue, location);
+    this.kind = 'uriParam';
     this.uriPathSegment = uriPathSegment;
   }
 }

--- a/packages/codemodel.go/src/result.ts
+++ b/packages/codemodel.go/src/result.ts
@@ -77,7 +77,7 @@ export interface HeaderResponse {
 
   docs: type.Docs;
 
-  type: param.HeaderType;
+  type: param.HeaderScalarType;
 
   byValue: boolean;
 
@@ -236,7 +236,7 @@ export class HeaderMapResponse implements HeaderMapResponse {
 }
 
 export class HeaderResponse implements HeaderResponse {
-  constructor(fieldName: string, type: param.HeaderType, headerName: string, byValue: boolean) {
+  constructor(fieldName: string, type: param.HeaderScalarType, headerName: string, byValue: boolean) {
     this.fieldName = fieldName;
     this.type = type;
     this.byValue = byValue;


### PR DESCRIPTION
Switch to using discriminated unions to distinguish parameter types. Switch on parameter.kind instead of if/else chains where applicable. Scalar header/path/query parameter types were renamed to include the word Scalar to differentiate them from their collection-based peers. Cleaned up docs for parameter types.
Consolidated code for obtaining all operation parameters, splitting them into buckets (headers/path/query).