### PR TITLE
Refactor code model result types

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -204,15 +204,15 @@ function adaptResponseEnvelope(m4CodeModel: m4.CodeModel, codeModel: go.CodeMode
   // add any headers
   for (const prop of values(respEnvSchema.properties)) {
     if (prop.language.go!.fromHeader) {
-      let headerResp: go.HeaderResponse | go.HeaderMapResponse;
+      let headerResp: go.HeaderScalarResponse | go.HeaderMapResponse;
       if (prop.schema.language.go!.headerCollectionPrefix) {
         const headerType = adaptPossibleType(prop.schema, false);
         if (!go.isMapType(headerType)) {
           throw new Error(`unexpected type ${go.getTypeDeclaration(headerType)} for HeaderMapResponse ${prop.language.go!.name}`);
         }
-        headerResp = new go.HeaderMapResponse(prop.language.go!.name, headerType, prop.schema.language.go!.headerCollectionPrefix, prop.language.go!.fromHeader, prop.language.go!.byValue);
+        headerResp = new go.HeaderMapResponse(prop.language.go!.name, headerType, prop.schema.language.go!.headerCollectionPrefix);
       } else {
-        headerResp = new go.HeaderResponse(prop.language.go!.name, adaptHeaderScalarType(prop.schema, false), prop.language.go!.fromHeader, prop.language.go!.byValue);
+        headerResp = new go.HeaderScalarResponse(prop.language.go!.name, adaptHeaderScalarType(prop.schema, false), prop.language.go!.fromHeader, prop.language.go!.byValue);
       }
       if (hasDescription(prop.language.go!)) {
         headerResp.docs.description = prop.language.go!.description;
@@ -230,7 +230,7 @@ function adaptResponseEnvelope(m4CodeModel: m4.CodeModel, codeModel: go.CodeMode
   if (helpers.isMultiRespOperation(op)) {
     respEnv.result = adaptAnyResult(op);
   } else if (resultProp.schema.type === m4.SchemaType.Binary) {
-    respEnv.result = new go.BinaryResult(resultProp.language.go!.name, 'binary');
+    respEnv.result = new go.BinaryResult(resultProp.language.go!.name);
   } else if (m4CodeModel.language.go!.headAsBoolean && op.requests![0].protocol.http!.method === 'head') {
     respEnv.result = new go.HeadAsBooleanResult(resultProp.language.go!.name);
   } else if (!resultProp.language.go!.embeddedType) {

--- a/packages/codegen.go/src/polymorphics.ts
+++ b/packages/codegen.go/src/polymorphics.ts
@@ -69,18 +69,17 @@ export async function generatePolymorphicHelpers(codeModel: go.CodeModel, fakeSe
     }
 
     for (const respEnv of values(codeModel.responseEnvelopes)) {
-      if (!respEnv.result) {
-        continue;
-      }
-
-      if (go.isMonomorphicResult(respEnv.result)) {
-        if (go.isMapType(respEnv.result.monomorphicType)) {
-          trackDisciminator(respEnv.result.monomorphicType.valueType);
-        } else if (go.isSliceType(respEnv.result.monomorphicType)) {
-          trackDisciminator(respEnv.result.monomorphicType.elementType);
-        }
-      } else if (go.isPolymorphicResult(respEnv.result)) {
-        trackDisciminator(respEnv.result.interfaceType);
+      switch (respEnv.result?.kind) {
+        case 'monomorphicResult':
+          if (go.isMapType(respEnv.result.monomorphicType)) {
+            trackDisciminator(respEnv.result.monomorphicType.valueType);
+          } else if (go.isSliceType(respEnv.result.monomorphicType)) {
+            trackDisciminator(respEnv.result.monomorphicType.elementType);
+          }
+          break;
+        case 'polymorphicResult':
+          trackDisciminator(respEnv.result.interfaceType);
+          break;
       }
     }
   }

--- a/packages/codegen.go/src/time.ts
+++ b/packages/codegen.go/src/time.ts
@@ -91,7 +91,7 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
     }
 
     for (const respEnv of codeModel.responseEnvelopes) {
-      if (!respEnv.result || !go.isMonomorphicResult(respEnv.result) || respEnv.result.format !== 'JSON') {
+      if (!respEnv.result || respEnv.result.kind !== 'monomorphicResult' || respEnv.result.format !== 'JSON') {
         continue;
       }
       const unwrappedResult = recursiveUnwrapMapSlice(respEnv.result.monomorphicType);
@@ -121,7 +121,7 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
           setHelper(header.type.dateTimeFormat);
         }
       }
-      if (respEnv.result && go.isMonomorphicResult(respEnv.result) && go.isTimeType(respEnv.result.monomorphicType)) {
+      if (respEnv.result?.kind === 'monomorphicResult' && go.isTimeType(respEnv.result.monomorphicType)) {
         setHelper(respEnv.result.monomorphicType.dateTimeFormat);
       }
     }

--- a/packages/codemodel.go/src/examples.ts
+++ b/packages/codemodel.go/src/examples.ts
@@ -79,7 +79,7 @@ export interface ResponseEnvelopeExample {
 }
 
 export interface ResponseHeaderExample {
-  header: result.HeaderResponse | result.HeaderMapResponse;
+  header: result.HeaderScalarResponse | result.HeaderMapResponse;
   value: ExampleType;
 }
 
@@ -179,7 +179,7 @@ export class ResponseEnvelopeExample implements ResponseEnvelopeExample {
 }
 
 export class ResponseHeaderExample implements ResponseHeaderExample {
-  constructor(header: result.HeaderResponse | result.HeaderMapResponse, value: ExampleType) {
+  constructor(header: result.HeaderScalarResponse | result.HeaderMapResponse, value: ExampleType) {
     this.header = header;
     this.value = value;
   }

--- a/packages/codemodel.go/src/package.ts
+++ b/packages/codemodel.go/src/package.ts
@@ -137,7 +137,7 @@ export class CodeModel implements CodeModel {
   
     this.responseEnvelopes.sort((a: result.ResponseEnvelope, b: result.ResponseEnvelope) => { return sortAscending(a.name, b.name); });
     for (const respEnv of this.responseEnvelopes) {
-      respEnv.headers.sort((a: result.HeaderResponse | result.HeaderMapResponse, b: result.HeaderResponse | result.HeaderMapResponse) => { return sortAscending(a.fieldName, b.fieldName); });
+      respEnv.headers.sort((a: result.HeaderScalarResponse | result.HeaderMapResponse, b: result.HeaderScalarResponse | result.HeaderMapResponse) => { return sortAscending(a.fieldName, b.fieldName); });
     }
   
     this.clients.sort((a: client.Client, b: client.Client) => { return sortAscending(a.name, b.name); });

--- a/packages/codemodel.go/src/result.ts
+++ b/packages/codemodel.go/src/result.ts
@@ -4,192 +4,205 @@
 *--------------------------------------------------------------------------------------------*/
 
 import * as client from './client.js';
-import { CodeModelError } from './errors.js';
 import * as param from './param.js';
 import * as type from './type.js';
 
-export type ResultType = AnyResult | BinaryResult | HeadAsBooleanResult | MonomorphicResult | PolymorphicResult | ModelResult;
+/** defines the possible method result types within a response envelope */
+export type Result = AnyResult | BinaryResult | HeadAsBooleanResult | ModelResult | MonomorphicResult | PolymorphicResult;
 
-// AnyResult is for endpoints that return a different schema based on the HTTP status code.
+/** for endpoints that return a different schema based on the HTTP status code */
 export interface AnyResult {
-  // the name of the field within the response envelope
+  kind: 'anyResult';
+
+  /** the name of the field within the response envelope */
   fieldName: string;
 
+  /** any docs for the result */
   docs: type.Docs;
 
-  // maps an HTTP status code to a result type.
-  // status codes that don't return a schema will be absent.
+  /**
+   * maps an HTTP status code to a result type.
+   * status codes that don't return a schema will be absent.
+   */
   httpStatusCodeType: Record<number, type.PossibleType>;
 
-  // the format in which the result is returned
+  /** the format in which the result is returned */
   format: ResultFormat;
-
-  byValue: true;
 }
 
-// TODO: would this ever be anything else?
-export type BinaryResultFormat = 'binary';
-
-// BinaryResult is for responses that return the streaming response (i.e. the http.Response.Body)
+/** for endpoints that return a streaming response (i.e. the http.Response.Body) */
 export interface BinaryResult {
-  // the name of the field within the response envelope
+  kind: 'binaryResult';
+
+  /** the name of the field within the response envelope */
   fieldName: string;
 
+  /** any docs for the result */
   docs: type.Docs;
-
-  binaryFormat: BinaryResultFormat;
-
-  byValue: true;
 }
 
-// HeadAsBooleanResult is for responses to HTTP HEAD requests that treat the HTTP status code as success/failure
+/** used for responses to HTTP HEAD requests that treat the HTTP status code as success/failure */
 export interface HeadAsBooleanResult {
-  // the name of the field within the response envelope
+  kind: 'headAsBooleanResult';
+
+  /** the name of the field within the response envelope */
   fieldName: string;
 
+  /** any docs for the result */
   docs: type.Docs;
-
-  headAsBoolean: true;
-
-  byValue: true;
 }
 
-// this is a special type to support x-ms-header-collection-prefix (i.e. storage)
+/**
+ * a collection of header responses.
+ * NOTE: this is a specialized type to support storage.
+ */
 export interface HeaderMapResponse {
-  // the name of the field within the response envelope
+  kind: 'headerMapResponse';
+
+  /** the name of the field within the response envelope */
   fieldName: string;
 
+  /** any docs for the header */
   docs: type.Docs;
 
+  /** the type of the response header */
   type: type.MapType;
 
-  byValue: boolean;
-
-  // the name of the header sent over the wire
+  /** the header prefix for each header name in type */
   headerName: string;
-
-  collectionPrefix: string;
 }
 
-export interface HeaderResponse {
-  // the name of the field within the response envelope
+/** a typed header returned in a HTTP response */
+export interface HeaderScalarResponse {
+  kind: 'headerScalarResponse';
+
+  /** the name of the field within the response envelope */
   fieldName: string;
 
+  /** any docs for the header */
   docs: type.Docs;
 
+  /** the type of the response header */
   type: param.HeaderScalarType;
 
+  /** indicates if the header is returned by value or by pointer */
   byValue: boolean;
 
-  // the name of the header sent over the wire
+  /** the name of the header sent over the wire */
   headerName: string;
 }
 
-// ModelResult is a standard schema response.
-// The type is anonymously embedded in the response envelope.
+/**
+ * used for methods that return a typed payload.
+ * the type is anonymously embedded in the response envelope.
+ */
 export interface ModelResult {
+  kind: 'modelResult';
+
+  /** any docs for the result type */
   docs: type.Docs;
 
+  /** the type returned in the response envelope */
   modelType: type.ModelType;
 
-  // the format in which the result is returned
+  /** the format in which the result is returned */
   format: ModelResultFormat;
 }
 
+/** the wire format for model response bodies */
 export type ModelResultFormat = 'JSON' | 'XML';
 
-// MonomorphicResult includes scalar results (ints, bools) or maps/slices of scalars/InterfaceTypes/ModelTypes.
-// maps/slices can be recursive and/or combinatorial (e.g. map[string][]*sometype)
+/**
+ * includes scalar results (ints, bools) or maps/slices of scalars/InterfaceTypes/ModelTypes.
+ * maps/slices can be recursive and/or combinatorial (e.g. map[string][]*sometype)
+ */
 export interface MonomorphicResult {
-  // the name of the field within the response envelope
+  kind: 'monomorphicResult';
+
+  /** the name of the field within the response envelope */
   fieldName: string;
 
+  /** any docs for the result type */
   docs: type.Docs;
 
+  /** the type returned in the response envelope */
   monomorphicType: MonomorphicResultType;
 
-  // the format in which the result is returned
+  /** the format in which the result is returned */
   format: ResultFormat;
 
+  /** indicates if the response type is returned by value or by pointer */
   byValue: boolean;
 
+  /** optional XML schema metadata */
   xml?: type.XMLInfo;
 }
 
+/** the possible monomorphic result types */
 export type MonomorphicResultType = type.BytesType | type.ConstantType | type.MapType | type.PrimitiveType | type.SliceType | type.TimeType;
 
-// PolymorphicResult is for discriminated types.
-// The type is anonymously embedded in the response envelope.
+/**
+ * used for methods that return a discriminated type.
+ * the type is anonymously embedded in the response envelope.
+ */
 export interface PolymorphicResult {
+  kind: 'polymorphicResult';
+
+  /** any docs for the result type */
   docs: type.Docs;
 
+  /** the interface type used for the discriminated union of possible types */
   interfaceType: type.InterfaceType;
 
-  // the format in which the result is returned.
-  // only JSON is supported for polymorphic types.
+  /**
+   * the format in which the result is returned.
+   * only JSON is supported for polymorphic types.
+   */
   format: 'JSON';
 }
 
-// ResponseEnvelope is the type returned from a client method
+/**
+ * the type returned from a client method.
+ * this combines response headers with any response body.
+ */
 export interface ResponseEnvelope {
+  /** the name of the type */
   name: string;
 
+  /** any docs for the type */
   docs: type.Docs;
 
-  // for operations that return no body (e.g. a 204) this will be undefined.
-  result?: ResultType;
+  /**
+   * contains the body result type.
+   * for operations that return no body (e.g. a 204) this will be undefined.
+   */
+  result?: Result;
 
-  // any modeled response headers
-  headers: Array<HeaderResponse | HeaderMapResponse>;
+  /** any modeled response headers. can be empty */
+  headers: Array<HeaderScalarResponse | HeaderMapResponse>;
 
+  /** the method that returns this type */
   method: client.MethodType;
 }
 
+/** indicates the wire format for response bodies */
 export type ResultFormat = 'JSON' | 'XML' | 'Text';
 
-export function isAnyResult(resultType: ResultType): resultType is AnyResult {
-  return (<AnyResult>resultType).httpStatusCodeType !== undefined;
-}
-
-export function isBinaryResult(resultType: ResultType): resultType is BinaryResult {
-  return (<BinaryResult>resultType).binaryFormat !== undefined;
-}
-
-export function isHeadAsBooleanResult(resultType: ResultType): resultType is HeadAsBooleanResult {
-  return (<HeadAsBooleanResult>resultType).headAsBoolean !== undefined;
-}
-
-export function isHeaderMapResponse(resp: HeaderResponse | HeaderMapResponse): resp is HeaderMapResponse {
-  return (<HeaderMapResponse>resp).collectionPrefix !== undefined;
-}
-
-export function isMonomorphicResult(resultType: ResultType): resultType is MonomorphicResult {
-  return (<MonomorphicResult>resultType).monomorphicType !== undefined;
-}
-
-export function isPolymorphicResult(resultType: ResultType): resultType is PolymorphicResult {
-  return (<PolymorphicResult>resultType).interfaceType !== undefined;
-}
-
-export function isModelResult(resultType: ResultType): resultType is ModelResult {
-  return (<ModelResult>resultType).modelType !== undefined;
-}
-
-export function getResultPossibleType(resultType: ResultType): type.PossibleType {
-  if (isAnyResult(resultType)) {
-    return new type.PrimitiveType('any');
-  } else if (isBinaryResult(resultType)) {
-    return new type.QualifiedType('ReadCloser', 'io');
-  } else if (isHeadAsBooleanResult(resultType)) {
-    return new type.PrimitiveType('bool');
-  } else if (isMonomorphicResult(resultType)) {
-    return resultType.monomorphicType;
-  } else if (isPolymorphicResult(resultType)) {
-    return resultType.interfaceType;
-  } else if (isModelResult(resultType)) {
-    return resultType.modelType;
-  } else {
-    throw new CodeModelError(`unhandled result type ${resultType}`);
+/** returns the underlying type used for the specified result type */
+export function getResultType(result: Result): type.InterfaceType | type.ModelType | MonomorphicResultType | type.PrimitiveType | type.QualifiedType {
+  switch (result.kind) {
+    case 'anyResult':
+      return new type.PrimitiveType('any');
+    case 'binaryResult':
+      return new type.QualifiedType('ReadCloser', 'io');
+    case 'headAsBooleanResult':
+      return new type.PrimitiveType('bool');
+    case 'modelResult':
+      return result.modelType;
+    case 'monomorphicResult':
+      return result.monomorphicType;
+    case 'polymorphicResult':
+      return result.interfaceType;
   }
 }
 
@@ -198,45 +211,43 @@ export function getResultPossibleType(resultType: ResultType): type.PossibleType
 
 export class AnyResult implements AnyResult {
   constructor(fieldName: string, format: ResultFormat, resultTypes: Record<number, type.PossibleType>) {
+    this.kind = 'anyResult';
     this.fieldName = fieldName;
     this.format = format;
     this.httpStatusCodeType = resultTypes;
-    this.byValue = true;
     this.docs = {};
   }
 }
 
 export class BinaryResult implements BinaryResult {
-  constructor(fieldName: string, format: BinaryResultFormat) {
+  constructor(fieldName: string) {
+    this.kind = 'binaryResult';
     this.fieldName = fieldName;
-    this.binaryFormat = format;
-    this.byValue = true;
     this.docs = {};
   }
 }
 
 export class HeadAsBooleanResult implements HeadAsBooleanResult {
   constructor(fieldName: string) {
+    this.kind = 'headAsBooleanResult';
     this.fieldName = fieldName;
-    this.headAsBoolean = true;
-    this.byValue = true;
     this.docs = {};
   }
 }
 
 export class HeaderMapResponse implements HeaderMapResponse {
-  constructor(fieldName: string, type: type.MapType, collectionPrefix: string, headerName: string, byValue: boolean) {
+  constructor(fieldName: string, type: type.MapType, headerName: string) {
+    this.kind = 'headerMapResponse';
     this.fieldName = fieldName;
     this.type = type;
-    this.collectionPrefix = collectionPrefix;
-    this.byValue = byValue;
     this.headerName = headerName;
     this.docs = {};
   }
 }
 
-export class HeaderResponse implements HeaderResponse {
+export class HeaderScalarResponse implements HeaderScalarResponse {
   constructor(fieldName: string, type: param.HeaderScalarType, headerName: string, byValue: boolean) {
+    this.kind = 'headerScalarResponse';
     this.fieldName = fieldName;
     this.type = type;
     this.byValue = byValue;
@@ -247,6 +258,7 @@ export class HeaderResponse implements HeaderResponse {
 
 export class ModelResult implements ModelResult {
   constructor(type: type.ModelType, format: ModelResultFormat) {
+    this.kind = 'modelResult';
     this.modelType = type;
     this.format = format;
     this.docs = {};
@@ -255,6 +267,7 @@ export class ModelResult implements ModelResult {
 
 export class MonomorphicResult implements MonomorphicResult {
   constructor(fieldName: string, format: ResultFormat, type: MonomorphicResultType, byValue: boolean) {
+    this.kind = 'monomorphicResult';
     this.fieldName = fieldName;
     this.format = format;
     this.monomorphicType = type;
@@ -265,6 +278,7 @@ export class MonomorphicResult implements MonomorphicResult {
 
 export class PolymorphicResult implements PolymorphicResult {
   constructor(type: type.InterfaceType) {
+    this.kind = 'polymorphicResult';
     this.interfaceType = type;
     this.format = 'JSON';
     this.docs = {};
@@ -274,7 +288,7 @@ export class PolymorphicResult implements PolymorphicResult {
 export class ResponseEnvelope implements ResponseEnvelope {
   constructor(name: string, docs: type.Docs, forMethod: client.MethodType) {
     this.docs = docs;
-    this.headers = new Array<HeaderResponse | HeaderMapResponse>();
+    this.headers = new Array<HeaderScalarResponse | HeaderMapResponse>();
     this.method = forMethod;
     this.name = name;
   }


### PR DESCRIPTION
Switch to using discriminated unions to distinguish result types. Switch on result.kind instead of if/else chains where applicable. Renamed HeaderResponse to HeaderScalarResponse.
Removed redundant 'binary' parameter to BinaryResult. Removed redundant collectionPrefix from HeaderMapResponse. Removed byValue from several response/result types as the values were constant for their types. The remaining cases of byValue are now handled in codegen.go as required.
Cleaned up docs for response/result types.