### PR TITLE
Remove any from Scalar and into its own type

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -123,7 +123,7 @@ function populateMethod(op: m4.Operation, method: go.MethodType | go.NextPageMet
 function adaptHeaderScalarType(schema: m4.Schema, forParam: boolean): go.HeaderScalarType {
   // for header params, we never pass the element type by pointer
   const type = adaptPossibleType(schema, forParam);
-  if (go.isInterfaceType(type) || go.isMapType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type) || go.isQualifiedType(type)) {
+  if (go.isAnyType(type) || go.isInterfaceType(type) || go.isMapType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type) || go.isQualifiedType(type)) {
     throw new Error(`unexpected header parameter type ${schema.type}`);
   }
   return type;
@@ -131,7 +131,7 @@ function adaptHeaderScalarType(schema: m4.Schema, forParam: boolean): go.HeaderS
 
 function adaptPathScalarParameterType(schema: m4.Schema): go.PathScalarParameterType {
   const type = adaptPossibleType(schema);
-  if (go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type)  || go.isQualifiedType(type)) {
+  if (go.isAnyType(type) || go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type)  || go.isQualifiedType(type)) {
     throw new Error(`unexpected path parameter type ${schema.type}`);
   }
   return type;
@@ -139,7 +139,7 @@ function adaptPathScalarParameterType(schema: m4.Schema): go.PathScalarParameter
 
 function adaptQueryScalarParameterType(schema: m4.Schema): go.QueryScalarParameterType {
   const type = adaptPossibleType(schema);
-  if (go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type)  || go.isQualifiedType(type)) {
+  if (go.isAnyType(type) || go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type)  || go.isQualifiedType(type)) {
     throw new Error(`unexpected query parameter type ${schema.type}`);
   }
   return type;
@@ -235,7 +235,7 @@ function adaptResponseEnvelope(m4CodeModel: m4.CodeModel, codeModel: go.CodeMode
     respEnv.result = new go.HeadAsBooleanResult(resultProp.language.go!.name);
   } else if (!resultProp.language.go!.embeddedType) {
     const resultType = adaptPossibleType(resultProp.schema);
-    if (go.isInterfaceType(resultType) || go.isLiteralValue(resultType) || go.isModelType(resultType) || go.isPolymorphicType(resultType) || go.isQualifiedType(resultType)) {
+    if (go.isAnyType(resultType) || go.isInterfaceType(resultType) || go.isLiteralValue(resultType) || go.isModelType(resultType) || go.isPolymorphicType(resultType) || go.isQualifiedType(resultType)) {
       throw new Error(`invalid monomorphic result type ${go.getTypeDeclaration(resultType)}`);
     }
     respEnv.result = new go.MonomorphicResult(resultProp.language.go!.name, adaptResultFormat(helpers.getSchemaResponse(op)!.protocol), resultType, resultProp.language.go!.byValue);

--- a/packages/autorest.go/src/m4togocodemodel/types.ts
+++ b/packages/autorest.go/src/m4togocodemodel/types.ts
@@ -289,7 +289,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (anyType) {
         return anyType;
       }
-      anyType = new go.Scalar('any');
+      anyType = new go.Any();
       types.set(m4.SchemaType.Any, anyType);
       return anyType;
     }
@@ -309,7 +309,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (anyObject) {
         return anyObject;
       }
-      anyObject = new go.Map(new go.Scalar('any'), true);
+      anyObject = new go.Map(new go.Any(), true);
       types.set(m4.SchemaType.AnyObject, anyObject);
       return anyObject;
     }

--- a/packages/codegen.go/src/example.ts
+++ b/packages/codegen.go/src/example.ts
@@ -365,7 +365,6 @@ function getPointerValue(type: go.PossibleType, valueString: string, byValue: bo
   if (go.isPrimitiveType(type)) {
     let prtType = '';
     switch (type.typeName) {
-      case 'any':
       case `bool`:
       case `byte`:
       case `rune`:
@@ -376,7 +375,7 @@ function getPointerValue(type: go.PossibleType, valueString: string, byValue: bo
     }
     if (imports) imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/to');
     return `to.${prtType}(${valueString})`;
-  } else if (go.isStringType(type)) {
+  } else if (go.isAnyType(type) || go.isStringType(type)) {
     if (imports) imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/to');
     return `to.Ptr(${valueString})`;
   } else if (go.isConstantType(type) || go.isTimeType(type)) {
@@ -422,10 +421,10 @@ function jsonToGo(value: any, indent: string): string {
 }
 
 function generateFakeExample(goType: go.PossibleType, name?: string): go.ExampleType {
-  if (go.isPrimitiveType(goType)) {
+  if (go.isAnyType(goType)) {
+    return new go.NullExample(goType);
+  } else if (go.isPrimitiveType(goType)) {
     switch (goType.typeName) {
-      case 'any':
-        return new go.NullExample(goType);
       case 'bool':
         return new go.BooleanExample(false, goType);
       case 'byte':

--- a/packages/codegen.go/src/models.ts
+++ b/packages/codegen.go/src/models.ts
@@ -367,7 +367,7 @@ function generateJSONMarshallerBody(modelType: go.Model | go.PolymorphicModel, m
       if (go.isTimeType(field.type)) {
         populate += capitalize(field.type.format);
         modelDef.SerDe.needsJSONPopulate = true;
-      } else if (go.isPrimitiveType(field.type) && field.type.typeName === 'any') {
+      } else if (go.isAnyType(field.type)) {
         populate += 'Any';
         modelDef.SerDe.needsJSONPopulateAny = true;
       } else {

--- a/packages/codemodel.go/src/examples.ts
+++ b/packages/codemodel.go/src/examples.ts
@@ -13,7 +13,7 @@ export type ExampleType = AnyExample | ArrayExample | BooleanExample | Dictionar
 export interface AnyExample {
   kind: 'any';
   value: any;
-  type: type.PossibleType;
+  type: type.Any;
 }
 
 export interface ArrayExample {
@@ -103,7 +103,7 @@ export class AnyExample implements AnyExample {
   constructor(value: any) {
     this.kind = 'any';
     this.value = value;
-    this.type = new type.Scalar('any');
+    this.type = new type.Any();
   }
 }
 

--- a/packages/codemodel.go/src/result.ts
+++ b/packages/codemodel.go/src/result.ts
@@ -139,7 +139,7 @@ export interface MonomorphicResult {
 }
 
 /** the possible monomorphic result types */
-export type MonomorphicResultType = type.Constant | type.EncodedBytes | type.Map | type.Scalar | type.Slice | type.String | type.Time;
+export type MonomorphicResultType = type.Any | type.Constant | type.EncodedBytes | type.Map | type.Scalar | type.Slice | type.String | type.Time;
 
 /**
  * used for methods that return a discriminated type.
@@ -192,7 +192,7 @@ export type ResultFormat = 'JSON' | 'XML' | 'Text';
 export function getResultType(result: Result): type.Interface | type.Model | MonomorphicResultType | type.Scalar | type.QualifiedType {
   switch (result.kind) {
     case 'anyResult':
-      return new type.Scalar('any');
+      return new type.Any();
     case 'binaryResult':
       return new type.QualifiedType('ReadCloser', 'io');
     case 'headAsBooleanResult':

--- a/packages/codemodel.go/src/type.ts
+++ b/packages/codemodel.go/src/type.ts
@@ -15,7 +15,12 @@ export interface Docs {
 }
 
 /** defines types that go across the wire */
-export type PossibleType = Constant | EncodedBytes | Interface | Literal | Map | Model | PolymorphicModel | QualifiedType | Scalar | Slice | String | Time;
+export type PossibleType = Any | Constant | EncodedBytes | Interface | Literal | Map | Model | PolymorphicModel | QualifiedType | Scalar | Slice | String | Time;
+
+/** the Go any type */
+export interface Any {
+  isAny: true;
+}
 
 /** a const type definition */
 export interface Constant {
@@ -150,7 +155,7 @@ export interface Scalar {
 }
 
 /** the supported Go scalar types */
-export type ScalarType = 'any' | 'bool' | 'byte' | 'float32' | 'float64' | 'int8' | 'int16' | 'int32' | 'int64' | 'rune' | 'uint8' | 'uint16' | 'uint32' | 'uint64';
+export type ScalarType = 'bool' | 'byte' | 'float32' | 'float64' | 'int8' | 'int16' | 'int32' | 'int64' | 'rune' | 'uint8' | 'uint16' | 'uint32' | 'uint64';
 
 /** a Go string */
 export interface String {
@@ -234,6 +239,10 @@ export interface XMLInfo {
   text: boolean;
 }
 
+export function isAnyType(type: PossibleType): type is Any {
+  return (<Any>type).isAny !== undefined;
+}
+
 export function isBytesType(type: PossibleType): type is EncodedBytes {
   return (<EncodedBytes>type).encoding !== undefined;
 }
@@ -303,7 +312,9 @@ export function getLiteralValueTypeName(literal: LiteralType): string {
 }
 
 export function getTypeDeclaration(type: PossibleType, pkgName?: string): string {
-  if (isPrimitiveType(type)) {
+  if (isAnyType(type)) {
+    return 'any';
+  } else if (isPrimitiveType(type)) {
     return type.typeName;
   } else if (isQualifiedType(type)) {
     let pkg = type.packageName;
@@ -360,6 +371,12 @@ export class Struct implements Struct {
     this.fields = new Array<StructField>();
     this.name = name;
     this.docs = {};
+  }
+}
+
+export class Any implements Any {
+  constructor() {
+    this.isAny = true;
   }
 }
 

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -793,7 +793,7 @@ export class clientAdapter {
   private adaptHeaderScalarType(sdkType: tcgc.SdkType, forParam: boolean): go.HeaderScalarType {
     // for header params, we never pass the element type by pointer
     const type = this.ta.getPossibleType(sdkType, forParam, false);
-    if (go.isInterfaceType(type) || go.isMapType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type) || go.isQualifiedType(type)) {
+    if (go.isAnyType(type) || go.isInterfaceType(type) || go.isMapType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type) || go.isQualifiedType(type)) {
       throw new AdapterError('InternalError', `unexpected header parameter type ${sdkType.kind}`, sdkType.__raw?.node ?? NoTarget);
     }
     return type;
@@ -801,7 +801,7 @@ export class clientAdapter {
 
   private adaptPathScalarParameterType(sdkType: tcgc.SdkType): go.PathScalarParameterType {
     const type = this.ta.getPossibleType(sdkType, false, false);
-    if (go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type) || go.isQualifiedType(type)) {
+    if (go.isAnyType(type) || go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type) || go.isQualifiedType(type)) {
       throw new AdapterError('InternalError', `unexpected path parameter type ${sdkType.kind}`, sdkType.__raw?.node ?? NoTarget);
     }
     return type;
@@ -809,7 +809,7 @@ export class clientAdapter {
 
   private adaptQueryScalarParameterType(sdkType: tcgc.SdkType): go.QueryScalarParameterType {
     const type = this.ta.getPossibleType(sdkType, false, false);
-    if (go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type) || go.isQualifiedType(type)) {
+    if (go.isAnyType(type) || go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type) || go.isQualifiedType(type)) {
       throw new AdapterError('InternalError', `unexpected query parameter type ${sdkType.kind}`, sdkType.__raw?.node ?? NoTarget);
     }
     return type;
@@ -885,7 +885,7 @@ export class clientAdapter {
           if (response.bodyValue && method.responseEnvelope.result) {
             switch (method.responseEnvelope.result.kind) {
               case 'anyResult':
-                goExample.responseEnvelope.result = this.adaptExampleType(response.bodyValue, new go.Scalar('any'));
+                goExample.responseEnvelope.result = this.adaptExampleType(response.bodyValue, new go.Any());
                 break;
               case 'binaryResult':
                 goExample.responseEnvelope.result = this.adaptExampleType(response.bodyValue, new go.Scalar('byte'));
@@ -930,7 +930,7 @@ export class clientAdapter {
       case 'null':
         return new go.NullExample(goType);
       case 'unknown':
-        if (go.isPrimitiveType(goType) && goType.typeName === 'any') {
+        if (go.isAnyType(goType)) {
           return new go.AnyExample(exampleType.value);
         }
         break;

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -312,7 +312,7 @@ export class typeAdapter {
         if (anyType) {
           return anyType;
         }
-        anyType = new go.Scalar('any');
+        anyType = new go.Any();
         this.types.set('any', anyType);
         return anyType;
       }


### PR DESCRIPTION
Obviates the need to special-case any from the other scalar types that require parsing/formatting.