### PR TITLE
Refactor code model type names

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/adapter.ts
+++ b/packages/autorest.go/src/m4togocodemodel/adapter.ts
@@ -116,8 +116,8 @@ function adaptConstantTypes(m4CodeModel: m4.CodeModel, goCodeModel: go.CodeModel
   }
 }
 
-function adaptParameterGroup(paramGroup: go.ParameterGroup): go.StructType {
-  const structType = new go.StructType(paramGroup.groupName);
+function adaptParameterGroup(paramGroup: go.ParameterGroup): go.Struct {
+  const structType = new go.Struct(paramGroup.groupName);
   structType.docs = paramGroup.docs;
   if (paramGroup.params.length > 0) {
     for (const param of values(paramGroup.params)) {
@@ -139,7 +139,7 @@ function adaptParameterGroup(paramGroup: go.ParameterGroup): go.StructType {
 }
 
 interface InterfaceTypeObjectSchema {
-  iface: go.InterfaceType;
+  iface: go.Interface;
   obj: m4.ObjectSchema;
 }
 
@@ -158,21 +158,21 @@ function adaptInterfaceTypes(m4CodeModel: m4.CodeModel, goCodeModel: go.CodeMode
     }
     // we must adapt all InterfaceTypes first. this is because ModelTypes/PolymorphicTypes can
     // contain references to InterfaceTypes and/or cyclic references
-    recursiveAdaptInterfaceType(discriminator, goCodeModel.interfaceTypes, ifaceObjs);
+    recursiveAdaptInterfaceType(discriminator, goCodeModel.interfaces, ifaceObjs);
   }
 
   // now that the InterfaceTypes have been created, we can populate the rootType and possibleTypes
   for (const ifaceObj of values(ifaceObjs)) {
-    ifaceObj.iface.rootType = <go.PolymorphicType>adaptModel(ifaceObj.obj);
-    ifaceObj.iface.possibleTypes = new Array<go.PolymorphicType>();
+    ifaceObj.iface.rootType = <go.PolymorphicModel>adaptModel(ifaceObj.obj);
+    ifaceObj.iface.possibleTypes = new Array<go.PolymorphicModel>();
     for (const disc of values(ifaceObj.obj.discriminator!.all)) {
       const possibleType = adaptModel(<m4.ObjectSchema>disc);
-      ifaceObj.iface.possibleTypes.push(<go.PolymorphicType>possibleType);
+      ifaceObj.iface.possibleTypes.push(<go.PolymorphicModel>possibleType);
     }
   }
 }
 
-function recursiveAdaptInterfaceType(obj: m4.ObjectSchema, ifaces: Array<go.InterfaceType>, ifaceObjs: Array<InterfaceTypeObjectSchema>, parent?: go.InterfaceType) {
+function recursiveAdaptInterfaceType(obj: m4.ObjectSchema, ifaces: Array<go.Interface>, ifaceObjs: Array<InterfaceTypeObjectSchema>, parent?: go.Interface) {
   const iface = adaptInterfaceType(obj, parent);
   if (ifaces.includes(iface)) {
     return;
@@ -189,7 +189,7 @@ function recursiveAdaptInterfaceType(obj: m4.ObjectSchema, ifaces: Array<go.Inte
 }
 
 interface ModelTypeObjectSchema {
-  type: go.ModelType | go.PolymorphicType;
+  type: go.Model | go.PolymorphicModel;
   obj: m4.ObjectSchema;
 }
 

--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -241,8 +241,8 @@ function adaptResponseEnvelope(m4CodeModel: m4.CodeModel, codeModel: go.CodeMode
     respEnv.result = new go.MonomorphicResult(resultProp.language.go!.name, adaptResultFormat(helpers.getSchemaResponse(op)!.protocol), resultType, resultProp.language.go!.byValue);
     respEnv.result.xml = adaptXMLInfo(resultProp.schema);
   } else if (resultProp.isDiscriminator) {
-    let ifaceResult: go.InterfaceType | undefined;
-    for (const iface of values(codeModel.interfaceTypes)) {
+    let ifaceResult: go.Interface | undefined;
+    for (const iface of values(codeModel.interfaces)) {
       if (iface.name === resultProp.schema.language.go!.name) {
         ifaceResult = iface;
         break;
@@ -253,7 +253,7 @@ function adaptResponseEnvelope(m4CodeModel: m4.CodeModel, codeModel: go.CodeMode
     }
     respEnv.result = new go.PolymorphicResult(ifaceResult);
   } else if (helpers.getSchemaResponse(op)) {
-    let modelType: go.ModelType | undefined;
+    let modelType: go.Model | undefined;
     for (const model of codeModel.models) {
       if (model.name === resultProp.schema.language.go!.name) {
         modelType = model;
@@ -512,7 +512,7 @@ function adaptParameterStyle(param: m4.Parameter): go.ParameterStyle {
     if (!go.isLiteralValueType(adaptedType)) {
       throw new Error(`unsupported client side default type ${go.getTypeDeclaration(adaptedType)} for parameter ${param.language.go!.name}`);
     }
-    return new go.ClientSideDefault(new go.LiteralValue(adaptedType, param.clientDefaultValue));
+    return new go.ClientSideDefault(new go.Literal(adaptedType, param.clientDefaultValue));
   } else if (param.schema.type === m4.SchemaType.Constant) {
     if (param.required) {
       return 'literal';

--- a/packages/autorest.go/src/m4togocodemodel/types.ts
+++ b/packages/autorest.go/src/m4togocodemodel/types.ts
@@ -18,12 +18,12 @@ export function hasDescription(lang: m4.Language): boolean {
 const types = new Map<string, go.PossibleType>();
 const constValues = new Map<string, go.ConstantValue>();
 
-export function adaptConstantType(choice: m4.ChoiceSchema | m4.SealedChoiceSchema): go.ConstantType {
+export function adaptConstantType(choice: m4.ChoiceSchema | m4.SealedChoiceSchema): go.Constant {
   let constType = types.get(choice.language.go!.name);
   if (constType) {
-    return <go.ConstantType>constType;
+    return <go.Constant>constType;
   }
-  constType = new go.ConstantType(choice.language.go!.name, adaptPrimitiveType(choice.choiceType.language.go!.name), choice.language.go!.possibleValuesFunc);
+  constType = new go.Constant(choice.language.go!.name, adaptPrimitiveType(choice.choiceType.language.go!.name), choice.language.go!.possibleValuesFunc);
   constType.values = adaptConstantValue(constType, choice.choices);
   if (hasDescription(choice.language.go!)) {
     constType.docs.description = choice.language.go!.description;
@@ -32,7 +32,7 @@ export function adaptConstantType(choice: m4.ChoiceSchema | m4.SealedChoiceSchem
   return constType;
 }
 
-function adaptConstantValue(type: go.ConstantType, choices: Array<m4.ChoiceValue>): Array<go.ConstantValue> {
+function adaptConstantValue(type: go.Constant, choices: Array<m4.ChoiceValue>): Array<go.ConstantValue> {
   const values = new Array<go.ConstantValue>();
   for (const choice of choices) {
     let value = constValues.get(choice.language.go!.name);
@@ -62,13 +62,13 @@ function adaptPrimitiveType(name: string): 'bool' | 'float32' | 'float64' | 'int
   }
 }
 
-export function adaptInterfaceType(obj: m4.ObjectSchema, parent?: go.InterfaceType): go.InterfaceType {
+export function adaptInterfaceType(obj: m4.ObjectSchema, parent?: go.Interface): go.Interface {
   let iface = types.get(obj.language.go!.discriminatorInterface);
   if (iface) {
-    return <go.InterfaceType>iface;
+    return <go.Interface>iface;
   }
 
-  iface = new go.InterfaceType(obj.language.go!.discriminatorInterface, obj.discriminator!.property.serializedName);
+  iface = new go.Interface(obj.language.go!.discriminatorInterface, obj.discriminator!.property.serializedName);
   if (parent) {
     iface.parent = parent;
   }
@@ -77,10 +77,10 @@ export function adaptInterfaceType(obj: m4.ObjectSchema, parent?: go.InterfaceTy
   return iface;
 }
 
-export function adaptModel(obj: m4.ObjectSchema): go.ModelType | go.PolymorphicType {
+export function adaptModel(obj: m4.ObjectSchema): go.Model | go.PolymorphicModel {
   let modelType = types.get(obj.language.go!.name);
   if (modelType) {
-    return <go.ModelType | go.PolymorphicType>modelType;
+    return <go.Model | go.PolymorphicModel>modelType;
   }
 
   const annotations = new go.ModelAnnotations(obj.language.go!.omitSerDeMethods, false);
@@ -108,13 +108,13 @@ export function adaptModel(obj: m4.ObjectSchema): go.ModelType | go.PolymorphicT
     if (!iface) {
       throw new Error(`didn't find InterfaceType for discriminator interface ${ifaceName} on type ${obj.language.go!.name}`);
     }
-    modelType = new go.PolymorphicType(obj.language.go!.name, <go.InterfaceType>iface, annotations, adaptUsage(obj));
+    modelType = new go.PolymorphicModel(obj.language.go!.name, <go.Interface>iface, annotations, adaptUsage(obj));
     // only non-root and sub-root discriminators will have a discriminatorValue
     if (obj.discriminatorValue) {
-      (<go.PolymorphicType>modelType).discriminatorValue = getDiscriminatorLiteral(obj.discriminatorValue);
+      (<go.PolymorphicModel>modelType).discriminatorValue = getDiscriminatorLiteral(obj.discriminatorValue);
     }
   } else {
-    modelType = new go.ModelType(obj.language.go!.name, annotations, adaptUsage(obj));
+    modelType = new go.Model(obj.language.go!.name, annotations, adaptUsage(obj));
     // polymorphic types don't have XMLInfo
     modelType.xml = adaptXMLInfo(obj);
   }
@@ -138,9 +138,9 @@ function adaptUsage(obj: m4.ObjectSchema): go.UsageFlags {
   return flags;
 }
 
-function getDiscriminatorLiteral(discriminatorValue: string): go.LiteralValue {
-  const createLiteralValue = function(type: go.LiteralValueType, value: string | go.ConstantValue): go.LiteralValue {
-    let valueKey: go.ConstantValueValueTypes;
+function getDiscriminatorLiteral(discriminatorValue: string): go.Literal {
+  const createLiteralValue = function(type: go.LiteralType, value: string | go.ConstantValue): go.Literal {
+    let valueKey: go.ConstantValueType;
     if (typeof value === 'string') {
       valueKey = value;
     } else {
@@ -149,17 +149,17 @@ function getDiscriminatorLiteral(discriminatorValue: string): go.LiteralValue {
     const keyName = `literal-${go.getTypeDeclaration(type)}-${valueKey}`;
     let literalString = types.get(keyName);
     if (literalString) {
-      return <go.LiteralValue>literalString;
+      return <go.Literal>literalString;
     }
-    literalString = new go.LiteralValue(type, value);
+    literalString = new go.Literal(type, value);
     types.set(keyName, literalString);
     return literalString;
   };
 
-  let discriminatorLiteral: go.LiteralValue;
+  let discriminatorLiteral: go.Literal;
   // the discriminatorValue is either a quoted string or a constant (i.e. enum) value
   if (discriminatorValue[0] === '"') {
-    discriminatorLiteral = createLiteralValue(new go.PrimitiveType('string'), discriminatorValue);
+    discriminatorLiteral = createLiteralValue(new go.Scalar('string'), discriminatorValue);
   } else {
     // find the corresponding constant value
     const value = constValues.get(discriminatorValue);
@@ -196,15 +196,15 @@ export function adaptModelField(prop: m4.Property, obj: m4.ObjectSchema): go.Mod
         throw new Error(`didn't find ConstantType for ${field.type.name}`);
       }
       let found = false;
-      for (const val of values((<go.ConstantType>constType).values)) {
+      for (const val of values((<go.Constant>constType).values)) {
         if (val.value === prop.clientDefaultValue) {
           const keyName = `literal-${val.name}`;
           let literalValue = types.get(keyName);
           if (!literalValue) {
-            literalValue = new go.LiteralValue(field.type, val);
+            literalValue = new go.Literal(field.type, val);
             types.set(keyName, literalValue);
           }
-          field.defaultValue = <go.LiteralValue>literalValue;
+          field.defaultValue = <go.Literal>literalValue;
           found = true;
           break;
         }
@@ -216,10 +216,10 @@ export function adaptModelField(prop: m4.Property, obj: m4.ObjectSchema): go.Mod
       const keyName = `literal-${go.getTypeDeclaration(field.type)}-${prop.clientDefaultValue}`;
       let literalValue = types.get(keyName);
       if (!literalValue) {
-        literalValue = new go.LiteralValue(field.type, prop.clientDefaultValue);
+        literalValue = new go.Literal(field.type, prop.clientDefaultValue);
         types.set(keyName, literalValue);
       }
-      field.defaultValue = <go.LiteralValue>literalValue;
+      field.defaultValue = <go.Literal>literalValue;
     }
   }
 
@@ -280,7 +280,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
         if (anyRawJSON) {
           return anyRawJSON;
         }
-        anyRawJSON = new go.SliceType(new go.PrimitiveType('byte'), true);
+        anyRawJSON = new go.Slice(new go.Scalar('byte'), true);
         anyRawJSON.rawJSONAsBytes = true;
         types.set(anyRawJSONKey, anyRawJSON);
         return anyRawJSON;
@@ -289,7 +289,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (anyType) {
         return anyType;
       }
-      anyType = new go.PrimitiveType('any');
+      anyType = new go.Scalar('any');
       types.set(m4.SchemaType.Any, anyType);
       return anyType;
     }
@@ -300,7 +300,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
         if (anyObjectRawJSON) {
           return anyObjectRawJSON;
         }
-        anyObjectRawJSON = new go.SliceType(new go.PrimitiveType('byte'), true);
+        anyObjectRawJSON = new go.Slice(new go.Scalar('byte'), true);
         anyObjectRawJSON.rawJSONAsBytes = true;
         types.set(anyObjectRawJSONKey, anyObjectRawJSON);
         return anyObjectRawJSON;
@@ -309,7 +309,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (anyObject) {
         return anyObject;
       }
-      anyObject = new go.MapType(new go.PrimitiveType('any'), true);
+      anyObject = new go.Map(new go.Scalar('any'), true);
       types.set(m4.SchemaType.AnyObject, anyObject);
       return anyObject;
     }
@@ -318,7 +318,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (stringType) {
         return stringType;
       }
-      stringType = new go.PrimitiveType('string');
+      stringType = new go.Scalar('string');
       types.set(m4.SchemaType.ArmId, stringType);
       return stringType;
     }
@@ -332,7 +332,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (arrayType) {
         return arrayType;
       }
-      arrayType = new go.SliceType(adaptPossibleType((<m4.ArraySchema>schema).elementType, elementTypeByValue), myElementTypeByValue);
+      arrayType = new go.Slice(adaptPossibleType((<m4.ArraySchema>schema).elementType, elementTypeByValue), myElementTypeByValue);
       types.set(keyName, arrayType);
       return arrayType;
     }
@@ -350,7 +350,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (primitiveBool) {
         return primitiveBool;
       }
-      primitiveBool = new go.PrimitiveType('bool');
+      primitiveBool = new go.Scalar('bool');
       types.set(m4.SchemaType.Boolean, primitiveBool);
       return primitiveBool;
     }
@@ -361,7 +361,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (rune) {
         return rune;
       }
-      rune = new go.PrimitiveType('rune');
+      rune = new go.Scalar('rune');
       types.set(m4.SchemaType.Char, rune);
       return rune;
     }
@@ -374,7 +374,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (credType) {
         return credType;
       }
-      credType = new go.PrimitiveType('string');
+      credType = new go.Scalar('string');
       types.set(m4.SchemaType.Credential, credType);
       return credType;
     }
@@ -386,7 +386,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (time) {
         return time;
       }
-      time = new go.TimeType(schema.language.go!.internalTimeType, false);
+      time = new go.Time(schema.language.go!.internalTimeType, false);
       types.set(schema.language.go!.internalTimeType, time);
       return time;
     }
@@ -397,7 +397,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (mapType) {
         return mapType;
       }
-      mapType = new go.MapType(adaptPossibleType((<m4.DictionarySchema>schema).elementType, elementTypeByValue), valueTypeByValue);
+      mapType = new go.Map(adaptPossibleType((<m4.DictionarySchema>schema).elementType, elementTypeByValue), valueTypeByValue);
       types.set(keyName, mapType);
       return mapType;
     }
@@ -406,7 +406,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (duration) {
         return duration;
       }
-      duration = new go.PrimitiveType('string');
+      duration = new go.Scalar('string');
       types.set(m4.SchemaType.Duration, duration);
       return duration;
     }
@@ -417,7 +417,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
         if (int32) {
           return int32;
         }
-        int32 = new go.PrimitiveType(int32Key);
+        int32 = new go.Scalar(int32Key);
         types.set(int32Key, int32);
         return int32;
       }
@@ -426,7 +426,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (int64) {
         return int64;
       }
-      int64 = new go.PrimitiveType(int64Key);
+      int64 = new go.Scalar(int64Key);
       types.set(int64Key, int64);
       return int64;
     }
@@ -437,7 +437,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
         if (float32) {
           return float32;
         }
-        float32 = new go.PrimitiveType(float32Key);
+        float32 = new go.Scalar(float32Key);
         types.set(float32Key, float32);
         return float32;
       }
@@ -446,7 +446,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (float64) {
         return float64;
       }
-      float64 = new go.PrimitiveType(float64Key);
+      float64 = new go.Scalar(float64Key);
       types.set(float64Key, float64);
       return float64;
     }
@@ -457,7 +457,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (odataType) {
         return odataType;
       }
-      odataType = new go.PrimitiveType('string');
+      odataType = new go.Scalar('string');
       types.set(m4.SchemaType.ODataQuery, odataType);
       return odataType;
     }
@@ -468,7 +468,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (stringType) {
         return stringType;
       }
-      stringType = new go.PrimitiveType('string');
+      stringType = new go.Scalar('string');
       types.set(m4.SchemaType.String, stringType);
       return stringType;
     }
@@ -477,7 +477,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (uriType) {
         return uriType;
       }
-      uriType = new go.PrimitiveType('string');
+      uriType = new go.Scalar('string');
       types.set(m4.SchemaType.Uri, uriType);
       return uriType;
     }
@@ -486,7 +486,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (uuid) {
         return uuid;
       }
-      uuid = new go.PrimitiveType('string');
+      uuid = new go.Scalar('string');
       types.set(m4.SchemaType.Uuid, uuid);
       return uuid;
     }
@@ -495,15 +495,15 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
   }
 }
 
-function adaptLiteralValue(constSchema: m4.ConstantSchema): go.LiteralValue {
+function adaptLiteralValue(constSchema: m4.ConstantSchema): go.Literal {
   switch (constSchema.valueType.type) {
     case m4.SchemaType.Boolean: {
       const keyName = `literal-${m4.SchemaType.Boolean}-${constSchema.value.value}`;
       let literalBool = types.get(keyName);
       if (literalBool) {
-        return <go.LiteralValue>literalBool;
+        return <go.Literal>literalBool;
       }
-      literalBool = new go.LiteralValue(new go.PrimitiveType('bool'), constSchema.value.value);
+      literalBool = new go.Literal(new go.Scalar('bool'), constSchema.value.value);
       types.set(keyName, literalBool);
       return literalBool;
     }
@@ -511,9 +511,9 @@ function adaptLiteralValue(constSchema: m4.ConstantSchema): go.LiteralValue {
       const keyName = `literal-${m4.SchemaType.ByteArray}-${constSchema.value.value}`;
       let literalByteArray = types.get(keyName);
       if (literalByteArray) {
-        return <go.LiteralValue>literalByteArray;
+        return <go.Literal>literalByteArray;
       }
-      literalByteArray = new go.LiteralValue(adaptBytesType(<m4.ByteArraySchema>constSchema.valueType), constSchema.value.value);
+      literalByteArray = new go.Literal(adaptBytesType(<m4.ByteArraySchema>constSchema.valueType), constSchema.value.value);
       types.set(keyName, literalByteArray);
       return literalByteArray;
     }
@@ -522,9 +522,9 @@ function adaptLiteralValue(constSchema: m4.ConstantSchema): go.LiteralValue {
       const keyName = `literal-${constSchema.language.go!.name}-${constSchema.value.value}`;
       let literalConst = types.get(keyName);
       if (literalConst) {
-        return <go.LiteralValue>literalConst;
+        return <go.Literal>literalConst;
       }
-      literalConst = new go.LiteralValue(adaptConstantType(<m4.ChoiceSchema>constSchema.valueType), constSchema.value.value);
+      literalConst = new go.Literal(adaptConstantType(<m4.ChoiceSchema>constSchema.valueType), constSchema.value.value);
       types.set(keyName, literalConst);
       return literalConst;
     }
@@ -534,9 +534,9 @@ function adaptLiteralValue(constSchema: m4.ConstantSchema): go.LiteralValue {
       const keyName = `literal-${constSchema.valueType.language.go!.internalTimeType}-${constSchema.value.value}`;
       let literalTime = types.get(keyName);
       if (literalTime) {
-        return <go.LiteralValue>literalTime;
+        return <go.Literal>literalTime;
       }
-      literalTime = new go.LiteralValue(new go.TimeType(constSchema.valueType.language.go!.internalTimeType, false), constSchema.value.value);
+      literalTime = new go.Literal(new go.Time(constSchema.valueType.language.go!.internalTimeType, false), constSchema.value.value);
       types.set(keyName, literalTime);
       return literalTime;
     }
@@ -544,12 +544,12 @@ function adaptLiteralValue(constSchema: m4.ConstantSchema): go.LiteralValue {
       const keyName = `literal-int${(<m4.NumberSchema>constSchema.valueType).precision}-${constSchema.value.value}`;
       let literalInt = types.get(keyName);
       if (literalInt) {
-        return <go.LiteralValue>literalInt;
+        return <go.Literal>literalInt;
       }
       if ((<m4.NumberSchema>constSchema.valueType).precision === 32) {
-        literalInt = new go.LiteralValue(new go.PrimitiveType('int32'), constSchema.value.value);
+        literalInt = new go.Literal(new go.Scalar('int32'), constSchema.value.value);
       } else {
-        literalInt = new go.LiteralValue(new go.PrimitiveType('int64'), constSchema.value.value);
+        literalInt = new go.Literal(new go.Scalar('int64'), constSchema.value.value);
       }
       types.set(keyName, literalInt);
       return literalInt;
@@ -558,12 +558,12 @@ function adaptLiteralValue(constSchema: m4.ConstantSchema): go.LiteralValue {
       const keyName = `literal-float${(<m4.NumberSchema>constSchema.valueType).precision}-${constSchema.value.value}`;
       let literalFloat = types.get(keyName);
       if (literalFloat) {
-        return <go.LiteralValue>literalFloat;
+        return <go.Literal>literalFloat;
       }
       if ((<m4.NumberSchema>constSchema.valueType).precision === 32) {
-        literalFloat = new go.LiteralValue(new go.PrimitiveType('float32'), constSchema.value.value);
+        literalFloat = new go.Literal(new go.Scalar('float32'), constSchema.value.value);
       } else {
-        literalFloat = new go.LiteralValue(new go.PrimitiveType('float64'), constSchema.value.value);
+        literalFloat = new go.Literal(new go.Scalar('float64'), constSchema.value.value);
       }
       types.set(keyName, literalFloat);
       return literalFloat;
@@ -574,9 +574,9 @@ function adaptLiteralValue(constSchema: m4.ConstantSchema): go.LiteralValue {
       const keyName = `literal-string-${constSchema.value.value}`;
       let literalString = types.get(keyName);
       if (literalString) {
-        return <go.LiteralValue>literalString;
+        return <go.Literal>literalString;
       }
-      literalString = new go.LiteralValue(new go.PrimitiveType('string'), constSchema.value.value);
+      literalString = new go.Literal(new go.Scalar('string'), constSchema.value.value);
       types.set(keyName, literalString);
       return literalString;
     }
@@ -585,7 +585,7 @@ function adaptLiteralValue(constSchema: m4.ConstantSchema): go.LiteralValue {
   }
 }
 
-function adaptBytesType(schema: m4.ByteArraySchema): go.BytesType {
+function adaptBytesType(schema: m4.ByteArraySchema): go.EncodedBytes {
   let format: go.BytesEncoding = 'Std';
   if (schema.format === 'base64url') {
     format = 'URL';
@@ -593,9 +593,9 @@ function adaptBytesType(schema: m4.ByteArraySchema): go.BytesType {
   const keyName = `${m4.SchemaType.ByteArray}-${format}`;
   let bytesType = types.get(keyName);
   if (bytesType) {
-    return <go.BytesType>bytesType;
+    return <go.EncodedBytes>bytesType;
   }
-  bytesType = new go.BytesType(format);
+  bytesType = new go.EncodedBytes(format);
   types.set(keyName, bytesType);
   return bytesType;
 }

--- a/packages/codegen.go/src/example.ts
+++ b/packages/codegen.go/src/example.ts
@@ -187,7 +187,7 @@ export async function generateExamples(codeModel: go.CodeModel): Promise<Array<E
           for (const header of example.responseEnvelope?.headers ?? []) {
             exampleText += `\t\t// \t${header.header.fieldName}: ${getExampleValue(codeModel, header.value, '', undefined, true).split('\n').join('\n\t\t// \t')}\n`;
           }
-          exampleText += `\t\t// \t${(example.responseEnvelope?.result.type as go.ModelType).name}: ${getExampleValue(codeModel, example.responseEnvelope?.result!, '', undefined, true).split('\n').join('\n\t\t// \t')},\n`;
+          exampleText += `\t\t// \t${(example.responseEnvelope?.result.type as go.Model).name}: ${getExampleValue(codeModel, example.responseEnvelope?.result!, '', undefined, true).split('\n').join('\n\t\t// \t')},\n`;
           exampleText += '\t\t// }\n';
           exampleText += `\t}\n`;
         } else if (checkResponse) {
@@ -202,7 +202,7 @@ export async function generateExamples(codeModel: go.CodeModel): Promise<Array<E
             exampleText += `\t// \t${header.header.fieldName}: ${getExampleValue(codeModel, header.value, '', undefined, true).split('\n').join('\n\t// \t')}\n`;
           }
           if (example.responseEnvelope?.result) {
-            exampleText += `\t// \t${fieldName ? fieldName : (example.responseEnvelope?.result.type as go.ModelType).name}: ${getExampleValue(codeModel, example.responseEnvelope.result, '').split('\n').join('\n\t// \t')},\n`;
+            exampleText += `\t// \t${fieldName ? fieldName : (example.responseEnvelope?.result.type as go.Model).name}: ${getExampleValue(codeModel, example.responseEnvelope.result, '').split('\n').join('\n\t// \t')},\n`;
           }
           exampleText += '\t// }\n';
         }
@@ -321,7 +321,7 @@ function getRef(byValue: boolean): string {
 
 }
 
-function getConstantValue(codeModel: go.CodeModel, type: go.ConstantType, value: any): string {
+function getConstantValue(codeModel: go.CodeModel, type: go.Constant, value: any): string {
   for (const constantValue of type.values) {
     if (constantValue.value === value) {
       return `${codeModel.packageName}.${constantValue.name}`
@@ -335,18 +335,18 @@ function getConstantValue(codeModel: go.CodeModel, type: go.ConstantType, value:
   }
 }
 
-function getTimeValue(type: go.TimeType, value: any, imports?: ImportManager): string {
-  if (type.dateTimeFormat === 'dateType' || type.dateTimeFormat === 'timeRFC3339') {
+function getTimeValue(type: go.Time, value: any, imports?: ImportManager): string {
+  if (type.format === 'dateType' || type.format === 'timeRFC3339') {
     if (imports) imports.add('time');
     let format = helpers.dateFormat;
-    if (type.dateTimeFormat === 'timeRFC3339') {
+    if (type.format === 'timeRFC3339') {
       format = helpers.timeRFC3339Format;
     }
     return `func() time.Time { t, _ := time.Parse("${format}", "${value}"); return t}()`;
-  } else if (type.dateTimeFormat === 'dateTimeRFC1123' || type.dateTimeFormat === 'dateTimeRFC3339') {
+  } else if (type.format === 'dateTimeRFC1123' || type.format === 'dateTimeRFC3339') {
     if (imports) imports.add('time');
     let format = helpers.datetimeRFC3339Format;
-    if (type.dateTimeFormat === 'dateTimeRFC1123') {
+    if (type.format === 'dateTimeRFC1123') {
       format = helpers.datetimeRFC1123Format;
     }
     return `func() time.Time { t, _ := time.Parse(${format}, "${value}"); return t}()`;

--- a/packages/codegen.go/src/interfaces.ts
+++ b/packages/codegen.go/src/interfaces.ts
@@ -9,14 +9,14 @@ import { contentPreamble, sortAscending } from './helpers.js';
 
 // Creates the content in interfaces.go
 export async function generateInterfaces(codeModel: go.CodeModel): Promise<string> {
-  if (codeModel.interfaceTypes.length === 0) {
+  if (codeModel.interfaces.length === 0) {
     // no polymorphic types
     return '';
   }
 
   let text = contentPreamble(codeModel);
 
-  for (const iface of codeModel.interfaceTypes) {
+  for (const iface of codeModel.interfaces) {
     const methodName = `Get${iface.rootType.name}`;
     text += `// ${iface.name} provides polymorphic access to related types.\n`;
     text += `// Call the interface's ${methodName}() method to access the common type.\n`;

--- a/packages/codegen.go/src/options.ts
+++ b/packages/codegen.go/src/options.ts
@@ -28,7 +28,7 @@ export async function generateOptions(codeModel: go.CodeModel): Promise<string> 
   return optionsText;
 }
 
-function emit(struct: go.StructType, imports: ImportManager): string {
+function emit(struct: go.Struct, imports: ImportManager): string {
   let text = helpers.formatDocComment(struct.docs);
   text += `type ${struct.name} struct {\n`;
 

--- a/packages/codegen.go/src/polymorphics.ts
+++ b/packages/codegen.go/src/polymorphics.ts
@@ -10,7 +10,7 @@ import { ImportManager } from './imports.js';
 
 // Creates the content in polymorphic_helpers.go
 export async function generatePolymorphicHelpers(codeModel: go.CodeModel, fakeServerPkg?: string): Promise<string> {
-  if (codeModel.interfaceTypes.length === 0) {
+  if (codeModel.interfaces.length === 0) {
     // no polymorphic types
     return '';
   }
@@ -78,7 +78,7 @@ export async function generatePolymorphicHelpers(codeModel: go.CodeModel, fakeSe
           }
           break;
         case 'polymorphicResult':
-          trackDisciminator(respEnv.result.interfaceType);
+          trackDisciminator(respEnv.result.interface);
           break;
       }
     }
@@ -98,7 +98,7 @@ export async function generatePolymorphicHelpers(codeModel: go.CodeModel, fakeSe
     prefix = `${codeModel.packageName}.`;
   }
 
-  for (const interfaceType of codeModel.interfaceTypes) {
+  for (const interfaceType of codeModel.interfaces) {
     // generate unmarshallers for each discriminator
 
     // scalar unmarshaller

--- a/packages/codegen.go/src/responses.ts
+++ b/packages/codegen.go/src/responses.ts
@@ -65,7 +65,7 @@ function generateMarshaller(respEnv: go.ResponseEnvelope, imports: ImportManager
     text += `${comment(`MarshalJSON implements the json.Marshaller interface for type ${respEnv.name}.`, '// ', undefined, helpers.commentLength)}\n`;
     text += `func (${receiver} ${respEnv.name}) MarshalJSON() ([]byte, error) {\n`;
     // TODO: this doesn't include any headers. however, LROs with header responses are currently broken :(
-    text += `\treturn json.Marshal(${receiver}.${go.getTypeDeclaration(respEnv.result.interfaceType)})\n}\n\n`;
+    text += `\treturn json.Marshal(${receiver}.${go.getTypeDeclaration(respEnv.result.interface)})\n}\n\n`;
   }
   return text;
 }
@@ -93,7 +93,7 @@ function generateUnmarshaller(respEnv: go.ResponseEnvelope, imports: ImportManag
 
   // add a custom unmarshaller to the response envelope
   if (polymorphicRes) {
-    const type = polymorphicRes.interfaceType.name;
+    const type = polymorphicRes.interface.name;
     unmarshaller += `\tres, err := unmarshal${type}(data)\n`;
     unmarshaller += '\tif err != nil {\n';
     unmarshaller += '\t\treturn err\n';

--- a/packages/codegen.go/src/time.ts
+++ b/packages/codegen.go/src/time.ts
@@ -29,7 +29,7 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
   let needsTimeRFC3339Helper = false;
   let needsUnixTimeHelper = false;
 
-  const setHelper = function(dateTimeFormat: go.DateTimeFormat): void {
+  const setHelper = function(dateTimeFormat: go.TimeFormat): void {
     switch (dateTimeFormat) {
       case 'dateTimeRFC1123':
         needsDateTimeRFC1123Helper = true;
@@ -69,8 +69,8 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
           // for header/path/query params, the conversion happens in place. the only
           // exceptions are for timeRFC3339 and timeUnix
           // TODO: clean this up when moving to DateTime type in azcore
-          if (param.kind === 'bodyParam' || unwrappedParam.dateTimeFormat === 'timeRFC3339' || unwrappedParam.dateTimeFormat === 'timeUnix') {
-            setHelper(unwrappedParam.dateTimeFormat);
+          if (param.kind === 'bodyParam' || unwrappedParam.format === 'timeRFC3339' || unwrappedParam.format === 'timeUnix') {
+            setHelper(unwrappedParam.format);
           }
         }
       }
@@ -86,7 +86,7 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
           // needsSerDeHelpers helpers are for JSON only
           needsSerDeHelpers = true;
         }
-        setHelper(unwrappedField.dateTimeFormat);
+        setHelper(unwrappedField.format);
       }
     }
 
@@ -98,7 +98,7 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
       if (!go.isTimeType(unwrappedResult)) {
         continue;
       }
-      setHelper(unwrappedResult.dateTimeFormat);
+      setHelper(unwrappedResult.format);
     }
   } else {
 	// for fakes, only need to check the if the body params are of type time.Time.
@@ -107,7 +107,7 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
       for (const method of client.methods) {
         for (const param of method.parameters) {
           if (param.kind === 'bodyParam' && go.isTimeType(param.type)) {
-            setHelper(param.type.dateTimeFormat);
+            setHelper(param.type.format);
           }
         }
       }
@@ -117,12 +117,12 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
       for (const header of respEnv.headers) {
         // for header/path/query params, the conversion happens in place. the only
         // exceptions are for timeRFC3339 and timeUnix
-        if (go.isTimeType(header.type) && (header.type.dateTimeFormat === 'timeRFC3339' || header.type.dateTimeFormat === 'timeUnix')) {
-          setHelper(header.type.dateTimeFormat);
+        if (go.isTimeType(header.type) && (header.type.format === 'timeRFC3339' || header.type.format === 'timeUnix')) {
+          setHelper(header.type.format);
         }
       }
       if (respEnv.result?.kind === 'monomorphicResult' && go.isTimeType(respEnv.result.monomorphicType)) {
-        setHelper(respEnv.result.monomorphicType.dateTimeFormat);
+        setHelper(respEnv.result.monomorphicType.format);
       }
     }
   }

--- a/packages/codemodel.go/src/examples.ts
+++ b/packages/codemodel.go/src/examples.ts
@@ -6,7 +6,7 @@
 import * as client from './client.js';
 import * as param from './param.js';
 import * as result from './result.js';
-import { BytesType, ConstantType, Docs, LiteralValue, MapType, ModelType, PolymorphicType, PossibleType, PrimitiveType, QualifiedType, SliceType, TimeType } from './type.js';
+import { Constant, Docs, EncodedBytes, Literal, Map, Model, PolymorphicModel, PossibleType, Scalar, QualifiedType, Slice, Time } from './type.js';
 
 export type ExampleType = AnyExample | ArrayExample | BooleanExample | DictionaryExample | NullExample | NumberExample | QualifiedExample| StringExample | StructExample;
 
@@ -19,19 +19,19 @@ export interface AnyExample {
 export interface ArrayExample {
   kind: 'array';
   value: Array<ExampleType>;
-  type: SliceType;
+  type: Slice;
 }
 
 export interface BooleanExample {
   kind: 'boolean';
   value: boolean;
-  type: ConstantType | LiteralValue | PrimitiveType;
+  type: Constant | Literal | Scalar;
 }
 
 export interface DictionaryExample {
   kind: 'dictionary';
   value: Record<string, ExampleType>;
-  type: MapType;
+  type: Map;
 }
 
 // MethodExample is an example for a method. This code model part is for example or test generation.
@@ -58,7 +58,7 @@ export interface NullExample {
 export interface NumberExample {
   kind: 'number';
   value: number;
-  type: ConstantType | LiteralValue | TimeType | PrimitiveType;
+  type: Constant | Literal | Scalar | Time;
 }
 
 export interface ParameterExample {
@@ -86,14 +86,14 @@ export interface ResponseHeaderExample {
 export interface StringExample {
   kind: 'string';
   value: string;
-  type: ConstantType | BytesType | LiteralValue | TimeType | PrimitiveType;
+  type: Constant | EncodedBytes | Literal | Scalar | Time;
 }
 
 export interface StructExample {
   kind: 'model';
   value: Record<string, ExampleType>;
   additionalProperties?: Record<string, ExampleType>;
-  type: ModelType | PolymorphicType;
+  type: Model | PolymorphicModel;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -103,12 +103,12 @@ export class AnyExample implements AnyExample {
   constructor(value: any) {
     this.kind = 'any';
     this.value = value;
-    this.type = new PrimitiveType('any');
+    this.type = new Scalar('any');
   }
 }
 
 export class ArrayExample implements ArrayExample {
-  constructor(type: SliceType) {
+  constructor(type: Slice) {
     this.kind = 'array';
     this.type = type;
     this.value = [];
@@ -116,7 +116,7 @@ export class ArrayExample implements ArrayExample {
 }
 
 export class BooleanExample implements BooleanExample {
-  constructor(value: boolean, type: ConstantType | LiteralValue | PrimitiveType) {
+  constructor(value: boolean, type: Constant | Literal | Scalar) {
     this.kind = 'boolean';
     this.value = value;
     this.type = type;
@@ -124,7 +124,7 @@ export class BooleanExample implements BooleanExample {
 }
 
 export class DictionaryExample implements DictionaryExample {
-  constructor(type: MapType) {
+  constructor(type: Map) {
     this.kind = 'dictionary';
     this.type = type;
     this.value = {};
@@ -149,7 +149,7 @@ export class NullExample implements NullExample {
 }
 
 export class NumberExample implements NumberExample {
-  constructor(value: number, type: ConstantType | LiteralValue | TimeType | PrimitiveType) {
+  constructor(value: number, type: Constant | Literal | Scalar | Time) {
     this.kind = 'number';
     this.value = value;
     this.type = type;
@@ -186,7 +186,7 @@ export class ResponseHeaderExample implements ResponseHeaderExample {
 }
 
 export class StringExample implements StringExample {
-  constructor(value: string, type: ConstantType | BytesType | LiteralValue | TimeType | PrimitiveType) {
+  constructor(value: string, type: Constant | EncodedBytes | Literal | Scalar | Time) {
     this.kind = 'string';
     this.value = value;
     this.type = type;
@@ -194,7 +194,7 @@ export class StringExample implements StringExample {
 }
 
 export class StructExample implements StructExample {
-  constructor(type: ModelType | PolymorphicType) {
+  constructor(type: Model | PolymorphicModel) {
     this.kind = 'model';
     this.type = type;
     this.value = {};

--- a/packages/codemodel.go/src/package.ts
+++ b/packages/codemodel.go/src/package.ts
@@ -21,24 +21,24 @@ export interface CodeModel {
   options: Options;
 
   // all of the struct model types to generate (models.go file)
-  models: Array<type.ModelType | type.PolymorphicType>;
+  models: Array<type.Model | type.PolymorphicModel>;
 
   // all of the const types to generate (constants.go file)
-  constants: Array<type.ConstantType>;
+  constants: Array<type.Constant>;
 
   // all of the operation groups (i.e. clients and their methods)
   // no clients indicates a models-only build
   clients: Array<client.Client>;
 
   // all of the parameter groups including the options types (options.go file)
-  paramGroups: Array<type.StructType>;
+  paramGroups: Array<type.Struct>;
 
   // all of the response envelopes (responses.go file)
   // no response envelopes indicates a models-only build
   responseEnvelopes: Array<result.ResponseEnvelope>;
 
   // all of the interfaces for discriminated types (interfaces.go file)
-  interfaceTypes: Array<type.InterfaceType>;
+  interfaces: Array<type.Interface>;
 
   // metadata of the package
   metadata?: {};
@@ -97,13 +97,13 @@ export interface Options {
 export class CodeModel implements CodeModel {
   constructor(info: Info, type: CodeModelType, packageName: string, options: Options) {
     this.clients = new Array<client.Client>();
-    this.constants = new Array<type.ConstantType>();
+    this.constants = new Array<type.Constant>();
     this.info = info;
-    this.interfaceTypes = new Array<type.InterfaceType>();
-    this.models = new Array<type.ModelType | type.PolymorphicType>();
+    this.interfaces = new Array<type.Interface>();
+    this.models = new Array<type.Model | type.PolymorphicModel>();
     this.options = options;
     this.packageName = packageName;
-    this.paramGroups = new Array<type.StructType>();
+    this.paramGroups = new Array<type.Struct>();
     this.responseEnvelopes = new Array<result.ResponseEnvelope>();
     this.type = type;
   }
@@ -113,24 +113,24 @@ export class CodeModel implements CodeModel {
       return a < b ? -1 : a > b ? 1 : 0;
     };
 
-    this.constants.sort((a: type.ConstantType, b: type.ConstantType) => { return sortAscending(a.name, b.name); });
+    this.constants.sort((a: type.Constant, b: type.Constant) => { return sortAscending(a.name, b.name); });
     for (const enm of this.constants) {
       enm.values.sort((a: type.ConstantValue, b: type.ConstantValue) => { return sortAscending(a.name, b.name); });
     }
   
-    this.interfaceTypes.sort((a: type.InterfaceType, b: type.InterfaceType) => { return sortAscending(a.name, b.name); });
-    for (const iface of this.interfaceTypes) {
+    this.interfaces.sort((a: type.Interface, b: type.Interface) => { return sortAscending(a.name, b.name); });
+    for (const iface of this.interfaces) {
       // we sort by literal value so that the switch/case statements in polymorphic_helpers.go
       // are ordered by the literal value which can be somewhat different from the model name.
-      iface.possibleTypes.sort((a: type.PolymorphicType, b: type.PolymorphicType) => { return sortAscending(a.discriminatorValue!.literal, b.discriminatorValue!.literal); });
+      iface.possibleTypes.sort((a: type.PolymorphicModel, b: type.PolymorphicModel) => { return sortAscending(a.discriminatorValue!.literal, b.discriminatorValue!.literal); });
     }
   
-    this.models.sort((a: type.ModelType | type.PolymorphicType, b: type.ModelType | type.PolymorphicType) => { return sortAscending(a.name, b.name); });
+    this.models.sort((a: type.Model | type.PolymorphicModel, b: type.Model | type.PolymorphicModel) => { return sortAscending(a.name, b.name); });
     for (const model of this.models) {
       model.fields.sort((a: type.ModelField, b: type.ModelField) => { return sortAscending(a.name, b.name); });
     }
   
-    this.paramGroups.sort((a: type.StructType, b: type.StructType) => { return sortAscending(a.name, b.name); });
+    this.paramGroups.sort((a: type.Struct, b: type.Struct) => { return sortAscending(a.name, b.name); });
     for (const paramGroup of this.paramGroups) {
       paramGroup.fields.sort((a: type.StructField, b: type.StructField) => { return sortAscending(a.name, b.name); });
     }

--- a/packages/codemodel.go/src/param.ts
+++ b/packages/codemodel.go/src/param.ts
@@ -41,7 +41,7 @@ export interface BodyParameter extends ParameterBase {
 /** represents parameters that have a default value on the client side */
 export interface ClientSideDefault {
   /** the literal used for the client-side default value */
-  defaultValue: type.LiteralValue;
+  defaultValue: type.Literal;
 }
 
 /** indicates how a collection is formatted on the wire */
@@ -58,7 +58,7 @@ export interface FormBodyCollectionParameter extends ParameterBase {
   formDataName: string;
 
   /** the type of the parameter */
-  type: type.SliceType;
+  type: type.Slice;
 
   /** the format of the collection */
   collectionFormat: ExtendedCollectionFormat;
@@ -80,7 +80,7 @@ export interface HeaderCollectionParameter extends ParameterBase {
   headerName: string;
 
   /** the collection of header param values */
-  type: type.SliceType;
+  type: type.Slice;
 
   /** the format of the collection */
   collectionFormat: CollectionFormat;
@@ -97,7 +97,7 @@ export interface HeaderMapParameter extends ParameterBase {
   headerName: string;
 
   /** the type of the param */
-  type: type.MapType;
+  type: type.Map;
 }
 
 /** a value that goes in a HTTP header */
@@ -112,7 +112,7 @@ export interface HeaderScalarParameter extends ParameterBase {
 }
 
 /** defines the possible types for a scalar header */
-export type HeaderScalarType = type.BytesType | type.ConstantType | type.PrimitiveType | type.TimeType | type.LiteralValue;
+export type HeaderScalarType = type.Constant | type.EncodedBytes | type.Literal | type.Scalar | type.Time;
 
 /** parameter goes in multipart/form body */
 export interface MultipartFormBodyParameter extends ParameterBase {
@@ -183,7 +183,7 @@ export interface PathCollectionParameter extends ParameterBase {
   pathSegment: string;
 
   /** the type of the parameter */
-  type: type.SliceType;
+  type: type.Slice;
 
   /** indicates if the values must be URL encoded */
   isEncoded: boolean;
@@ -207,7 +207,7 @@ export interface PathScalarParameter extends ParameterBase {
 }
 
 /** defines the possible types for a PathScalarParameter */
-export type PathScalarParameterType = type.BytesType | type.ConstantType | type.PrimitiveType | type.TimeType | type.LiteralValue;
+export type PathScalarParameterType = type.Constant | type.EncodedBytes | type.Literal | type.Scalar | type.Time;
 
 /** a collection of values that go in the HTTP query string */
 export interface QueryCollectionParameter extends ParameterBase {
@@ -217,7 +217,7 @@ export interface QueryCollectionParameter extends ParameterBase {
   queryParameter: string;
 
   /** the type of the parameter */
-  type: type.SliceType;
+  type: type.Slice;
 
   /** indicates if the values must be URL encoded */
   isEncoded: boolean;
@@ -241,7 +241,7 @@ export interface QueryScalarParameter extends ParameterBase {
 }
 
 /** defines the possible types for a QueryScalarParameter */
-export type QueryScalarParameterType = type.BytesType | type.ConstantType | type.PrimitiveType | type.TimeType | type.LiteralValue;
+export type QueryScalarParameterType = type.Constant | type.EncodedBytes | type.Literal | type.Scalar | type.Time;
 
 /** the synthesized resume token parameter for LROs */
 export interface ResumeTokenParameter extends ParameterBase {
@@ -260,7 +260,7 @@ export interface URIParameter extends ParameterBase {
 }
 
 /** defines the possible types for a URIParameter */
-export type URIParameterType = type.ConstantType | type.PrimitiveType;
+export type URIParameterType = type.Constant | type.Scalar;
 
 /** narrows style to a ClientSideDefault within the conditional block */
 export function isClientSideDefault(style: ParameterStyle): style is ClientSideDefault {
@@ -358,13 +358,13 @@ export class BodyParameter extends ParameterBase implements BodyParameter {
 }
 
 export class ClientSideDefault implements ClientSideDefault {
-  constructor(defaultValue: type.LiteralValue) {
+  constructor(defaultValue: type.Literal) {
     this.defaultValue = defaultValue;
   }
 }
 
 export class FormBodyCollectionParameter extends ParameterBase implements FormBodyCollectionParameter {
-  constructor(name: string, formDataName: string, type: type.SliceType, collectionFormat: ExtendedCollectionFormat, style: ParameterStyle, byValue: boolean) {
+  constructor(name: string, formDataName: string, type: type.Slice, collectionFormat: ExtendedCollectionFormat, style: ParameterStyle, byValue: boolean) {
     super(name, type, style, byValue, 'method');
     this.kind = 'formBodyCollectionParam';
     this.formDataName = formDataName;
@@ -381,7 +381,7 @@ export class FormBodyScalarParameter extends ParameterBase implements FormBodySc
 }
 
 export class HeaderCollectionParameter extends ParameterBase implements HeaderCollectionParameter {
-  constructor(name: string, headerName: string, type: type.SliceType, collectionFormat: CollectionFormat, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
+  constructor(name: string, headerName: string, type: type.Slice, collectionFormat: CollectionFormat, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, style, byValue, location);
     this.kind = 'headerCollectionParam';
     this.headerName = headerName;
@@ -390,7 +390,7 @@ export class HeaderCollectionParameter extends ParameterBase implements HeaderCo
 }
 
 export class HeaderMapParameter extends ParameterBase implements HeaderMapParameter {
-  constructor(name: string, headerName: string, type: type.MapType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
+  constructor(name: string, headerName: string, type: type.Map, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, style, byValue, location);
     this.kind = 'headerMapParam';
     this.headerName = headerName;
@@ -442,7 +442,7 @@ export class PartialBodyParameter extends ParameterBase implements PartialBodyPa
 }
 
 export class PathCollectionParameter extends ParameterBase implements PathCollectionParameter {
-  constructor(name: string, pathSegment: string, isEncoded: boolean, type: type.SliceType, collectionFormat: CollectionFormat, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
+  constructor(name: string, pathSegment: string, isEncoded: boolean, type: type.Slice, collectionFormat: CollectionFormat, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, style, byValue, location);
     this.kind = 'pathCollectionParam';
     this.pathSegment = pathSegment;
@@ -461,7 +461,7 @@ export class PathScalarParameter extends ParameterBase implements PathScalarPara
 }
 
 export class QueryCollectionParameter extends ParameterBase implements QueryCollectionParameter {
-  constructor(name: string, queryParam: string, isEncoded: boolean, type: type.SliceType, collectionFormat: ExtendedCollectionFormat, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
+  constructor(name: string, queryParam: string, isEncoded: boolean, type: type.Slice, collectionFormat: ExtendedCollectionFormat, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, style, byValue, location);
     this.kind = 'queryCollectionParam';
     this.queryParameter = queryParam;
@@ -481,14 +481,14 @@ export class QueryScalarParameter extends ParameterBase implements QueryScalarPa
 
 export class ResumeTokenParameter extends ParameterBase implements ResumeTokenParameter {
   constructor() {
-    super('ResumeToken', new type.PrimitiveType('string'), 'optional', true, 'method');
+    super('ResumeToken', new type.Scalar('string'), 'optional', true, 'method');
     this.kind = 'resumeTokenParam';
     this.docs.summary = 'Resumes the long-running operation from the provided token.';
   }
 }
 
 export class URIParameter extends ParameterBase implements URIParameter {
-  constructor(name: string, uriPathSegment: string, type: type.ConstantType | type.PrimitiveType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
+  constructor(name: string, uriPathSegment: string, type: type.Constant | type.Scalar, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, style, byValue, location);
     this.kind = 'uriParam';
     this.uriPathSegment = uriPathSegment;

--- a/packages/codemodel.go/src/result.ts
+++ b/packages/codemodel.go/src/result.ts
@@ -66,7 +66,7 @@ export interface HeaderMapResponse {
   docs: type.Docs;
 
   /** the type of the response header */
-  type: type.MapType;
+  type: type.Map;
 
   /** the header prefix for each header name in type */
   headerName: string;
@@ -103,7 +103,7 @@ export interface ModelResult {
   docs: type.Docs;
 
   /** the type returned in the response envelope */
-  modelType: type.ModelType;
+  modelType: type.Model;
 
   /** the format in which the result is returned */
   format: ModelResultFormat;
@@ -139,7 +139,7 @@ export interface MonomorphicResult {
 }
 
 /** the possible monomorphic result types */
-export type MonomorphicResultType = type.BytesType | type.ConstantType | type.MapType | type.PrimitiveType | type.SliceType | type.TimeType;
+export type MonomorphicResultType = type.Constant | type.EncodedBytes | type.Map | type.Scalar | type.Slice | type.Time;
 
 /**
  * used for methods that return a discriminated type.
@@ -152,7 +152,7 @@ export interface PolymorphicResult {
   docs: type.Docs;
 
   /** the interface type used for the discriminated union of possible types */
-  interfaceType: type.InterfaceType;
+  interface: type.Interface;
 
   /**
    * the format in which the result is returned.
@@ -189,20 +189,20 @@ export interface ResponseEnvelope {
 export type ResultFormat = 'JSON' | 'XML' | 'Text';
 
 /** returns the underlying type used for the specified result type */
-export function getResultType(result: Result): type.InterfaceType | type.ModelType | MonomorphicResultType | type.PrimitiveType | type.QualifiedType {
+export function getResultType(result: Result): type.Interface | type.Model | MonomorphicResultType | type.Scalar | type.QualifiedType {
   switch (result.kind) {
     case 'anyResult':
-      return new type.PrimitiveType('any');
+      return new type.Scalar('any');
     case 'binaryResult':
       return new type.QualifiedType('ReadCloser', 'io');
     case 'headAsBooleanResult':
-      return new type.PrimitiveType('bool');
+      return new type.Scalar('bool');
     case 'modelResult':
       return result.modelType;
     case 'monomorphicResult':
       return result.monomorphicType;
     case 'polymorphicResult':
-      return result.interfaceType;
+      return result.interface;
   }
 }
 
@@ -236,7 +236,7 @@ export class HeadAsBooleanResult implements HeadAsBooleanResult {
 }
 
 export class HeaderMapResponse implements HeaderMapResponse {
-  constructor(fieldName: string, type: type.MapType, headerName: string) {
+  constructor(fieldName: string, type: type.Map, headerName: string) {
     this.kind = 'headerMapResponse';
     this.fieldName = fieldName;
     this.type = type;
@@ -257,7 +257,7 @@ export class HeaderScalarResponse implements HeaderScalarResponse {
 }
 
 export class ModelResult implements ModelResult {
-  constructor(type: type.ModelType, format: ModelResultFormat) {
+  constructor(type: type.Model, format: ModelResultFormat) {
     this.kind = 'modelResult';
     this.modelType = type;
     this.format = format;
@@ -277,9 +277,9 @@ export class MonomorphicResult implements MonomorphicResult {
 }
 
 export class PolymorphicResult implements PolymorphicResult {
-  constructor(type: type.InterfaceType) {
+  constructor(type: type.Interface) {
     this.kind = 'polymorphicResult';
-    this.interfaceType = type;
+    this.interface = type;
     this.format = 'JSON';
     this.docs = {};
   }

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -60,7 +60,7 @@ export class typeAdapter {
       if (modelType.discriminatedSubtypes) {
         // this is a root discriminated type
         const iface = this.getInterfaceType(modelType);
-        this.codeModel.interfaceTypes.push(iface);
+        this.codeModel.interfaces.push(iface);
         ifaceTypes.push({go: iface, tcgc: modelType});
       }
       // TODO: what's the equivalent of x-ms-external?
@@ -82,9 +82,9 @@ export class typeAdapter {
 
     // now that the interface/model types have been generated, we can populate the rootType and possibleTypes
     for (const ifaceType of ifaceTypes) {
-      ifaceType.go.rootType = <go.PolymorphicType>this.getModel(ifaceType.tcgc);
+      ifaceType.go.rootType = <go.PolymorphicModel>this.getModel(ifaceType.tcgc);
       for (const subType of values(ifaceType.tcgc.discriminatedSubtypes)) {
-        const possibleType = <go.PolymorphicType>this.getModel(subType);
+        const possibleType = <go.PolymorphicModel>this.getModel(subType);
         ifaceType.go.possibleTypes.push(possibleType);
       }
     }
@@ -108,7 +108,7 @@ export class typeAdapter {
       }
       if (content.addlProps) {
         const annotations = new go.ModelFieldAnnotations(false, false, true, false);
-        const addlPropsType = new go.MapType(this.getPossibleType(content.addlProps, false, false), isTypePassedByValue(content.addlProps));
+        const addlPropsType = new go.Map(this.getPossibleType(content.addlProps, false, false), isTypePassedByValue(content.addlProps));
         const addlProps = new go.ModelField('AdditionalProperties', addlPropsType, true, '', annotations);
         modelType.go.fields.push(addlProps);
       }
@@ -190,7 +190,7 @@ export class typeAdapter {
         if (arrayType) {
           return arrayType;
         }
-        arrayType = new go.SliceType(this.getPossibleType(elementType, elementTypeByValue, substituteDiscriminator), myElementTypeByValue);
+        arrayType = new go.Slice(this.getPossibleType(elementType, elementTypeByValue, substituteDiscriminator), myElementTypeByValue);
         this.types.set(keyName, arrayType);
         return arrayType;
       }
@@ -200,7 +200,7 @@ export class typeAdapter {
         if (stringType) {
           return stringType;
         }
-        stringType = new go.PrimitiveType('string');
+        stringType = new go.Scalar('string');
         this.types.set(stringKey, stringType);
         return stringType;
       }
@@ -220,7 +220,7 @@ export class typeAdapter {
         if (mapType) {
           return mapType;
         }
-        mapType = new go.MapType(this.getPossibleType(type.valueType, elementTypeByValue, substituteDiscriminator), valueTypeByValue);
+        mapType = new go.Map(this.getPossibleType(type.valueType, elementTypeByValue, substituteDiscriminator), valueTypeByValue);
         this.types.set(keyName, mapType);
         return mapType;
       }
@@ -249,13 +249,13 @@ export class typeAdapter {
     }
   }
 
-  private getTimeType(encode: tsp.DateTimeKnownEncoding, utc: boolean): go.TimeType {
+  private getTimeType(encode: tsp.DateTimeKnownEncoding, utc: boolean): go.Time {
     const encoding = getDateTimeEncoding(encode);
     let datetime = this.types.get(encoding);
     if (datetime) {
-      return <go.TimeType>datetime;
+      return <go.Time>datetime;
     }
-    datetime = new go.TimeType(encoding, utc);
+    datetime = new go.Time(encoding, utc);
     this.types.set(encoding, datetime);
     return datetime;
   }
@@ -270,7 +270,7 @@ export class typeAdapter {
     if (!rsc) {
       rsc = new go.QualifiedType('ReadSeekCloser', 'io');
       if (sliceOf) {
-        rsc = new go.SliceType(rsc, true);
+        rsc = new go.Slice(rsc, true);
       }
       this.types.set(keyName, rsc);
     }
@@ -287,7 +287,7 @@ export class typeAdapter {
     if (!rsc) {
       rsc = new go.QualifiedType('MultipartContent', 'github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
       if (sliceOf) {
-        rsc = new go.SliceType(rsc, true);
+        rsc = new go.Slice(rsc, true);
       }
       this.types.set(keyName, rsc);
     }
@@ -303,7 +303,7 @@ export class typeAdapter {
           if (anyRawJSON) {
             return anyRawJSON;
           }
-          anyRawJSON = new go.SliceType(new go.PrimitiveType('byte'), true);
+          anyRawJSON = new go.Slice(new go.Scalar('byte'), true);
           anyRawJSON.rawJSONAsBytes = true;
           this.types.set(anyRawJSONKey, anyRawJSON);
           return anyRawJSON;
@@ -312,7 +312,7 @@ export class typeAdapter {
         if (anyType) {
           return anyType;
         }
-        anyType = new go.PrimitiveType('any');
+        anyType = new go.Scalar('any');
         this.types.set('any', anyType);
         return anyType;
       }
@@ -322,7 +322,7 @@ export class typeAdapter {
         if (primitiveBool) {
           return primitiveBool;
         }
-        primitiveBool = new go.PrimitiveType('bool');
+        primitiveBool = new go.Scalar('bool');
         this.types.set(boolKey, primitiveBool);
         return primitiveBool;
       }
@@ -334,7 +334,7 @@ export class typeAdapter {
         if (date) {
           return date;
         }
-        date = new go.TimeType('dateType', false);
+        date = new go.Time('dateType', false);
         this.types.set(dateKey, date);
         return date;
       }
@@ -345,7 +345,7 @@ export class typeAdapter {
         if (decimalType) {
           return decimalType;
         }
-        decimalType = new go.PrimitiveType(decimalKey);
+        decimalType = new go.Scalar(decimalKey);
         this.types.set(decimalKey, decimalType);
         return decimalType;
       }
@@ -356,7 +356,7 @@ export class typeAdapter {
         if (float32) {
           return float32;
         }
-        float32 = new go.PrimitiveType(float32Key);
+        float32 = new go.Scalar(float32Key);
         this.types.set(float32Key, float32);
         return float32;
       }
@@ -366,7 +366,7 @@ export class typeAdapter {
         if (float64) {
           return float64;
         }
-        float64 = new go.PrimitiveType(float64Key);
+        float64 = new go.Scalar(float64Key);
         this.types.set(float64Key, float64);
         return float64;
       }
@@ -383,7 +383,7 @@ export class typeAdapter {
         if (intType) {
           return intType;
         }
-        intType = new go.PrimitiveType(type.kind, type.encode === 'string');
+        intType = new go.Scalar(type.kind, type.encode === 'string');
         this.types.set(keyName, intType);
         return intType;
       }
@@ -393,7 +393,7 @@ export class typeAdapter {
         if (int64) {
           return int64;
         }
-        int64 = new go.PrimitiveType('int64', type.encode === 'string');
+        int64 = new go.Scalar('int64', type.encode === 'string');
         this.types.set(safeintkey, int64);
         return int64;
       }
@@ -415,7 +415,7 @@ export class typeAdapter {
         if (stringType) {
           return stringType;
         }
-        stringType = new go.PrimitiveType('string');
+        stringType = new go.Scalar('string');
         this.types.set(stringKey, stringType);
         return stringType;
       }
@@ -425,7 +425,7 @@ export class typeAdapter {
         if (time) {
           return time;
         }
-        time = new go.TimeType(encoding, false);
+        time = new go.Time(encoding, false);
         this.types.set(encoding, time);
         return time;
       
@@ -436,16 +436,16 @@ export class typeAdapter {
   }
 
   // converts an SdkEnumType to a go.ConstantType
-  private getConstantType(enumType: tcgc.SdkEnumType): go.ConstantType {
+  private getConstantType(enumType: tcgc.SdkEnumType): go.Constant {
     let constTypeName = naming.ensureNameCase(enumType.name);
     if (enumType.access === 'internal') {
       constTypeName = naming.getEscapedReservedName(uncapitalize(constTypeName), 'Type');
     }
     let constType = this.types.get(constTypeName);
     if (constType) {
-      return <go.ConstantType>constType;
+      return <go.Constant>constType;
     }
-    constType = new go.ConstantType(constTypeName, getPrimitiveType(enumType.valueType), `Possible${constTypeName}Values`);
+    constType = new go.Constant(constTypeName, getPrimitiveType(enumType.valueType), `Possible${constTypeName}Values`);
     constType.values = this.getConstantValues(constType, enumType.values);
     constType.docs.summary = enumType.summary;
     constType.docs.description = enumType.doc;
@@ -453,7 +453,7 @@ export class typeAdapter {
     return constType;
   }
 
-  private getInterfaceType(model: tcgc.SdkModelType, parent?: go.InterfaceType): go.InterfaceType {
+  private getInterfaceType(model: tcgc.SdkModelType, parent?: go.Interface): go.Interface {
     if (model.name.length === 0) {
       throw new AdapterError('InternalError', 'unnamed model', tsp.NoTarget);
     }
@@ -466,7 +466,7 @@ export class typeAdapter {
     }
     let iface = this.types.get(ifaceName);
     if (iface) {
-      return <go.InterfaceType>iface;
+      return <go.Interface>iface;
     }
     // find the discriminator field
     let discriminatorField: string | undefined;
@@ -480,7 +480,7 @@ export class typeAdapter {
     if (!discriminatorField) {
       throw new AdapterError('InternalError', `failed to find discriminator field for type ${model.name}`, tsp.NoTarget);
     }
-    iface = new go.InterfaceType(ifaceName, discriminatorField);
+    iface = new go.Interface(ifaceName, discriminatorField);
     if (parent) {
       iface.parent = parent;
     }
@@ -489,14 +489,14 @@ export class typeAdapter {
   }
 
   // converts an SdkModelType to a go.ModelType or go.PolymorphicType if the model is polymorphic
-  private getModel(model: tcgc.SdkModelType): go.ModelType | go.PolymorphicType {
+  private getModel(model: tcgc.SdkModelType): go.Model | go.PolymorphicModel {
     let modelName = naming.ensureNameCase(model.name);
     if (model.access === 'internal') {
       modelName = naming.getEscapedReservedName(uncapitalize(modelName), 'Model');
     }
     let modelType = this.types.get(modelName);
     if (modelType) {
-      return <go.ModelType | go.PolymorphicType>modelType;
+      return <go.Model | go.PolymorphicModel>modelType;
     }
   
     let usage = go.UsageFlags.None;
@@ -509,8 +509,8 @@ export class typeAdapter {
 
     const annotations = new go.ModelAnnotations(false, <tcgc.UsageFlags>(model.usage & tcgc.UsageFlags.MultipartFormData) === tcgc.UsageFlags.MultipartFormData);
     if (model.discriminatedSubtypes || model.discriminatorValue) {
-      let iface: go.InterfaceType | undefined;
-      let discriminatorLiteral: go.LiteralValue | undefined;
+      let iface: go.Interface | undefined;
+      let discriminatorLiteral: go.Literal | undefined;
 
       if (model.discriminatedSubtypes) {
         // root type, we can get the InterfaceType directly from it
@@ -538,10 +538,10 @@ export class typeAdapter {
         }
       }
 
-      modelType = new go.PolymorphicType(modelName, iface, annotations, usage);
-      (<go.PolymorphicType>modelType).discriminatorValue = discriminatorLiteral;
+      modelType = new go.PolymorphicModel(modelName, iface, annotations, usage);
+      (<go.PolymorphicModel>modelType).discriminatorValue = discriminatorLiteral;
     } else {
-      modelType = new go.ModelType(modelName, annotations, usage);
+      modelType = new go.Model(modelName, annotations, usage);
       // polymorphic types don't have XMLInfo
       modelType.xml = adaptXMLInfo(model.decorators);
     }
@@ -562,7 +562,7 @@ export class typeAdapter {
     return modelType;
   }
 
-  private getDiscriminatorLiteral(sdkProp: tcgc.SdkBodyModelPropertyType): go.LiteralValue {
+  private getDiscriminatorLiteral(sdkProp: tcgc.SdkBodyModelPropertyType): go.Literal {
     switch (sdkProp.type.kind) {
       case 'constant':
       case 'enumvalue':
@@ -618,7 +618,7 @@ export class typeAdapter {
     return field;
   }
 
-  private getConstantValues(type: go.ConstantType, valueTypes: Array<tcgc.SdkEnumValueType>): Array<go.ConstantValue> {
+  private getConstantValues(type: go.Constant, valueTypes: Array<tcgc.SdkEnumValueType>): Array<go.ConstantValue> {
     const values = new Array<go.ConstantValue>();
     for (const valueType of valueTypes) {
       let valueTypeName = `${type.name}${naming.ensureNameCase(valueType.name)}`;
@@ -637,7 +637,7 @@ export class typeAdapter {
     return values;
   }
 
-  private adaptBytesType(sdkType: tcgc.SdkBuiltInType): go.BytesType {
+  private adaptBytesType(sdkType: tcgc.SdkBuiltInType): go.EncodedBytes {
     let format: go.BytesEncoding = 'Std';
     if (sdkType.encode === 'base64url') {
       format = 'URL';
@@ -645,26 +645,26 @@ export class typeAdapter {
     const keyName = `bytes-${format}`;
     let bytesType = this.types.get(keyName);
     if (bytesType) {
-      return <go.BytesType>bytesType;
+      return <go.EncodedBytes>bytesType;
     }
-    bytesType = new go.BytesType(format);
+    bytesType = new go.EncodedBytes(format);
     this.types.set(keyName, bytesType);
     return bytesType;
   }
 
-  private getLiteralValue(constType: tcgc.SdkConstantType | tcgc.SdkEnumValueType): go.LiteralValue {
+  private getLiteralValue(constType: tcgc.SdkConstantType | tcgc.SdkEnumValueType): go.Literal {
     if (constType.kind === 'enumvalue') {
       const valueName = `${naming.ensureNameCase(constType.enumType.name)}${naming.ensureNameCase(constType.name)}`;
       const keyName = `literal-${valueName}`;
       let literalConst = this.types.get(keyName);
       if (literalConst) {
-        return <go.LiteralValue>literalConst;
+        return <go.Literal>literalConst;
       }
       const constValue = this.constValues.get(valueName);
       if (!constValue) {
         throw new AdapterError('InternalError', `failed to find const value for ${constType.name} in enum ${constType.enumType.name}`, constType.__raw?.node ?? tsp.NoTarget);
       }
-      literalConst = new go.LiteralValue(this.getConstantType(constType.enumType), constValue);
+      literalConst = new go.Literal(this.getConstantType(constType.enumType), constValue);
       this.types.set(keyName, literalConst);
       return literalConst;
     }
@@ -674,9 +674,9 @@ export class typeAdapter {
         const keyName = `literal-boolean-${constType.value}`;
         let literalBool = this.types.get(keyName);
         if (literalBool) {
-          return <go.LiteralValue>literalBool;
+          return <go.Literal>literalBool;
         }
-        literalBool = new go.LiteralValue(new go.PrimitiveType('bool'), constType.value);
+        literalBool = new go.Literal(new go.Scalar('bool'), constType.value);
         this.types.set(keyName, literalBool);
         return literalBool;
       }
@@ -684,9 +684,9 @@ export class typeAdapter {
         const keyName = `literal-bytes-${constType.value}`;
         let literalByteArray = this.types.get(keyName);
         if (literalByteArray) {
-          return <go.LiteralValue>literalByteArray;
+          return <go.Literal>literalByteArray;
         }
-        literalByteArray = new go.LiteralValue(this.adaptBytesType(constType.valueType), constType.value);
+        literalByteArray = new go.Literal(this.adaptBytesType(constType.valueType), constType.value);
         this.types.set(keyName, literalByteArray);
         return literalByteArray;
       }
@@ -695,9 +695,9 @@ export class typeAdapter {
         const keyName = `literal-${constType.valueType.kind}-${constType.value}`;
         let literalDecimal = this.types.get(keyName);
         if (literalDecimal) {
-          return <go.LiteralValue>literalDecimal;
+          return <go.Literal>literalDecimal;
         }
-        literalDecimal = new go.LiteralValue(new go.PrimitiveType('float64'), constType.value);
+        literalDecimal = new go.Literal(new go.Scalar('float64'), constType.value);
         this.types.set(keyName, literalDecimal);
         return literalDecimal;
       }
@@ -725,9 +725,9 @@ export class typeAdapter {
         const keyName = `literal-${constType.valueType.kind}-${constType.value}`;
         let literalInt = this.types.get(keyName);
         if (literalInt) {
-          return <go.LiteralValue>literalInt;
+          return <go.Literal>literalInt;
         }
-        literalInt = new go.LiteralValue(new go.PrimitiveType(constType.valueType.kind), constType.value);
+        literalInt = new go.Literal(new go.Scalar(constType.valueType.kind), constType.value);
         this.types.set(keyName, literalInt);
         return literalInt;
       }
@@ -736,9 +736,9 @@ export class typeAdapter {
         const keyName = `literal-${constType.valueType.kind}-${constType.value}`;
         let literalFloat = this.types.get(keyName);
         if (literalFloat) {
-          return <go.LiteralValue>literalFloat;
+          return <go.Literal>literalFloat;
         }
-        literalFloat = new go.LiteralValue(new go.PrimitiveType(constType.valueType.kind), constType.value);
+        literalFloat = new go.Literal(new go.Scalar(constType.valueType.kind), constType.value);
         this.types.set(keyName, literalFloat);
         return literalFloat;
       }
@@ -747,9 +747,9 @@ export class typeAdapter {
         const keyName = `literal-string-${constType.value}`;
         let literalString = this.types.get(keyName);
         if (literalString) {
-          return <go.LiteralValue>literalString;
+          return <go.Literal>literalString;
         }
-        literalString = new go.LiteralValue(new go.PrimitiveType('string'), constType.value);
+        literalString = new go.Literal(new go.Scalar('string'), constType.value);
         this.types.set(keyName, literalString);
         return literalString;
       }
@@ -792,7 +792,7 @@ function getPrimitiveType(type: tcgc.SdkBuiltInType): 'bool' | 'float32' | 'floa
   }
 }
 
-function getDateTimeEncoding(encoding: tsp.DateTimeKnownEncoding): go.DateTimeFormat {
+function getDateTimeEncoding(encoding: tsp.DateTimeKnownEncoding): go.TimeFormat {
   switch (encoding) {
     case 'rfc3339':
       return 'dateTimeRFC3339';
@@ -846,12 +846,12 @@ export function isTypePassedByValue(type: tcgc.SdkType): boolean {
 }
 
 interface ModelTypeSdkModelType {
-  go: go.ModelType | go.PolymorphicType;
+  go: go.Model | go.PolymorphicModel;
   tcgc: tcgc.SdkModelType;
 }
 
 interface InterfaceTypeSdkModelType {
-  go: go.InterfaceType;
+  go: go.Interface;
   tcgc: tcgc.SdkModelType;
 }
 


### PR DESCRIPTION
Dropped the suffix "Type" from type names as it was redundant and caused some ugly dependent type names (e.g. ConstantTypeTypes). BytesType was renamed to EncodedBytes.
LiteralValue was renamed to Literal.
PolymorphicType was renamed to PolymorphicModel.
PrimitiveType was renamed to Scalar.
Fixed sorting of union types.
Added some doc comments. The rest will be added in a subsequent change.