### PR TITLE
Remove string from Scalar and into its own type

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -147,7 +147,7 @@ function adaptQueryScalarParameterType(schema: m4.Schema): go.QueryScalarParamet
 
 function adaptURIPrameterType(schema: m4.Schema): go.URIParameterType {
   const type = adaptPossibleType(schema);
-  if (!go.isConstantType(type) && !go.isPrimitiveType(type)) {
+  if (!go.isConstantType(type) && !go.isPrimitiveType(type) && !go.isStringType(type)) {
     throw new Error(`unexpected URI parameter type ${schema.type}`);
   }
   return type;

--- a/packages/autorest.go/src/m4togocodemodel/types.ts
+++ b/packages/autorest.go/src/m4togocodemodel/types.ts
@@ -159,7 +159,7 @@ function getDiscriminatorLiteral(discriminatorValue: string): go.Literal {
   let discriminatorLiteral: go.Literal;
   // the discriminatorValue is either a quoted string or a constant (i.e. enum) value
   if (discriminatorValue[0] === '"') {
-    discriminatorLiteral = createLiteralValue(new go.Scalar('string'), discriminatorValue);
+    discriminatorLiteral = createLiteralValue(new go.String(), discriminatorValue);
   } else {
     // find the corresponding constant value
     const value = constValues.get(discriminatorValue);
@@ -318,7 +318,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (stringType) {
         return stringType;
       }
-      stringType = new go.Scalar('string');
+      stringType = new go.String();
       types.set(m4.SchemaType.ArmId, stringType);
       return stringType;
     }
@@ -374,7 +374,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (credType) {
         return credType;
       }
-      credType = new go.Scalar('string');
+      credType = new go.String();
       types.set(m4.SchemaType.Credential, credType);
       return credType;
     }
@@ -406,7 +406,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (duration) {
         return duration;
       }
-      duration = new go.Scalar('string');
+      duration = new go.String();
       types.set(m4.SchemaType.Duration, duration);
       return duration;
     }
@@ -457,7 +457,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (odataType) {
         return odataType;
       }
-      odataType = new go.Scalar('string');
+      odataType = new go.String();
       types.set(m4.SchemaType.ODataQuery, odataType);
       return odataType;
     }
@@ -468,7 +468,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (stringType) {
         return stringType;
       }
-      stringType = new go.Scalar('string');
+      stringType = new go.String();
       types.set(m4.SchemaType.String, stringType);
       return stringType;
     }
@@ -477,7 +477,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (uriType) {
         return uriType;
       }
-      uriType = new go.Scalar('string');
+      uriType = new go.String();
       types.set(m4.SchemaType.Uri, uriType);
       return uriType;
     }
@@ -486,7 +486,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (uuid) {
         return uuid;
       }
-      uuid = new go.Scalar('string');
+      uuid = new go.String();
       types.set(m4.SchemaType.Uuid, uuid);
       return uuid;
     }
@@ -576,7 +576,7 @@ function adaptLiteralValue(constSchema: m4.ConstantSchema): go.Literal {
       if (literalString) {
         return <go.Literal>literalString;
       }
-      literalString = new go.Literal(new go.Scalar('string'), constSchema.value.value);
+      literalString = new go.Literal(new go.String(), constSchema.value.value);
       types.set(keyName, literalString);
       return literalString;
     }

--- a/packages/codegen.go/src/example.ts
+++ b/packages/codegen.go/src/example.ts
@@ -369,7 +369,6 @@ function getPointerValue(type: go.PossibleType, valueString: string, byValue: bo
       case `bool`:
       case `byte`:
       case `rune`:
-      case `string`:
         prtType = 'Ptr';
         break;
       default:
@@ -377,6 +376,9 @@ function getPointerValue(type: go.PossibleType, valueString: string, byValue: bo
     }
     if (imports) imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/to');
     return `to.${prtType}(${valueString})`;
+  } else if (go.isStringType(type)) {
+    if (imports) imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/to');
+    return `to.Ptr(${valueString})`;
   } else if (go.isConstantType(type) || go.isTimeType(type)) {
     if (imports) imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/to');
     return `to.Ptr(${valueString})`;
@@ -427,7 +429,6 @@ function generateFakeExample(goType: go.PossibleType, name?: string): go.Example
       case 'bool':
         return new go.BooleanExample(false, goType);
       case 'byte':
-      case 'string':
       case 'rune':
         return new go.StringExample(`<${name ?? 'test'}>`, goType);
       default:
@@ -444,6 +445,8 @@ function generateFakeExample(goType: go.PossibleType, name?: string): go.Example
       default:
         return new go.NumberExample(goType.values[0].value as number, goType);
     }
+  } else if (go.isStringType(goType)) {
+    return new go.StringExample(`<${name ?? 'test'}>`, goType);
   }
   throw new CodegenError('InternalError', `fake example does not support non primitive type: ${go.getTypeDeclaration(goType)}`);
 }

--- a/packages/codegen.go/src/helpers.ts
+++ b/packages/codegen.go/src/helpers.ts
@@ -229,7 +229,7 @@ export function formatParamValue(param: go.MethodParameter, imports: ImportManag
         return content;
       }
       const separator = getDelimiterForCollectionFormat(param.collectionFormat);
-      if (go.isPrimitiveType(param.type.elementType) && param.type.elementType.typeName === 'string') {
+      if (go.isStringType(param.type.elementType)) {
         imports.add('strings');
         return `strings.Join(${paramName}, "${separator}")`;
       } else if (go.isBytesType(param.type.elementType)) {
@@ -338,7 +338,7 @@ export function formatLiteralValue(value: go.Literal, withCast: boolean): string
     return (<go.ConstantValue>value.literal).name;
   } else if (go.isPrimitiveType(value.type)) {
     // if it's a string, we want the uncasted version to include quotes
-    if (!withCast && value.type.typeName !== 'string') {
+    if (!withCast) {
       return `${value.literal}`;
     }
     switch (value.type.typeName) {
@@ -350,15 +350,15 @@ export function formatLiteralValue(value: go.Literal, withCast: boolean): string
         return `int32(${value.literal})`;
       case 'int64':
         return `int64(${value.literal})`;
-      case 'string':
-        if (value.literal[0] === '"') {
-          // string is already quoted
-          return value.literal;
-        }
-        return `"${value.literal}"`;
       default:
         return value.literal;
     }
+  } else if (go.isStringType(value.type)) {
+    if (value.literal[0] === '"') {
+      // string is already quoted
+      return value.literal;
+    }
+    return `"${value.literal}"`;
   } else if (go.isTimeType(value.type)) {
     return `"${value.literal}"`;
   }

--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -280,13 +280,13 @@ function formatHeaderResponseValue(headerResp: go.HeaderScalarResponse | go.Head
       } else {
         text += `\t\t${name}, err := strconv.ParseFloat(val, 64)\n`;
       }
-    } else if (headerResp.type.typeName === 'string') {
-      text += `\t\t${respObj}.${headerResp.fieldName} = &val\n`;
-      text += '\t}\n';
-      return text;
     } else {
       throw new CodegenError('InternalError', `unhandled primitive type ${headerResp.type.typeName}`);
     }
+  } else if (go.isStringType(headerResp.type)) {
+    text += `\t\t${respObj}.${headerResp.fieldName} = &val\n`;
+    text += '\t}\n';
+    return text;
   } else if (go.isTimeType(headerResp.type)) {
     imports.add('time');
     if (headerResp.type.format === 'dateType') {
@@ -591,7 +591,7 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
         return type.type === 'string';
       };
       // TODO: https://github.com/Azure/autorest.go/issues/1593
-      if (pp.kind === 'pathScalarParam' && ((go.isPrimitiveType(pp.type) && pp.type.typeName === 'string' || choiceIsString(pp.type)) && pp.isEncoded)) {
+      if (pp.kind === 'pathScalarParam' && ((go.isStringType(pp.type) || choiceIsString(pp.type)) && pp.isEncoded)) {
         const paramName = helpers.getParamName(pp);
         imports.add('errors');
         text += `\tif ${paramName} == "" {\n`;
@@ -671,7 +671,7 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
             imports.add('fmt');
             queryVal = 'fmt.Sprintf("%d", qv)';
           }
-        } else if (go.isPrimitiveType(arrayQP.elementType) && arrayQP.elementType.typeName === 'string') {
+        } else if (go.isStringType(arrayQP.elementType)) {
           queryVal = 'qv';
         } else {
           imports.add('fmt');

--- a/packages/codemodel.go/src/examples.ts
+++ b/packages/codemodel.go/src/examples.ts
@@ -6,39 +6,39 @@
 import * as client from './client.js';
 import * as param from './param.js';
 import * as result from './result.js';
-import { Constant, Docs, EncodedBytes, Literal, Map, Model, PolymorphicModel, PossibleType, Scalar, QualifiedType, Slice, Time } from './type.js';
+import * as type from './type.js';
 
 export type ExampleType = AnyExample | ArrayExample | BooleanExample | DictionaryExample | NullExample | NumberExample | QualifiedExample| StringExample | StructExample;
 
 export interface AnyExample {
   kind: 'any';
   value: any;
-  type: PossibleType;
+  type: type.PossibleType;
 }
 
 export interface ArrayExample {
   kind: 'array';
   value: Array<ExampleType>;
-  type: Slice;
+  type: type.Slice;
 }
 
 export interface BooleanExample {
   kind: 'boolean';
   value: boolean;
-  type: Constant | Literal | Scalar;
+  type: type.Constant | type.Literal | type.Scalar;
 }
 
 export interface DictionaryExample {
   kind: 'dictionary';
   value: Record<string, ExampleType>;
-  type: Map;
+  type: type.Map;
 }
 
 // MethodExample is an example for a method. This code model part is for example or test generation.
 export interface MethodExample {
   name: string;
 
-  docs: Docs;
+  docs: type.Docs;
 
   filePath: string;
 
@@ -52,13 +52,13 @@ export interface MethodExample {
 export interface NullExample {
   kind: 'null';
   value: null;
-  type: PossibleType;
+  type: type.PossibleType;
 }
 
 export interface NumberExample {
   kind: 'number';
   value: number;
-  type: Constant | Literal | Scalar | Time;
+  type: type.Constant | type.Literal | type.Scalar | type.Time;
 }
 
 export interface ParameterExample {
@@ -69,7 +69,7 @@ export interface ParameterExample {
 export interface QualifiedExample {
   kind: 'qualified';
   value: any;
-  type: QualifiedType;
+  type: type.QualifiedType;
 }
 
 export interface ResponseEnvelopeExample {
@@ -86,14 +86,14 @@ export interface ResponseHeaderExample {
 export interface StringExample {
   kind: 'string';
   value: string;
-  type: Constant | EncodedBytes | Literal | Scalar | Time;
+  type: type.Constant | type.EncodedBytes | type.Literal | type.Scalar | type.String | type.Time;
 }
 
 export interface StructExample {
   kind: 'model';
   value: Record<string, ExampleType>;
   additionalProperties?: Record<string, ExampleType>;
-  type: Model | PolymorphicModel;
+  type: type.Model | type.PolymorphicModel;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -103,12 +103,12 @@ export class AnyExample implements AnyExample {
   constructor(value: any) {
     this.kind = 'any';
     this.value = value;
-    this.type = new Scalar('any');
+    this.type = new type.Scalar('any');
   }
 }
 
 export class ArrayExample implements ArrayExample {
-  constructor(type: Slice) {
+  constructor(type: type.Slice) {
     this.kind = 'array';
     this.type = type;
     this.value = [];
@@ -116,7 +116,7 @@ export class ArrayExample implements ArrayExample {
 }
 
 export class BooleanExample implements BooleanExample {
-  constructor(value: boolean, type: Constant | Literal | Scalar) {
+  constructor(value: boolean, type: type.Constant | type.Literal | type.Scalar) {
     this.kind = 'boolean';
     this.value = value;
     this.type = type;
@@ -124,7 +124,7 @@ export class BooleanExample implements BooleanExample {
 }
 
 export class DictionaryExample implements DictionaryExample {
-  constructor(type: Map) {
+  constructor(type: type.Map) {
     this.kind = 'dictionary';
     this.type = type;
     this.value = {};
@@ -132,7 +132,7 @@ export class DictionaryExample implements DictionaryExample {
 }
 
 export class MethodExample implements MethodExample {
-  constructor(name: string, docs: Docs, filePath: string) {
+  constructor(name: string, docs: type.Docs, filePath: string) {
     this.name = name;
     this.docs = docs;
     this.filePath = filePath;
@@ -142,14 +142,14 @@ export class MethodExample implements MethodExample {
 }
 
 export class NullExample implements NullExample {
-  constructor(type: PossibleType) {
+  constructor(type: type.PossibleType) {
     this.kind = 'null';
     this.type = type;
   }
 }
 
 export class NumberExample implements NumberExample {
-  constructor(value: number, type: Constant | Literal | Scalar | Time) {
+  constructor(value: number, type: type.Constant | type.Literal | type.Scalar | type.Time) {
     this.kind = 'number';
     this.value = value;
     this.type = type;
@@ -164,7 +164,7 @@ export class ParameterExample implements ParameterExample {
 }
 
 export class QualifiedExample implements QualifiedExample {
-  constructor(type: QualifiedType, value: any) {
+  constructor(type: type.QualifiedType, value: any) {
     this.kind = 'qualified';
     this.type = type;
     this.value = value;
@@ -186,7 +186,7 @@ export class ResponseHeaderExample implements ResponseHeaderExample {
 }
 
 export class StringExample implements StringExample {
-  constructor(value: string, type: Constant | EncodedBytes | Literal | Scalar | Time) {
+  constructor(value: string, type: type.Constant | type.EncodedBytes | type.Literal | type.Scalar | type.String | type.Time) {
     this.kind = 'string';
     this.value = value;
     this.type = type;
@@ -194,7 +194,7 @@ export class StringExample implements StringExample {
 }
 
 export class StructExample implements StructExample {
-  constructor(type: Model | PolymorphicModel) {
+  constructor(type: type.Model | type.PolymorphicModel) {
     this.kind = 'model';
     this.type = type;
     this.value = {};

--- a/packages/codemodel.go/src/param.ts
+++ b/packages/codemodel.go/src/param.ts
@@ -112,7 +112,7 @@ export interface HeaderScalarParameter extends ParameterBase {
 }
 
 /** defines the possible types for a scalar header */
-export type HeaderScalarType = type.Constant | type.EncodedBytes | type.Literal | type.Scalar | type.Time;
+export type HeaderScalarType = type.Constant | type.EncodedBytes | type.Literal | type.Scalar | type.String | type.Time;
 
 /** parameter goes in multipart/form body */
 export interface MultipartFormBodyParameter extends ParameterBase {
@@ -207,7 +207,7 @@ export interface PathScalarParameter extends ParameterBase {
 }
 
 /** defines the possible types for a PathScalarParameter */
-export type PathScalarParameterType = type.Constant | type.EncodedBytes | type.Literal | type.Scalar | type.Time;
+export type PathScalarParameterType = type.Constant | type.EncodedBytes | type.Literal | type.Scalar | type.String | type.Time;
 
 /** a collection of values that go in the HTTP query string */
 export interface QueryCollectionParameter extends ParameterBase {
@@ -241,7 +241,7 @@ export interface QueryScalarParameter extends ParameterBase {
 }
 
 /** defines the possible types for a QueryScalarParameter */
-export type QueryScalarParameterType = type.Constant | type.EncodedBytes | type.Literal | type.Scalar | type.Time;
+export type QueryScalarParameterType = type.Constant | type.EncodedBytes | type.Literal | type.Scalar | type.String | type.Time;
 
 /** the synthesized resume token parameter for LROs */
 export interface ResumeTokenParameter extends ParameterBase {
@@ -260,7 +260,7 @@ export interface URIParameter extends ParameterBase {
 }
 
 /** defines the possible types for a URIParameter */
-export type URIParameterType = type.Constant | type.Scalar;
+export type URIParameterType = type.Constant | type.Scalar | type.String;
 
 /** narrows style to a ClientSideDefault within the conditional block */
 export function isClientSideDefault(style: ParameterStyle): style is ClientSideDefault {
@@ -481,14 +481,14 @@ export class QueryScalarParameter extends ParameterBase implements QueryScalarPa
 
 export class ResumeTokenParameter extends ParameterBase implements ResumeTokenParameter {
   constructor() {
-    super('ResumeToken', new type.Scalar('string'), 'optional', true, 'method');
+    super('ResumeToken', new type.String(), 'optional', true, 'method');
     this.kind = 'resumeTokenParam';
     this.docs.summary = 'Resumes the long-running operation from the provided token.';
   }
 }
 
 export class URIParameter extends ParameterBase implements URIParameter {
-  constructor(name: string, uriPathSegment: string, type: type.Constant | type.Scalar, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
+  constructor(name: string, uriPathSegment: string, type: URIParameterType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, style, byValue, location);
     this.kind = 'uriParam';
     this.uriPathSegment = uriPathSegment;

--- a/packages/codemodel.go/src/result.ts
+++ b/packages/codemodel.go/src/result.ts
@@ -139,7 +139,7 @@ export interface MonomorphicResult {
 }
 
 /** the possible monomorphic result types */
-export type MonomorphicResultType = type.Constant | type.EncodedBytes | type.Map | type.Scalar | type.Slice | type.Time;
+export type MonomorphicResultType = type.Constant | type.EncodedBytes | type.Map | type.Scalar | type.Slice | type.String | type.Time;
 
 /**
  * used for methods that return a discriminated type.

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -167,7 +167,7 @@ export class clientAdapter {
 
   private adaptURIParam(sdkParam: tcgc.SdkPathParameter): go.URIParameter {
     const paramType = this.ta.getPossibleType(sdkParam.type, true, false);
-    if (!go.isConstantType(paramType) && !go.isPrimitiveType(paramType)) {
+    if (!go.isConstantType(paramType) && !go.isPrimitiveType(paramType) && !go.isStringType(paramType)) {
       throw new AdapterError('UnsupportedTsp', `unsupported URI parameter type ${go.getTypeDeclaration(paramType)}`, sdkParam.__raw?.node ?? NoTarget);
     }
     // TODO: follow up with tcgc if serializedName should actually be optional
@@ -484,7 +484,7 @@ export class clientAdapter {
     if (param.isApiVersionParam && param.clientDefaultValue) {
       // we emit the api version param inline as a literal, never as a param.
       // the ClientOptions.APIVersion setting is used to change the version.
-      const paramType = new go.Literal(new go.Scalar('string'), param.clientDefaultValue);
+      const paramType = new go.Literal(new go.String(), param.clientDefaultValue);
       switch (param.kind) {
         case 'header':
           return new go.HeaderScalarParameter(param.name, param.serializedName, paramType, 'literal', true, 'method');
@@ -910,7 +910,7 @@ export class clientAdapter {
   private adaptExampleType(exampleType: tcgc.SdkExampleValue, goType: go.PossibleType): go.ExampleType {
     switch (exampleType.kind) {
       case 'string':
-        if (go.isConstantType(goType) || go.isBytesType(goType) || go.isLiteralValue(goType) || go.isTimeType(goType) || go.isPrimitiveType(goType)) {
+        if (go.isConstantType(goType) || go.isBytesType(goType) || go.isLiteralValue(goType) || go.isTimeType(goType) || go.isStringType(goType)) {
           return new go.StringExample(exampleType.value, goType);
         }
         if (go.isQualifiedType(goType)) {

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -200,7 +200,7 @@ export class typeAdapter {
         if (stringType) {
           return stringType;
         }
-        stringType = new go.Scalar('string');
+        stringType = new go.String();
         this.types.set(stringKey, stringType);
         return stringType;
       }
@@ -415,7 +415,7 @@ export class typeAdapter {
         if (stringType) {
           return stringType;
         }
-        stringType = new go.Scalar('string');
+        stringType = new go.String();
         this.types.set(stringKey, stringType);
         return stringType;
       }
@@ -749,7 +749,7 @@ export class typeAdapter {
         if (literalString) {
           return <go.Literal>literalString;
         }
-        literalString = new go.Literal(new go.Scalar('string'), constType.value);
+        literalString = new go.Literal(new go.String(), constType.value);
         this.types.set(keyName, literalString);
         return literalString;
       }
@@ -924,7 +924,7 @@ export function adaptXMLInfo(decorators: Array<tcgc.DecoratorInfo>, field?: go.M
       case 'TypeSpec.Xml.@unwrapped':
         // unwrapped can only be applied fields
         if (field) {
-          if (go.isPrimitiveType(field.type) && field.type.typeName === 'string') {
+          if (go.isStringType(field.type)) {
             // an unwrapped string means it's text
             xmlInfo.text = true;  
           } else if (go.isSliceType(field.type)) {


### PR DESCRIPTION
Strings were special cased as they don't require any parsing or formatting like the other scalar types. Splitting them into their own type removes the need for special handling.