### PR TITLE
Refactor code model types

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -123,34 +123,34 @@ function populateMethod(op: m4.Operation, method: go.MethodType | go.NextPageMet
 function adaptHeaderScalarType(schema: m4.Schema, forParam: boolean): go.HeaderScalarType {
   // for header params, we never pass the element type by pointer
   const type = adaptPossibleType(schema, forParam);
-  if (go.isAnyType(type) || go.isInterfaceType(type) || go.isMapType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isRawJSON(type) || go.isSliceType(type) || go.isQualifiedType(type)) {
-    throw new Error(`unexpected header parameter type ${schema.type}`);
+  if (go.isHeaderScalarType(type)) {
+    return type;
   }
-  return type;
+  throw new Error(`unexpected header scalar parameter type ${schema.type}`);
 }
 
 function adaptPathScalarParameterType(schema: m4.Schema): go.PathScalarParameterType {
   const type = adaptPossibleType(schema);
-  if (go.isAnyType(type) || go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isRawJSON(type) || go.isSliceType(type)  || go.isQualifiedType(type)) {
-    throw new Error(`unexpected path parameter type ${schema.type}`);
+  if (go.isPathScalarParameterType(type)) {
+    return type;
   }
-  return type;
+  throw new Error(`unexpected path scalar parameter type ${schema.type}`);
 }
 
 function adaptQueryScalarParameterType(schema: m4.Schema): go.QueryScalarParameterType {
   const type = adaptPossibleType(schema);
-  if (go.isAnyType(type) || go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isRawJSON(type) || go.isSliceType(type)  || go.isQualifiedType(type)) {
-    throw new Error(`unexpected query parameter type ${schema.type}`);
+  if (go.isQueryScalarParameterType(type)) {
+    return type;
   }
-  return type;
+  throw new Error(`unexpected query scalar parameter type ${schema.type}`);
 }
 
 function adaptURIPrameterType(schema: m4.Schema): go.URIParameterType {
   const type = adaptPossibleType(schema);
-  if (!go.isConstantType(type) && !go.isPrimitiveType(type) && !go.isStringType(type)) {
-    throw new Error(`unexpected URI parameter type ${schema.type}`);
+  if (go.isURIParameterType(type)) {
+    return type;
   }
-  return type;
+  throw new Error(`unexpected URI parameter type ${schema.type}`);
 }
 
 function adaptClient(type: go.CodeModelType, group: m4.OperationGroup): go.Client {
@@ -207,7 +207,7 @@ function adaptResponseEnvelope(m4CodeModel: m4.CodeModel, codeModel: go.CodeMode
       let headerResp: go.HeaderScalarResponse | go.HeaderMapResponse;
       if (prop.schema.language.go!.headerCollectionPrefix) {
         const headerType = adaptPossibleType(prop.schema, false);
-        if (!go.isMapType(headerType)) {
+        if (headerType.kind !== 'map') {
           throw new Error(`unexpected type ${go.getTypeDeclaration(headerType)} for HeaderMapResponse ${prop.language.go!.name}`);
         }
         headerResp = new go.HeaderMapResponse(prop.language.go!.name, headerType, prop.schema.language.go!.headerCollectionPrefix);
@@ -235,11 +235,12 @@ function adaptResponseEnvelope(m4CodeModel: m4.CodeModel, codeModel: go.CodeMode
     respEnv.result = new go.HeadAsBooleanResult(resultProp.language.go!.name);
   } else if (!resultProp.language.go!.embeddedType) {
     const resultType = adaptPossibleType(resultProp.schema);
-    if (go.isAnyType(resultType) || go.isInterfaceType(resultType) || go.isLiteralValue(resultType) || go.isModelType(resultType) || go.isPolymorphicType(resultType) || go.isQualifiedType(resultType)) {
-      throw new Error(`invalid monomorphic result type ${go.getTypeDeclaration(resultType)}`);
+    if (go.isMonomorphicResultType(resultType)) {
+      respEnv.result = new go.MonomorphicResult(resultProp.language.go!.name, adaptResultFormat(helpers.getSchemaResponse(op)!.protocol), resultType, resultProp.language.go!.byValue);
+      respEnv.result.xml = adaptXMLInfo(resultProp.schema);
+    } else {
+      throw new Error(`invalid monomorphic result type ${resultType.kind}`);
     }
-    respEnv.result = new go.MonomorphicResult(resultProp.language.go!.name, adaptResultFormat(helpers.getSchemaResponse(op)!.protocol), resultType, resultProp.language.go!.byValue);
-    respEnv.result.xml = adaptXMLInfo(resultProp.schema);
   } else if (resultProp.isDiscriminator) {
     let ifaceResult: go.Interface | undefined;
     for (const iface of values(codeModel.interfaces)) {
@@ -255,7 +256,7 @@ function adaptResponseEnvelope(m4CodeModel: m4.CodeModel, codeModel: go.CodeMode
   } else if (helpers.getSchemaResponse(op)) {
     let modelType: go.Model | undefined;
     for (const model of codeModel.models) {
-      if (model.name === resultProp.schema.language.go!.name) {
+      if (model.kind === 'model' && model.name === resultProp.schema.language.go!.name) {
         modelType = model;
         break;
       }
@@ -336,7 +337,7 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.MethodP
       if (op.requests![0].protocol.http!.knownMediaType === KnownMediaType.Form) {
         const collectionFormat = adaptCollectionFormat(param);
         if (collectionFormat) {
-          if (!go.isSliceType(bodyType)) {
+          if (bodyType.kind !== 'slice') {
             throw new Error(`unexpected type ${go.getTypeDeclaration(bodyType)} for FormBodyCollectionParameter ${param.language.go!.name}`);
           }
           adaptedParam = new go.FormBodyCollectionParameter(param.language.go!.name, param.language.go!.serializedName, bodyType, collectionFormat, style, param.language.go!.byValue);
@@ -357,14 +358,14 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.MethodP
       const collectionFormat = adaptCollectionFormat(param);
       if (param.schema.language.go!.headerCollectionPrefix) {
         const headerType = adaptPossibleType(param.schema, true);
-        if (!go.isMapType(headerType)) {
+        if (headerType.kind !== 'map') {
           throw new Error(`unexpected type ${go.getTypeDeclaration(headerType)} for HeaderMapParameter ${param.language.go!.name}`);
         }
         adaptedParam = new go.HeaderMapParameter(param.language.go!.name, param.schema.language.go!.headerCollectionPrefix, headerType, style,
           param.language.go!.byValue, location);
       } else if (collectionFormat) {
         const headerType = adaptPossibleType(param.schema, true);
-        if (!go.isSliceType(headerType)) {
+        if (headerType.kind !== 'slice') {
           throw new Error(`unexpected type ${go.getTypeDeclaration(headerType)} for HeaderCollectionParameter ${param.language.go!.name}`);
         }
         adaptedParam = new go.HeaderCollectionParameter(param.language.go!.name, param.language.go!.serializedName, headerType, collectionFormat, style,
@@ -379,7 +380,7 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.MethodP
       const collectionFormat = adaptCollectionFormat(param);
       if (collectionFormat) {
         const pathType = adaptPossibleType(param.schema);
-        if (!go.isSliceType(pathType)) {
+        if (pathType.kind !== 'slice') {
           throw new Error(`unexpected type ${go.getTypeDeclaration(pathType)} for PathCollectionParameter ${param.language.go!.name}`);
         }
         adaptedParam = new go.PathCollectionParameter(param.language.go!.name, param.language.go!.serializedName, !skipURLEncoding(param),
@@ -394,7 +395,7 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.MethodP
       const collectionFormat = adaptExtendedCollectionFormat(param);
       if (collectionFormat) {
         const queryType = adaptPossibleType(param.schema);
-        if (!go.isSliceType(queryType)) {
+        if (queryType.kind !== 'slice') {
           throw new Error(`unexpected type ${go.getTypeDeclaration(queryType)} for QueryCollectionParameter ${param.language.go!.name}`);
         }
         adaptedParam = new go.QueryCollectionParameter(param.language.go!.name, param.language.go!.serializedName, !skipURLEncoding(param),

--- a/packages/autorest.go/src/m4togocodemodel/types.ts
+++ b/packages/autorest.go/src/m4togocodemodel/types.ts
@@ -111,7 +111,7 @@ export function adaptModel(obj: m4.ObjectSchema): go.Model | go.PolymorphicModel
     modelType = new go.PolymorphicModel(obj.language.go!.name, <go.Interface>iface, annotations, adaptUsage(obj));
     // only non-root and sub-root discriminators will have a discriminatorValue
     if (obj.discriminatorValue) {
-      (<go.PolymorphicModel>modelType).discriminatorValue = getDiscriminatorLiteral(obj.discriminatorValue);
+      modelType.discriminatorValue = getDiscriminatorLiteral(obj.discriminatorValue);
     }
   } else {
     modelType = new go.Model(obj.language.go!.name, annotations, adaptUsage(obj));
@@ -174,7 +174,7 @@ function getDiscriminatorLiteral(discriminatorValue: string): go.Literal {
 export function adaptModelField(prop: m4.Property, obj: m4.ObjectSchema): go.ModelField {
   const fieldType = adaptPossibleType(prop.schema);
   let required = prop.required === true;
-  if (go.isLiteralValue(fieldType)) {
+  if (fieldType.kind === 'literal') {
     // for OpenAPI, literal values are always considered required
     required = true;
   }
@@ -189,7 +189,7 @@ export function adaptModelField(prop: m4.Property, obj: m4.ObjectSchema): go.Mod
     if (!go.isLiteralValueType(field.type)) {
       throw new Error(`unsupported default value type ${go.getTypeDeclaration(field.type)} for field ${field.name}`);
     }
-    if (go.isConstantType(field.type)) {
+    if (field.type.kind === 'constant') {
       // find the corresponding ConstantValue
       const constType = types.get(field.type.name);
       if (!constType) {
@@ -348,7 +348,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (primitiveBool) {
         return primitiveBool;
       }
-      primitiveBool = new go.Scalar('bool');
+      primitiveBool = new go.Scalar('bool', false);
       types.set(m4.SchemaType.Boolean, primitiveBool);
       return primitiveBool;
     }
@@ -359,7 +359,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (rune) {
         return rune;
       }
-      rune = new go.Scalar('rune');
+      rune = new go.Scalar('rune', false);
       types.set(m4.SchemaType.Char, rune);
       return rune;
     }
@@ -415,7 +415,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
         if (int32) {
           return int32;
         }
-        int32 = new go.Scalar(int32Key);
+        int32 = new go.Scalar(int32Key, false);
         types.set(int32Key, int32);
         return int32;
       }
@@ -424,7 +424,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (int64) {
         return int64;
       }
-      int64 = new go.Scalar(int64Key);
+      int64 = new go.Scalar(int64Key, false);
       types.set(int64Key, int64);
       return int64;
     }
@@ -435,7 +435,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
         if (float32) {
           return float32;
         }
-        float32 = new go.Scalar(float32Key);
+        float32 = new go.Scalar(float32Key, false);
         types.set(float32Key, float32);
         return float32;
       }
@@ -444,7 +444,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (float64) {
         return float64;
       }
-      float64 = new go.Scalar(float64Key);
+      float64 = new go.Scalar(float64Key, false);
       types.set(float64Key, float64);
       return float64;
     }
@@ -501,7 +501,7 @@ function adaptLiteralValue(constSchema: m4.ConstantSchema): go.Literal {
       if (literalBool) {
         return <go.Literal>literalBool;
       }
-      literalBool = new go.Literal(new go.Scalar('bool'), constSchema.value.value);
+      literalBool = new go.Literal(new go.Scalar('bool', false), constSchema.value.value);
       types.set(keyName, literalBool);
       return literalBool;
     }
@@ -545,9 +545,9 @@ function adaptLiteralValue(constSchema: m4.ConstantSchema): go.Literal {
         return <go.Literal>literalInt;
       }
       if ((<m4.NumberSchema>constSchema.valueType).precision === 32) {
-        literalInt = new go.Literal(new go.Scalar('int32'), constSchema.value.value);
+        literalInt = new go.Literal(new go.Scalar('int32', false), constSchema.value.value);
       } else {
-        literalInt = new go.Literal(new go.Scalar('int64'), constSchema.value.value);
+        literalInt = new go.Literal(new go.Scalar('int64', false), constSchema.value.value);
       }
       types.set(keyName, literalInt);
       return literalInt;
@@ -559,9 +559,9 @@ function adaptLiteralValue(constSchema: m4.ConstantSchema): go.Literal {
         return <go.Literal>literalFloat;
       }
       if ((<m4.NumberSchema>constSchema.valueType).precision === 32) {
-        literalFloat = new go.Literal(new go.Scalar('float32'), constSchema.value.value);
+        literalFloat = new go.Literal(new go.Scalar('float32', false), constSchema.value.value);
       } else {
-        literalFloat = new go.Literal(new go.Scalar('float64'), constSchema.value.value);
+        literalFloat = new go.Literal(new go.Scalar('float64', false), constSchema.value.value);
       }
       types.set(keyName, literalFloat);
       return literalFloat;

--- a/packages/codegen.go/src/helpers.ts
+++ b/packages/codegen.go/src/helpers.ts
@@ -145,7 +145,7 @@ export function getMethodParameters(method: go.MethodType | go.NextPageMethod, p
       if (!paramGroups.includes(param.group)) {
         paramGroups.push(param.group);
       }
-    } else if (go.isLiteralValue(param.type)) {
+    } else if (param.type.kind === 'literal') {
       // don't generate a parameter for a constant
       // NOTE: this check must come last as non-required optional constants
       // in header/query params get dumped into the optional params group
@@ -218,6 +218,9 @@ export function formatParamValue(param: go.MethodParameter, imports: ImportManag
       if (param.collectionFormat === 'multi') {
         throw new CodegenError('InternalError', 'multi collection format should have been previously handled');
       }
+
+      const separator = getDelimiterForCollectionFormat(param.collectionFormat);
+
       const emitConvertOver = function(paramName: string, format: string): string {
         const encodedVar = `encoded${capitalize(paramName)}`;
         let content = 'strings.Join(func() []string {\n';
@@ -228,26 +231,27 @@ export function formatParamValue(param: go.MethodParameter, imports: ImportManag
         content += `\t}(), "${separator}")`;
         return content;
       }
-      const separator = getDelimiterForCollectionFormat(param.collectionFormat);
-      if (go.isStringType(param.type.elementType)) {
-        imports.add('strings');
-        return `strings.Join(${paramName}, "${separator}")`;
-      } else if (go.isBytesType(param.type.elementType)) {
-        imports.add('encoding/base64');
-        imports.add('strings');
-        return emitConvertOver(param.name, `base64.${formatBytesEncoding(param.type.elementType.encoding)}Encoding.EncodeToString(${param.name}[i])`);
-      } else if (go.isTimeType(param.type.elementType)) {
-        imports.add('strings');
-        return emitConvertOver(param.name, `${param.type.elementType.format}(${param.name}[i]).String()`);
-      } else {
-        imports.add('fmt');
-        imports.add('strings');
-        return `strings.Join(strings.Fields(strings.Trim(fmt.Sprint(${paramName}), "[]")), "${separator}")`;
+
+      switch (param.type.elementType.kind) {
+        case 'encodedBytes':
+          imports.add('encoding/base64');
+          imports.add('strings');
+          return emitConvertOver(param.name, `base64.${formatBytesEncoding(param.type.elementType.encoding)}Encoding.EncodeToString(${param.name}[i])`);
+        case 'string':
+          imports.add('strings');
+          return `strings.Join(${paramName}, "${separator}")`;
+        case 'time':
+          imports.add('strings');
+          return emitConvertOver(param.name, `${param.type.elementType.format}(${param.name}[i]).String()`);
+        default:
+          imports.add('fmt');
+          imports.add('strings');
+          return `strings.Join(strings.Fields(strings.Trim(fmt.Sprint(${paramName}), "[]")), "${separator}")`;
       }
     }
   }
 
-  if (go.isTimeType(param.type) && param.type.format !== 'timeUnix') {
+  if (param.type.kind === 'time' && param.type.format !== 'timeUnix') {
     // for most time types we call methods on time.Time which is why we remove the dereference.
     // however, for unix time, we cast to our unixTime helper first so we must keep the dereference.
     if (!go.isRequiredParameter(param) && paramName[0] === '*') {
@@ -281,88 +285,93 @@ export function formatValue(paramName: string, type: go.PossibleType, imports: I
   if (defef === true) {
     star = '*';
   }
-  if (go.isLiteralValue(type)) {
-    // cannot use formatLiteralValue() since all values are treated as strings
-    return `"${type.literal}"`;
-  } else if (go.isBytesType(type)) {
-    // ByteArray is a base-64 encoded value in string format
-    imports.add('encoding/base64');
-    return `base64.${formatBytesEncoding(type.encoding)}Encoding.EncodeToString(${paramName})`;
-  } else if (go.isPrimitiveType(type)) {
-    if (type.typeName === 'bool') {
-      imports.add('strconv');
-      return `strconv.FormatBool(${star}${paramName})`;
-    } else if (type.typeName === 'int32') {
-      imports.add('strconv');
-      return `strconv.FormatInt(int64(${star}${paramName}), 10)`;
-    } else if (type.typeName === 'int64') {
-      imports.add('strconv');
-      return `strconv.FormatInt(${star}${paramName}, 10)`;
-    } else if (type.typeName === 'float32') {
-      imports.add('strconv');
-      return `strconv.FormatFloat(float64(${star}${paramName}), 'f', -1, 32)`;
-    } else if (type.typeName === 'float64') {
-      imports.add('strconv');
-      return `strconv.FormatFloat(${star}${paramName}, 'f', -1, 64)`;
-    }
-  } else if (go.isTimeType(type)) {
-    if (type.format === 'dateType') {
-      return `${paramName}.Format("${dateFormat}")`;
-    } else if (type.format === 'timeUnix') {
-      return `timeUnix(${star}${paramName}).String()`;
-    } else if (type.format === 'timeRFC3339') {
-      return `timeRFC3339(${star}${paramName}).String()`;
-    } else {
-      imports.add('time');
-      let format = datetimeRFC3339Format;
-      if (type.format === 'dateTimeRFC1123') {
-        format = datetimeRFC1123Format;
+
+  switch (type.kind) {
+    case 'constant':
+      if (type.type === 'string') {
+        return `string(${star}${paramName})`;
       }
-      return `${paramName}.Format(${format})`;
-    }
-  } else if (go.isConstantType(type)) {
-    if (type.type === 'string') {
-      return `string(${star}${paramName})`;
-    }
-    imports.add('fmt');
-    return `fmt.Sprintf("%v", ${star}${paramName})`;
+      imports.add('fmt');
+      return `fmt.Sprintf("%v", ${star}${paramName})`;
+    case 'encodedBytes':
+      // a base-64 encoded value in string format
+      imports.add('encoding/base64');
+      return `base64.${formatBytesEncoding(type.encoding)}Encoding.EncodeToString(${paramName})`;
+    case 'literal':
+      // cannot use formatLiteralValue() since all values are treated as strings
+      return `"${type.literal}"`;
+    case 'scalar':
+      switch (type.type) {
+        case 'bool':
+          imports.add('strconv');
+          return `strconv.FormatBool(${star}${paramName})`;
+        case 'float32':
+          imports.add('strconv');
+          return `strconv.FormatFloat(float64(${star}${paramName}), 'f', -1, 32)`;
+        case 'float64':
+          imports.add('strconv');
+          return `strconv.FormatFloat(${star}${paramName}, 'f', -1, 64)`;
+        case 'int32':
+          imports.add('strconv');
+          return `strconv.FormatInt(int64(${star}${paramName}), 10)`;
+        case 'int64':
+          imports.add('strconv');
+          return `strconv.FormatInt(${star}${paramName}, 10)`;
+        default:
+          throw new CodegenError('InternalError', `unhandled scalar type ${type.type}`);
+      }
+    case 'time':
+      switch (type.format) {
+        case 'dateTimeRFC1123':
+        case 'dateTimeRFC3339':
+          imports.add('time');
+          return `${paramName}.Format(${type.format === 'dateTimeRFC1123' ? datetimeRFC1123Format : datetimeRFC3339Format})`;
+        case 'dateType':
+          return `${paramName}.Format("${dateFormat}")`;
+        case 'timeRFC3339':
+          return `timeRFC3339(${star}${paramName}).String()`;
+        case 'timeUnix':
+          return `timeUnix(${star}${paramName}).String()`;
+      }
+    default:
+      return `${star}${paramName}`;
   }
-  return `${star}${paramName}`;
 }
 
 // returns the clientDefaultValue of the specified param.
 // this is usually the value in quotes (i.e. a string) however
 // it could also be a constant.
 export function formatLiteralValue(value: go.Literal, withCast: boolean): string {
-  if (go.isConstantType(value.type)) {
-    return (<go.ConstantValue>value.literal).name;
-  } else if (go.isPrimitiveType(value.type)) {
-    // if it's a string, we want the uncasted version to include quotes
-    if (!withCast) {
-      return `${value.literal}`;
-    }
-    switch (value.type.typeName) {
-      case 'float32':
-        return `float32(${value.literal})`;
-      case 'float64':
-        return `float64(${value.literal})`;
-      case 'int32':
-        return `int32(${value.literal})`;
-      case 'int64':
-        return `int64(${value.literal})`;
-      default:
-        return value.literal;
-    }
-  } else if (go.isStringType(value.type)) {
-    if (value.literal[0] === '"') {
-      // string is already quoted
+  switch (value.type.kind) {
+    case 'constant':
+      return (<go.ConstantValue>value.literal).name;
+    case 'encodedBytes':
       return value.literal;
-    }
-    return `"${value.literal}"`;
-  } else if (go.isTimeType(value.type)) {
-    return `"${value.literal}"`;
+    case 'scalar':
+      if (!withCast) {
+        return `${value.literal}`;
+      }
+      switch (value.type.type) {
+        case 'float32':
+          return `float32(${value.literal})`;
+        case 'float64':
+          return `float64(${value.literal})`;
+        case 'int32':
+          return `int32(${value.literal})`;
+        case 'int64':
+          return `int64(${value.literal})`;
+        default:
+          return value.literal;
+      }
+    case 'string':
+      if (value.literal[0] === '"') {
+        // string is already quoted
+        return value.literal;
+      }
+      return `"${value.literal}"`;
+    case 'time':
+      return `"${value.literal}"`;
   }
-  return value.literal;
 }
 
 // returns true if at least one of the responses has a schema
@@ -646,12 +655,14 @@ export function getBitSizeForNumber(intSize: 'float32' | 'float64' | 'int8' | 'i
 // returns the underlying map/slice element/value type
 // if item isn't a map or slice, item is returned
 export function recursiveUnwrapMapSlice(item: go.PossibleType): go.PossibleType {
-  if (go.isMapType(item)) {
-    return recursiveUnwrapMapSlice(item.valueType);
-  } else if (go.isSliceType(item)) {
-    return recursiveUnwrapMapSlice(item.elementType);
+  switch (item.kind) {
+    case 'map':
+      return recursiveUnwrapMapSlice(item.valueType);
+    case 'slice':
+      return recursiveUnwrapMapSlice(item.elementType);
+    default:
+      return item;
   }
-  return item;
 }
 
 // returns a * for optional params
@@ -680,22 +691,26 @@ export function getSerDeFormat(model: go.Model | go.PolymorphicModel, codeModel:
   // recursively walks the fields in model, updating serDeFormatCache with the model name and specified format
   const recursiveWalkModelFields = function(type: go.PossibleType, serDeFormat: SerDeFormat): void {
     type = recursiveUnwrapMapSlice(type);
-    if (go.isInterfaceType(type)) {
-      recursiveWalkModelFields(type.rootType, serDeFormat);
-      for (const possibleType of type.possibleTypes) {
-        recursiveWalkModelFields(possibleType, serDeFormat);
-      }
-    } else if (go.isPolymorphicType(type) || go.isModelType(type)) {
-      if (serDeFormatCache.has(type.name)) {
-        // we've already processed this type, don't do it again
-        return;
-      }
+    switch (type.kind) {
+      case 'interface':
+        recursiveWalkModelFields(type.rootType, serDeFormat);
+        for (const possibleType of type.possibleTypes) {
+          recursiveWalkModelFields(possibleType, serDeFormat);
+        }
+        break;
+      case 'model':
+      case 'polymorphicModel':
+        if (serDeFormatCache.has(type.name)) {
+          // we've already processed this type, don't do it again
+          return;
+        }
 
-      serDeFormatCache.set(type.name, serDeFormat);
-      for (const field of type.fields) {
-        const fieldType = recursiveUnwrapMapSlice(field.type);
-        recursiveWalkModelFields(fieldType, serDeFormat);
-      }
+        serDeFormatCache.set(type.name, serDeFormat);
+        for (const field of type.fields) {
+          const fieldType = recursiveUnwrapMapSlice(field.type);
+          recursiveWalkModelFields(fieldType, serDeFormat);
+        }
+        break;
     }
   };
 

--- a/packages/codegen.go/src/imports.ts
+++ b/packages/codegen.go/src/imports.ts
@@ -51,14 +51,19 @@ export class ImportManager {
   }
 
   addImportForType(type: go.PossibleType) {
-    if (go.isMapType(type)) {
-      this.addImportForType(type.valueType);
-    } else if (go.isSliceType(type)) {
-      this.addImportForType(type.elementType);
-    } else if (go.isQualifiedType(type)) {
-      this.add(type.packageName);
-    } else if (go.isTimeType(type)) {
-      this.add('time');
+    switch (type.kind) {
+      case 'map':
+        this.addImportForType(type.valueType);
+        break;
+      case 'slice':
+        this.addImportForType(type.elementType);
+        break;
+      case 'qualifiedType':
+        this.add(type.packageName);
+        break;
+      case 'time':
+        this.add('time');
+        break;
     }
   }
 

--- a/packages/codegen.go/src/models.ts
+++ b/packages/codegen.go/src/models.ts
@@ -152,15 +152,15 @@ function generateModelDefs(modelImports: ImportManager, serdeImports: ImportMana
       const descriptionMods = new Array<string>();
       if (field.annotations.readOnly) {
         descriptionMods.push('READ-ONLY');
-      } else if (field.annotations.required && (!go.isLiteralValue(field.type) || model.usage === go.UsageFlags.Output)) {
+      } else if (field.annotations.required && (field.type.kind !== 'literal' || model.usage === go.UsageFlags.Output)) {
         descriptionMods.push('REQUIRED');
-      } else if (go.isLiteralValue(field.type)) {
+      } else if (field.type.kind === 'literal') {
         if (!field.annotations.required) {
           descriptionMods.push('FLAG');
         }
         descriptionMods.push('CONSTANT');
       }
-      if (go.isLiteralValue(field.type) && model.usage !== go.UsageFlags.Output) {
+      if (field.type.kind === 'literal' && model.usage !== go.UsageFlags.Output) {
         // add a comment with the const value for const properties that are sent over the wire
         if (field.docs.description) {
           field.docs.description += '\n';
@@ -169,7 +169,7 @@ function generateModelDefs(modelImports: ImportManager, serdeImports: ImportMana
       }
       if (field.docs.description) {
         descriptionMods.push(field.docs.description);
-      } else if (go.isRawJSON(field.type)) {
+      } else if (field.type.kind === 'rawJSON') {
         // add a basic description if one isn't available
         descriptionMods.push('The contents of this field are raw JSON.');
       }
@@ -182,15 +182,15 @@ function generateModelDefs(modelImports: ImportManager, serdeImports: ImportMana
       modelImports.addImportForType(field.type);
     }
 
-    if (go.isModelType(model) && serDeFormat === 'XML' && !model.annotations.omitSerDeMethods) {
+    if (model.kind === 'model' && serDeFormat === 'XML' && !model.annotations.omitSerDeMethods) {
       serdeImports.add('encoding/xml');
       let needsDateTimeMarshalling = false;
       let byteArrayFormat = false;
       for (const field of values(model.fields)) {
         serdeImports.addImportForType(field.type);
-        if (go.isTimeType(field.type)) {
+        if (field.type.kind === 'time') {
           needsDateTimeMarshalling = true;
-        } else if (go.isBytesType(field.type)) {
+        } else if (field.type.kind === 'encodedBytes') {
           byteArrayFormat = true;
         }
       }
@@ -207,7 +207,7 @@ function generateModelDefs(modelImports: ImportManager, serdeImports: ImportMana
       modelDefs.push(modelDef);
       continue;
     }
-    if (go.isPolymorphicType(model)) {
+    if (model.kind === 'polymorphicModel') {
       generateDiscriminatorMarkerMethod(model.interface, modelDef);
       for (let parent = model.interface.parent; parent !== undefined; parent = parent.parent) {
         generateDiscriminatorMarkerMethod(parent, modelDef);
@@ -228,7 +228,7 @@ function generateModelDefs(modelImports: ImportManager, serdeImports: ImportMana
 function needsXMLDictionaryHelper(modelType: go.Model): boolean {
   for (const field of values(modelType.fields)) {
     // additional properties uses an internal wrapper type with its own serde impl
-    if (go.isMapType(field.type) && !field.annotations.isAdditionalProperties) {
+    if (field.type.kind === 'map' && !field.annotations.isAdditionalProperties) {
       return true;
     }
   }
@@ -237,7 +237,7 @@ function needsXMLDictionaryHelper(modelType: go.Model): boolean {
 
 function needsXMLArrayMarshalling(modelType: go.Model): boolean {
   for (const prop of values(modelType.fields)) {
-    if (go.isSliceType(prop.type)) {
+    if (prop.type.kind === 'slice') {
       return true;
     }
   }
@@ -276,7 +276,7 @@ function generateToMultipartForm(modelDef: ModelDef) {
     if (!field.byValue) {
       star = '*';
     }
-    if (go.isModelType(fieldType) && !fieldType.annotations.multipartFormData) {
+    if (fieldType.kind === 'model' && !fieldType.annotations.multipartFormData) {
       setField = `\tif err := populateMultipartJSON(objectMap, "${field.serializedName}", ${star}${receiver}.${field.name}); err != nil {\n\t\treturn nil, err\n\t}\n`;
     } else {
       setField = `\tobjectMap["${field.serializedName}"] = ${star}${receiver}.${field.name}\n`;
@@ -291,7 +291,7 @@ function generateToMultipartForm(modelDef: ModelDef) {
 }
 
 function generateJSONMarshaller(modelType: go.Model | go.PolymorphicModel, modelDef: ModelDef, imports: ImportManager) {
-  if (go.isModelType(modelType) && modelType.fields.length === 0) {
+  if (modelType.kind === 'model' && modelType.fields.length === 0) {
     // non-discriminated types without content don't need a custom marshaller.
     // there is a case in network where child is allOf base and child has no properties.
     return;
@@ -311,7 +311,7 @@ function generateJSONMarshallerBody(modelType: go.Model | go.PolymorphicModel, m
   let marshaller = '';
   let addlProps: go.Map | undefined;
   for (const field of values(modelType.fields)) {
-    if (go.isMapType(field.type) && field.annotations.isAdditionalProperties) {
+    if (field.type.kind === 'map' && field.annotations.isAdditionalProperties) {
       addlProps = field.type;
       continue;
     }
@@ -323,12 +323,12 @@ function generateJSONMarshallerBody(modelType: go.Model | go.PolymorphicModel, m
         // this will enable support for custom types that aren't (yet) described in the swagger.
         marshaller += `\tobjectMap["${field.serializedName}"] = ${receiver}.${field.name}\n`;
       }
-    } else if (go.isBytesType(field.type)) {
+    } else if (field.type.kind === 'encodedBytes') {
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime');
       marshaller += `\tpopulateByteArray(objectMap, "${field.serializedName}", ${receiver}.${field.name}, func() any {\n`;
       marshaller += `\t\treturn runtime.EncodeByteArray(${receiver}.${field.name}, runtime.Base64${field.type.encoding}Format)\n\t})\n`;
       modelDef.SerDe.needsJSONPopulateByteArray = true;
-    } else if (go.isSliceType(field.type) && go.isBytesType(field.type.elementType)) {
+    } else if (field.type.kind === 'slice' && field.type.elementType.kind === 'encodedBytes') {
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime');
       marshaller += `\tpopulateByteArray(objectMap, "${field.serializedName}", ${receiver}.${field.name}, func() any {\n`;
       marshaller += `\t\tencodedValue := make([]string, len(${receiver}.${field.name}))\n`;
@@ -336,7 +336,7 @@ function generateJSONMarshallerBody(modelType: go.Model | go.PolymorphicModel, m
       marshaller += `\t\t\tencodedValue[i] = runtime.EncodeByteArray(${receiver}.${field.name}[i], runtime.Base64${field.type.elementType.encoding}Format)\n\t\t}\n`;
       marshaller += '\t\treturn encodedValue\n\t})\n';
       modelDef.SerDe.needsJSONPopulateByteArray = true;
-    } else if (go.isSliceType(field.type) && go.isTimeType(field.type.elementType)) {
+    } else if (field.type.kind === 'slice' && field.type.elementType.kind === 'time') {
       const source = `${receiver}.${field.name}`;
       let elementPtr = '*';
       if (field.type.elementTypeByValue) {
@@ -348,14 +348,14 @@ function generateJSONMarshallerBody(modelType: go.Model | go.PolymorphicModel, m
       marshaller += '\t}\n';
       marshaller += `\tpopulate(objectMap, "${field.serializedName}", aux)\n`;
       modelDef.SerDe.needsJSONPopulate = true;
-    } else if (go.isLiteralValue(field.type)) {
+    } else if (field.type.kind === 'literal') {
       const setter = `objectMap["${field.serializedName}"] = ${helpers.formatLiteralValue(field.type, true)}`;
       if (!field.annotations.required) {
         marshaller += `\tif ${receiver}.${field.name} != nil {\n\t\t${setter}\n\t}\n`;
       } else {
         marshaller += `\t${setter}\n`;
       }
-    } else if (go.isRawJSON(field.type)) {
+    } else if (field.type.kind === 'rawJSON') {
       marshaller += `\tpopulate(objectMap, "${field.serializedName}", json.RawMessage(${receiver}.${field.name}))\n`;
       modelDef.SerDe.needsJSONPopulate = true;
     } else {
@@ -364,23 +364,23 @@ function generateJSONMarshallerBody(modelType: go.Model | go.PolymorphicModel, m
         marshaller += `\tif ${receiver}.${field.name} == nil {\n\t\t${receiver}.${field.name} = to.Ptr(${helpers.formatLiteralValue(field.defaultValue, true)})\n\t}\n`;
       }
       let populate = 'populate';
-      if (go.isTimeType(field.type)) {
+      if (field.type.kind === 'time') {
         populate += capitalize(field.type.format);
         modelDef.SerDe.needsJSONPopulate = true;
-      } else if (go.isAnyType(field.type)) {
+      } else if (field.type.kind === 'any') {
         populate += 'Any';
         modelDef.SerDe.needsJSONPopulateAny = true;
       } else {
         modelDef.SerDe.needsJSONPopulate = true;
       }
-      if (go.isPrimitiveType(field.type) && (field.type.typeName.startsWith('uint') || field.type.typeName.startsWith('int')) && field.type.encodeAsString) {
+      if (field.type.kind === 'scalar' && (field.type.type.startsWith('uint') || field.type.type.startsWith('int')) && field.type.encodeAsString) {
         // TODO: need to handle map and slice type with underlying int as string type
         imports.add('strconv');
         imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/to');
-        if (field.type.typeName.startsWith('uint') && field.type.typeName !== 'uint64' || field.type.typeName.startsWith('int') && field.type.typeName !== 'int64') {
-          marshaller += `\t${populate}(objectMap, "${field.serializedName}", to.Ptr(strconv.${field.type.typeName.startsWith('int') ? 'FormatInt' : 'FormatUint'}(${field.type.typeName.startsWith('int') ? 'int64' : 'uint64'}(*${receiver}.${field.name}), 10)))\n`;
+        if (field.type.type.startsWith('uint') && field.type.type !== 'uint64' || field.type.type.startsWith('int') && field.type.type !== 'int64') {
+          marshaller += `\t${populate}(objectMap, "${field.serializedName}", to.Ptr(strconv.${field.type.type.startsWith('int') ? 'FormatInt' : 'FormatUint'}(${field.type.type.startsWith('int') ? 'int64' : 'uint64'}(*${receiver}.${field.name}), 10)))\n`;
         } else {
-          marshaller += `\t${populate}(objectMap, "${field.serializedName}", to.Ptr(strconv.${field.type.typeName.startsWith('int') ? 'FormatInt' : 'FormatUint'}(*${receiver}.${field.name}, 10)))\n`;
+          marshaller += `\t${populate}(objectMap, "${field.serializedName}", to.Ptr(strconv.${field.type.type.startsWith('int') ? 'FormatInt' : 'FormatUint'}(*${receiver}.${field.name}, 10)))\n`;
         }
       } else {
         marshaller += `\t${populate}(objectMap, "${field.serializedName}", ${receiver}.${field.name})\n`;
@@ -391,7 +391,7 @@ function generateJSONMarshallerBody(modelType: go.Model | go.PolymorphicModel, m
     marshaller += `\tif ${receiver}.AdditionalProperties != nil {\n`;
     marshaller += `\t\tfor key, val := range ${receiver}.AdditionalProperties {\n`;
     let assignment = 'val';
-    if (go.isTimeType(addlProps.valueType)) {
+    if (addlProps.valueType.kind === 'time') {
       assignment = `(*${addlProps.valueType.format})(val)`;
     }
     marshaller += `\t\t\tobjectMap[key] = ${assignment}\n`;
@@ -433,7 +433,7 @@ function generateJSONUnmarshallerBody(modelType: go.Model | go.PolymorphicModel,
     addlPropsText += `${tab}\t\tif val != nil {\n`;
     let auxType = go.getTypeDeclaration(addlProps.valueType);
     let assignment = `${ref}aux`;
-    if (go.isTimeType(addlProps.valueType)) {
+    if (addlProps.valueType.kind === 'time') {
       imports.add('time');
       auxType = addlProps.valueType.format;
       assignment = `(*time.Time)(${assignment})`;
@@ -451,17 +451,17 @@ function generateJSONUnmarshallerBody(modelType: go.Model | go.PolymorphicModel,
   unmarshalBody += '\t\tswitch key {\n';
   let addlProps: go.Map | undefined;
   for (const field of values(modelType.fields)) {
-    if (go.isMapType(field.type) && field.annotations.isAdditionalProperties) {
+    if (field.type.kind === 'map' && field.annotations.isAdditionalProperties) {
       addlProps = field.type;
       continue;
     }
     unmarshalBody += `\t\tcase "${field.serializedName}":\n`;
     if (hasDiscriminatorInterface(field.type)) {
       unmarshalBody += generateDiscriminatorUnmarshaller(field, receiver);
-    } else if (go.isTimeType(field.type)) {
+    } else if (field.type.kind === 'time') {
       unmarshalBody += `\t\t\t\terr = unpopulate${capitalize(field.type.format)}(val, "${field.name}", &${receiver}.${field.name})\n`;
       modelDef.SerDe.needsJSONUnpopulate = true;
-    } else if (go.isSliceType(field.type) && go.isTimeType(field.type.elementType)) {
+    } else if (field.type.kind === 'slice' && field.type.elementType.kind === 'time') {
       imports.add('time');
       let elementPtr = '*';
       if (field.type.elementTypeByValue) {
@@ -473,11 +473,11 @@ function generateJSONUnmarshallerBody(modelType: go.Model | go.PolymorphicModel,
       unmarshalBody += `\t\t\t\t${receiver}.${field.name} = append(${receiver}.${field.name}, (${elementPtr}time.Time)(au))\n`;
       unmarshalBody += '\t\t\t}\n';
       modelDef.SerDe.needsJSONUnpopulate = true;
-    } else if (go.isBytesType(field.type)) {
+    } else if (field.type.kind === 'encodedBytes') {
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime');
       unmarshalBody += '\t\tif val != nil && string(val) != "null" {\n';
       unmarshalBody += `\t\t\t\terr = runtime.DecodeByteArray(string(val), &${receiver}.${field.name}, runtime.Base64${field.type.encoding}Format)\n\t\t}\n`;
-    } else if (go.isSliceType(field.type) && go.isBytesType(field.type.elementType)) {
+    } else if (field.type.kind === 'slice' && field.type.elementType.kind === 'encodedBytes') {
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime');
       unmarshalBody += '\t\t\tvar encodedValue []string\n';
       unmarshalBody += `\t\t\terr = unpopulate(val, "${field.name}", &encodedValue)\n`;
@@ -487,20 +487,20 @@ function generateJSONUnmarshallerBody(modelType: go.Model | go.PolymorphicModel,
       unmarshalBody += `\t\t\t\t\terr = runtime.DecodeByteArray(encodedValue[i], &${receiver}.${field.name}[i], runtime.Base64${field.type.elementType.encoding}Format)\n`;
       unmarshalBody += '\t\t\t\t}\n\t\t\t}\n';
       modelDef.SerDe.needsJSONUnpopulate = true;
-    } else if (go.isRawJSON(field.type)) {
+    } else if (field.type.kind === 'rawJSON') {
       unmarshalBody += '\t\t\tif string(val) != "null" {\n';
       unmarshalBody += `\t\t\t\t${receiver}.${field.name} = val\n\t\t\t}\n`;
-    } else if (go.isPrimitiveType(field.type) && (field.type.typeName.startsWith('uint') || field.type.typeName.startsWith('int')) && field.type.encodeAsString) {
+    } else if (field.type.kind === 'scalar' && (field.type.type.startsWith('uint') || field.type.type.startsWith('int')) && field.type.encodeAsString) {
       // TODO: need to handle map and slice type with underlying int as string type
       imports.add('strconv');
       unmarshalBody += `\t\t\t\tvar aux string\n`;
       unmarshalBody += `\t\t\t\terr = unpopulate(val, "${field.name}", &aux)\n`;
       unmarshalBody += `\t\t\t\tif err == nil {\n`;
-      unmarshalBody += `\t\t\t\t\tvar v ${field.type.typeName.startsWith('int') ? 'int64' : 'uint64'}\n`;
-      unmarshalBody += `\t\t\t\t\tv, err = strconv.${field.type.typeName.startsWith('int') ? 'ParseInt' : 'ParseUint'}(aux, 10, 0)\n`;
+      unmarshalBody += `\t\t\t\t\tvar v ${field.type.type.startsWith('int') ? 'int64' : 'uint64'}\n`;
+      unmarshalBody += `\t\t\t\t\tv, err = strconv.${field.type.type.startsWith('int') ? 'ParseInt' : 'ParseUint'}(aux, 10, 0)\n`;
       unmarshalBody += `\t\t\t\t\tif err == nil {\n`;
-      if (field.type.typeName.startsWith('uint') && field.type.typeName !== 'uint64' || field.type.typeName.startsWith('int') && field.type.typeName !== 'int64') {
-        unmarshalBody += `\t\t\t\t\t\t${receiver}.${field.name} = to.Ptr(${field.type.typeName}(v))\n`;
+      if (field.type.type.startsWith('uint') && field.type.type !== 'uint64' || field.type.type.startsWith('int') && field.type.type !== 'int64') {
+        unmarshalBody += `\t\t\t\t\t\t${receiver}.${field.name} = to.Ptr(${field.type.type}(v))\n`;
       } else {
         unmarshalBody += `\t\t\t\t\t\t${receiver}.${field.name} = to.Ptr(v)\n`;
       }
@@ -532,14 +532,16 @@ function generateJSONUnmarshallerBody(modelType: go.Model | go.PolymorphicModel,
 // returns true if item has a discriminator interface.
 // recursively called for arrays and dictionaries.
 function hasDiscriminatorInterface(item: go.PossibleType): boolean {
-  if (go.isInterfaceType(item)) {
-    return true;
-  } else if (go.isMapType(item)) {
-    return hasDiscriminatorInterface(item.valueType);
-  } else if (go.isSliceType(item)) {
-    return hasDiscriminatorInterface(item.elementType);
+  switch (item.kind) {
+    case 'interface':
+      return true;
+    case 'map':
+      return hasDiscriminatorInterface(item.valueType);
+    case 'slice':
+      return hasDiscriminatorInterface(item.elementType);
+    default:
+      return false;
   }
-  return false;
 }
 
 // returns the text for unmarshalling a discriminated type
@@ -548,11 +550,11 @@ function generateDiscriminatorUnmarshaller(field: go.ModelField, receiver: strin
   const propertyName = field.name;
 
   // these are the simple, non-nested cases (e.g. IterfaceType, []InterfaceType, map[string]InterfaceType)
-  if (go.isInterfaceType(field.type)) {
+  if (field.type.kind === 'interface') {
     return `${startingIndentation}${receiver}.${propertyName}, err = unmarshal${field.type.name}(val)\n`;
-  } else if (go.isSliceType(field.type) && go.isInterfaceType(field.type.elementType)) {
+  } else if (field.type.kind === 'slice' && field.type.elementType.kind === 'interface') {
     return `${startingIndentation}${receiver}.${propertyName}, err = unmarshal${field.type.elementType.name}Array(val)\n`;
-  } else if (go.isMapType(field.type) && go.isInterfaceType(field.type.valueType)) {
+  } else if (field.type.kind === 'map' && field.type.valueType.kind === 'interface') {
     return `${startingIndentation}${receiver}.${propertyName}, err = unmarshal${field.type.valueType.name}Map(val)\n`;
   }
 
@@ -566,7 +568,7 @@ function generateDiscriminatorUnmarshaller(field: go.ModelField, receiver: strin
   // create a local instantiation of the final type
   const finalTargetVar = field.serializedName;
   let finalTargetCtor = recursiveGetDiscriminatorTypeName(field.type, false);
-  if (go.isSliceType(field.type)) {
+  if (field.type.kind === 'slice') {
     finalTargetCtor = `make(${finalTargetCtor}, len(${rawTargetVar}))`;
   } else {
     // must be a dictionary
@@ -587,12 +589,12 @@ function generateDiscriminatorUnmarshaller(field: go.ModelField, receiver: strin
 // !raw e.g. map[string]map[string]InterfaceType, [][]InterfaceType etc
 function recursiveGetDiscriminatorTypeName(item: go.PossibleType, raw: boolean): string {
   // when raw is true, stop recursing at the level before the leaf schema
-  if (go.isSliceType(item)) {
-    if (!raw || !go.isInterfaceType(item.elementType)) {
+  if (item.kind === 'slice') {
+    if (!raw || item.elementType.kind !== 'interface') {
       return `[]${recursiveGetDiscriminatorTypeName(item.elementType, raw)}`;
     }
-  } else if (go.isMapType(item)) {
-    if (!raw || !go.isInterfaceType(item.valueType)) {
+  } else if (item.kind === 'map') {
+    if (!raw || item.valueType.kind !== 'interface') {
       return `map[string]${recursiveGetDiscriminatorTypeName(item.valueType, raw)}`;
     }
   }
@@ -608,8 +610,8 @@ function recursivePopulateDiscriminator(item: go.PossibleType, receiver: string,
   let interfaceName = '';
   let targetType = '';
 
-  if (go.isSliceType(item)) {
-    if (!go.isInterfaceType(item.elementType)) {
+  if (item.kind === 'slice') {
+    if (item.elementType.kind !== 'interface') {
       if (nesting > 1) {
         // at nestling level 1, the destination var was already created in generateDiscriminatorUnmarshaller()
         text += `${indent}${dest} = make(${recursiveGetDiscriminatorTypeName(item, false)}, len(${rawSrc}))\n`;
@@ -626,8 +628,8 @@ function recursivePopulateDiscriminator(item: go.PossibleType, receiver: string,
     // we're at leaf node - 1, so get the interface from the element's type
     interfaceName = go.getTypeDeclaration(item.elementType);
     targetType = 'Array';
-  } else if (go.isMapType(item)) {
-    if (!go.isInterfaceType(item.valueType)) {
+  } else if (item.kind === 'map') {
+    if (item.valueType.kind !== 'interface') {
       if (nesting > 1) {
         // at nestling level 1, the destination var was already created in generateDiscriminatorUnmarshaller()
         text += `${indent}${dest} = ${recursiveGetDiscriminatorTypeName(item, false)}{}\n`;
@@ -662,13 +664,13 @@ function generateXMLMarshaller(modelType: go.Model, modelDef: ModelDef, imports:
   }
   text += generateAliasType(modelType, receiver, true);
   for (const field of values(modelDef.Fields)) {
-    if (go.isSliceType(field.type)) {
+    if (field.type.kind === 'slice') {
       text += `\tif ${receiver}.${field.name} != nil {\n`;
       text += `\t\taux.${field.name} = &${receiver}.${field.name}\n`;
       text += '\t}\n';
-    } else if (field.annotations.isAdditionalProperties || go.isMapType(field.type)) {
+    } else if (field.annotations.isAdditionalProperties || field.type.kind === 'map') {
       text += `\taux.${field.name} = (additionalProperties)(${receiver}.${field.name})\n`;
-    } else if (go.isBytesType(field.type)) {
+    } else if (field.type.kind === 'encodedBytes') {
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime');
       text += `\tif ${receiver}.${field.name} != nil {\n`;
       text += `\t\tencoded${field.name} := runtime.EncodeByteArray(${receiver}.${field.name}, runtime.Base64${field.type.encoding}Format)\n`;
@@ -691,12 +693,12 @@ function generateXMLUnmarshaller(modelType: go.Model, modelDef: ModelDef, import
   text += '\t\treturn err\n';
   text += '\t}\n';
   for (const field of values(modelDef.Fields)) {
-    if (go.isTimeType(field.type)) {
+    if (field.type.kind === 'time') {
       text += `\tif aux.${field.name} != nil && !(*time.Time)(aux.${field.name}).IsZero() {\n`;
       text += `\t\t${receiver}.${field.name} = (*time.Time)(aux.${field.name})\n\t}\n`;
-    } else if (field.annotations.isAdditionalProperties || go.isMapType(field.type)) {
+    } else if (field.annotations.isAdditionalProperties || field.type.kind === 'map') {
       text += `\t${receiver}.${field.name} = (map[string]*string)(aux.${field.name})\n`;
-    } else if (go.isBytesType(field.type)) {
+    } else if (field.type.kind === 'encodedBytes') {
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime');
       text += `\tif aux.${field.name} != nil {\n`;
       text += `\t\tif err := runtime.DecodeByteArray(*aux.${field.name}, &${receiver}.${field.name}, runtime.Base64${field.type.encoding}Format); err != nil {\n`;
@@ -717,13 +719,13 @@ function generateAliasType(modelType: go.Model, receiver: string, forMarshal: bo
   text += '\t\t*alias\n';
   for (const field of values(modelType.fields)) {
     const sn = getXMLSerialization(field, false);
-    if (go.isTimeType(field.type)) {
+    if (field.type.kind === 'time') {
       text += `\t\t${field.name} *${field.type.format} \`xml:"${sn}"\`\n`;
-    } else if (field.annotations.isAdditionalProperties || go.isMapType(field.type)) {
+    } else if (field.annotations.isAdditionalProperties || field.type.kind === 'map') {
       text += `\t\t${field.name} additionalProperties \`xml:"${sn}"\`\n`;
-    } else if (go.isSliceType(field.type)) {
+    } else if (field.type.kind === 'slice') {
       text += `\t\t${field.name} *${go.getTypeDeclaration(field.type)} \`xml:"${sn}"\`\n`;
-    } else if (go.isBytesType(field.type)) {
+    } else if (field.type.kind === 'encodedBytes') {
       text += `\t\t${field.name} *string \`xml:"${sn}"\`\n`;
     }
   }
@@ -736,7 +738,7 @@ function generateAliasType(modelType: go.Model, receiver: string, forMarshal: bo
   if (forMarshal) {
     // emit code to initialize time fields
     for (const field of modelType.fields) {
-      if (!go.isTimeType(field.type)) {
+      if (field.type.kind !== 'time') {
         continue;
       }
       text += `\t\t${field.name}: (*${field.type.format})(${receiver}.${field.name}),\n`;
@@ -817,9 +819,9 @@ class ModelDef {
         text += helpers.formatDocComment(field.docs);
       }
       let typeName = go.getTypeDeclaration(field.type);
-      if (go.isLiteralValue(field.type)) {
+      if (field.type.kind === 'literal') {
         // for constants we use the underlying type name
-        typeName = go.getLiteralValueTypeName(field.type.type);
+        typeName = go.getLiteralTypeDeclaration(field.type.type);
       }
       let serialization = field.serializedName;
       if (this.Format === 'JSON') {
@@ -860,7 +862,7 @@ export function getXMLSerialization(field: go.ModelField, isResponseEnvelope: bo
   if (field.xml?.attribute) {
     // value comes from an xml attribute
     serialization += ',attr';
-  } else if (go.isSliceType(field.type)) {
+  } else if (field.type.kind === 'slice') {
     // start with the serialized name of the element, preferring xml name if available
     let inner = go.getTypeDeclaration(field.type.elementType);
     if (field.xml?.name) {

--- a/packages/codegen.go/src/options.ts
+++ b/packages/codegen.go/src/options.ts
@@ -51,9 +51,9 @@ function emit(struct: go.Struct, imports: ImportManager): string {
       }
 
       let typeName = go.getTypeDeclaration(field.type);
-      if (go.isLiteralValue(field.type)) {
+      if (field.type.kind === 'literal') {
         // for constants we use the underlying type name
-        typeName = go.getLiteralValueTypeName(field.type.type);
+        typeName = go.getLiteralTypeDeclaration(field.type.type);
       }
 
       let pointer = '*';

--- a/packages/codegen.go/src/time.ts
+++ b/packages/codegen.go/src/time.ts
@@ -62,7 +62,7 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
       for (const method of client.methods) {
         for (const param of method.parameters) {
           const unwrappedParam = recursiveUnwrapMapSlice(param.type);
-          if (!go.isTimeType(unwrappedParam)) {
+          if (unwrappedParam.kind !== 'time') {
             continue;
           }
           // for body params, the helpers are always required.
@@ -79,7 +79,7 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
     for (const model of codeModel.models) {
       for (const field of values(model.fields)) {
         const unwrappedField = recursiveUnwrapMapSlice(field.type);
-        if (!go.isTimeType(unwrappedField)) {
+        if (unwrappedField.kind !== 'time') {
           continue;
         }
         if (getSerDeFormat(model, codeModel) === 'JSON') {
@@ -95,7 +95,7 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
         continue;
       }
       const unwrappedResult = recursiveUnwrapMapSlice(respEnv.result.monomorphicType);
-      if (!go.isTimeType(unwrappedResult)) {
+      if (unwrappedResult.kind !== 'time') {
         continue;
       }
       setHelper(unwrappedResult.format);
@@ -106,7 +106,7 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
     for (const client of codeModel.clients) {
       for (const method of client.methods) {
         for (const param of method.parameters) {
-          if (param.kind === 'bodyParam' && go.isTimeType(param.type)) {
+          if (param.kind === 'bodyParam' && param.type.kind === 'time') {
             setHelper(param.type.format);
           }
         }
@@ -117,11 +117,11 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
       for (const header of respEnv.headers) {
         // for header/path/query params, the conversion happens in place. the only
         // exceptions are for timeRFC3339 and timeUnix
-        if (go.isTimeType(header.type) && (header.type.format === 'timeRFC3339' || header.type.format === 'timeUnix')) {
+        if (header.type.kind === 'time' && (header.type.format === 'timeRFC3339' || header.type.format === 'timeUnix')) {
           setHelper(header.type.format);
         }
       }
-      if (respEnv.result?.kind === 'monomorphicResult' && go.isTimeType(respEnv.result.monomorphicType)) {
+      if (respEnv.result?.kind === 'monomorphicResult' && respEnv.result.monomorphicType.kind === 'time') {
         setHelper(respEnv.result.monomorphicType.format);
       }
     }

--- a/packages/codegen.go/src/xmlAdditionalProps.ts
+++ b/packages/codegen.go/src/xmlAdditionalProps.ts
@@ -17,7 +17,7 @@ export async function generateXMLAdditionalPropsHelpers(codeModel: go.CodeModel)
       continue;
     }
     for (const field of model.fields) {
-      if (go.isMapType(field.type)) {
+      if (field.type.kind === 'map') {
         required = true;
         break;
       }

--- a/packages/codemodel.go/src/param.ts
+++ b/packages/codemodel.go/src/param.ts
@@ -277,14 +277,59 @@ export function isHeaderParameter(param: MethodParameter): param is HeaderParame
   return param.kind === 'headerCollectionParam' || param.kind === 'headerMapParam' || param.kind === 'headerScalarParam';
 }
 
+/** narrows type to a HeaderScalarType within the conditional block */
+export function isHeaderScalarType(type: type.PossibleType): type is HeaderScalarType {
+  switch (type.kind) {
+    case 'constant':
+    case 'encodedBytes':
+    case 'literal':
+    case 'scalar':
+    case 'string':
+    case 'time':
+      return true;
+    default:
+      return false;
+  }
+}
+
 /** narrows param to a PathParameter within the conditional block */
 export function isPathParameter(param: MethodParameter): param is PathParameter {
   return param.kind === 'pathCollectionParam' || param.kind === 'pathScalarParam';
 }
 
+/** narrows type to a PathScalarParameterType within the conditional block */
+export function isPathScalarParameterType(type: type.PossibleType): type is PathScalarParameterType {
+  switch (type.kind) {
+    case 'constant':
+    case 'encodedBytes':
+    case 'literal':
+    case 'scalar':
+    case 'string':
+    case 'time':
+      return true;
+    default:
+      return false;
+  }
+}
+
 /** narrows param to a QueryParameter within the conditional block */
 export function isQueryParameter(param: MethodParameter): param is QueryParameter {
   return param.kind === 'queryCollectionParam' || param.kind === 'queryScalarParam';
+}
+
+/** narrows type to a QueryScalarParameterType within the conditional block */
+export function isQueryScalarParameterType(type: type.PossibleType): type is QueryScalarParameterType {
+  switch (type.kind) {
+    case 'constant':
+    case 'encodedBytes':
+    case 'literal':
+    case 'scalar':
+    case 'string':
+    case 'time':
+      return true;
+    default:
+      return false;
+  }
 }
 
 /** returns true if the param is required */
@@ -294,6 +339,18 @@ export function isRequiredParameter(param: MethodParameter | Parameter): boolean
     return false;
   }
   return param.style === 'required';
+}
+
+/** narrows type to a URIParameterType within the conditional block */
+export function isURIParameterType(type: type.PossibleType): type is URIParameterType {
+  switch (type.kind) {
+    case 'constant':
+    case 'scalar':
+    case 'string':
+      return true;
+    default:
+      return false;
+  }
 }
 
 /** returns true if the param is a literal */

--- a/packages/codemodel.go/src/result.ts
+++ b/packages/codemodel.go/src/result.ts
@@ -196,13 +196,31 @@ export function getResultType(result: Result): type.Interface | type.Model | Mon
     case 'binaryResult':
       return new type.QualifiedType('ReadCloser', 'io');
     case 'headAsBooleanResult':
-      return new type.Scalar('bool');
+      return new type.Scalar('bool', false);
     case 'modelResult':
       return result.modelType;
     case 'monomorphicResult':
       return result.monomorphicType;
     case 'polymorphicResult':
       return result.interface;
+  }
+}
+
+/** narrows type to a MonomorphicResultType within the conditional block */
+export function isMonomorphicResultType(type: type.PossibleType): type is MonomorphicResultType {
+  switch (type.kind) {
+    case 'any':
+    case 'constant':
+    case 'encodedBytes':
+    case 'map':
+    case 'rawJSON':
+    case 'scalar':
+    case 'slice':
+    case 'string':
+    case 'time':
+      return true;
+    default:
+      return false;
   }
 }
 

--- a/packages/codemodel.go/src/type.ts
+++ b/packages/codemodel.go/src/type.ts
@@ -3,8 +3,6 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { CodeModelError } from "./errors.js";
-
 /** Docs contains the values used in doc comment generation. */
 export interface Docs {
   /** the high level summary */
@@ -19,343 +17,372 @@ export type PossibleType = Any | Constant | EncodedBytes | Interface | Literal |
 
 /** the Go any type */
 export interface Any {
-  isAny: true;
+  kind: 'any';
 }
 
 /** a const type definition */
 export interface Constant {
+  kind: 'constant';
+
+  /** the const type name */
   name: string;
 
+  /** any docs for the const type */
   docs: Docs;
 
+  /** the underlying type of the const */
   type: ConstantType;
 
+  /** the possible values for this const */
   values: Array<ConstantValue>;
 
+  /** the name of the func that returns the set of values */
   valuesFuncName: string;
 }
 
 /** the underlying type of a const */
 export type ConstantType = 'bool' | 'float32' | 'float64' | 'int32' | 'int64' | 'string';
 
-/** a const vale definition */
+/** a const value definition */
 export interface ConstantValue {
+  kind: 'constantValue';
+
+  /** the const value name */
   name: string;
 
+  /** any docs for the const value */
   docs: Docs;
 
+  /** the const to which this value belongs */
   type: Constant;
 
+  /** the value for this const */
   value: ConstantValueType;
 }
 
+/** the underlying type of a const value */
 export type ConstantValueType = boolean | number | string;
 
 /** a byte slice that's base64 encoded */
 export interface EncodedBytes {
+  kind: 'encodedBytes';
+
   /** indicates what kind of base64-encoding to use */
   encoding: BytesEncoding;
 }
 
+/** the types of base64 encoding */
 export type BytesEncoding = 'Std' | 'URL';
 
-// InterfaceType represents the interface type for a polymorphic (discriminated) type
+/** a Go interface type used for discriminated types */
 export interface Interface {
-  // Name is the name of the interface (e.g. FishClassification)
+  kind: 'interface';
+
+  /** the name of the interface (e.g. FishClassification) */
   name: string;
 
+  /** any docs for the interface */
   docs: Docs;
 
-  // contains possible concrete type instances (e.g. Flounder, Carp)
+  /** contains possible concrete type instances (e.g. Flounder, Carp) */
   possibleTypes: Array<PolymorphicModel>;
 
-  // contains the name of the discriminator field in the JSON (e.g. "fishtype")
+  /** contains the name of the discriminator field in the JSON (e.g. "fishtype") */
   discriminatorField: string;
 
-  // does this polymorphic type have a parent (e.g. SalmonClassification has parent FishClassification)
+  /** does this polymorphic type have a parent (e.g. SalmonClassification has parent FishClassification) */
   parent?: Interface;
 
-  // this is the "root" type in the list of polymorphic types (e.g. Fish for FishClassification)
+  /**  this is the "root" type in the list of polymorphic types (e.g. Fish for FishClassification) */
   rootType: PolymorphicModel;
 }
 
-// LiteralValue is a literal value (e.g. "foo").
+/** a literal value (e.g. "foo", 123, true) */
 export interface Literal {
+  kind: 'literal';
+
+  /** the literal's underlying type */
   type: LiteralType;
 
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  /** the value for this literal */
   literal: any;
 }
 
+/** the possible types of literals */
 export type LiteralType = Constant | EncodedBytes | Scalar | String | Time;
 
+/** a Go map type. note that the key is always a string */
 export interface Map {
+  kind: 'map';
+
+  /** the type of values in the map */
   valueType: MapValueType;
 
+  /** indicates if the map's value type is pointer-to-type or not */
   valueTypeByValue: boolean;
 }
 
+/** the set of map value types */
 export type MapValueType = PossibleType;
 
-// ModelField describes a field within a model
+/** a field within a model */
 export interface ModelField extends StructField {
+  /** the name of the field as it's sent/received over the wire */
   serializedName: string;
 
+  /** metadata for this field */
   annotations: ModelFieldAnnotations;
 
-  // the value to send over the wire if one isn't specified
+  /** the value to send over the wire if one isn't specified */
   defaultValue?: Literal;
 
+  /** any XML metadata */
   xml?: XMLInfo;
 }
 
+/** additional settings for a model type */
 export interface ModelAnnotations {
+  /** when true, serde methods will not be generated */
   omitSerDeMethods: boolean;
 
-  // indicates the model should be converted into multipart/form data
+  /** indicates the model should be converted into multipart/form data */
   multipartFormData: boolean;
 }
 
+/** additional settings for a model field */
 export interface ModelFieldAnnotations {
+  /** the field is required on input and will always be populated on output */
   required: boolean;
 
+  /** the field is read-only and will be populated on output. any set value on input will be ignored */
   readOnly: boolean;
 
+  /** field is JSON additional properties */
   isAdditionalProperties: boolean;
 
+  /** field is the discriminator for a discriminated type */
   isDiscriminator: boolean;
 }
 
-// ModelType is a struct that participates in serialization over the wire.
-export interface Model extends Struct {
-  fields: Array<ModelField>;
-
-  annotations: ModelAnnotations;
-
-  usage: UsageFlags;
-
-  xml?: XMLInfo;
+/** a struct that participates in serialization over the wire */
+export interface Model extends ModelBase {
+  kind: 'model';
 }
 
-// PolymorphicType is a discriminated type
-export interface PolymorphicModel extends Model {
-  // this denotes the polymorphic interface this type implements
+/** a model that's a discriminated type */
+export interface PolymorphicModel extends ModelBase {
+  kind: 'polymorphicModel';
+
+  /** the polymorphic interface this type implements */
   interface: Interface;
 
-  // the value in the JSON that indicates what type was sent over the wire (e.g. goblin, salmon, shark)
-  // note that for "root" types (Fish), there is no discriminatorValue. however, "sub-root" types (e.g. Salmon)
-  // will have this populated.
+  /**
+   * the value in the JSON that indicates what type was sent over the wire (e.g. goblin, salmon, shark)
+   * note that for "root" types (Fish), there is no discriminatorValue. however, "sub-root" types (e.g. Salmon)
+   * will have this populated.
+   */
   discriminatorValue?: Literal;
 }
 
-// QualifiedType is a type from some package, e.g. the Go standard library (excluding time.Time)
+/** a type from some package, e.g. the Go standard library (excluding time.Time) */
 export interface QualifiedType {
-  // this is the type name minus any package qualifier (e.g. URL)
+  kind: 'qualifiedType';
+
+  /** the type name minus any package qualifier (e.g. URL) */
   exportName: string;
 
-  // the full name of the package to import (e.g. "net/url")
+  /** the full name of the package to import (e.g. "net/url") */
   packageName: string;
 }
 
 /** a byte slice containing raw JSON */
 export interface RawJSON {
-  rawJSON: true;
+  kind: 'rawJSON';
 }
 
 /** a Go scalar type */
 export interface Scalar {
-  typeName: ScalarType;
+  kind: 'scalar';
+
+  /** the type of scalar */
+  type: ScalarType;
+
+  /** indicates the value is sent/received as a string */
   encodeAsString: boolean;
 }
 
 /** the supported Go scalar types */
 export type ScalarType = 'bool' | 'byte' | 'float32' | 'float64' | 'int8' | 'int16' | 'int32' | 'int64' | 'rune' | 'uint8' | 'uint16' | 'uint32' | 'uint64';
 
+/** a Go slice */
 export interface Slice {
+  kind: 'slice';
+
+  /** the element type for this slice */
   elementType: SliceElementType;
 
+  /** indicates if the slice's element type is pointer-to-type or not */
   elementTypeByValue: boolean;
 }
 
+/** the set of slice element types */
 export type SliceElementType = PossibleType;
 
 /** a Go string */
 export interface String {
-  isString: true;
+  kind: 'string';
 }
 
-// Struct describes a vanilla struct definition (pretty much exclusively used for parameter groups/options bag types)
-// UDTs that are sent/received are modeled as ModelType.
+/** a vanilla struct definition (pretty much exclusively used for parameter groups/options bag types) */
 export interface Struct {
+  /** the name of the struct */
   name: string;
 
+  /** and docs for this struct */
   docs: Docs;
 
-  // there are only a few corner-cases where a struct has no fields
+  /** the fields in this struct. can be empty */
   fields: Array<StructField>;
 }
 
-// StructField describes a field definition within a struct
+/** a field definition within a struct */
 export interface StructField {
+  /** the name of the field */
   name: string;
 
+  /** and docs for this field */
   docs: Docs;
 
+  /** the field's underlying type */
   type: PossibleType;
 
+  /** indicates if the field is pointer-to-type or not */
   byValue: boolean;
 }
 
-// TimeType is a time.Time type from the standard library with a format specifier.
+/** a time.Time type from the standard library with a format specifier */
 export interface Time {
+  kind: 'time';
+
+  /** the serde format used */
   format: TimeFormat;
 
+  /** indicates if the time is always in UTC */
   utc: boolean;
 }
 
+/** the set of time serde formats */
 export type TimeFormat = 'dateType' | 'dateTimeRFC1123' | 'dateTimeRFC3339' | 'timeRFC3339' | 'timeUnix';
 
-// UsageFlags are bit flags indicating how a model/polymorphic type is used
+/** bit flags indicating how a model/polymorphic type is used */
 export enum UsageFlags {
-  // the type is unreferenced
+  /** the type is unreferenced */
   None = 0,
 
-  // the type is received over the wire
+  /** the type is received over the wire */
   Input = 1,
 
-  // the type is sent over the wire
+  /** the type is sent over the wire */
   Output = 2
 }
 
+/** metadata used for XML serde */
 export interface XMLInfo {
+  /** element name to use instead of the default name */
   name?: string;
 
-  // name propagated to the generated wrapper type
+  /** name propagated to the generated wrapper type */
   wrapper? :string;
 
-  // slices only. this is the name of the wrapped type
+  /** slices only. this is the name of the wrapped type */
   wraps?: string;
 
+  /** value is an XML attribute */
   attribute: boolean;
 
+  /** value is raw text */
   text: boolean;
 }
 
-export function isAnyType(type: PossibleType): type is Any {
-  return (<Any>type).isAny !== undefined;
-}
-
-export function isBytesType(type: PossibleType): type is EncodedBytes {
-  return (<EncodedBytes>type).encoding !== undefined;
-}
-
-export function isConstantType(type: PossibleType): type is Constant {
-  return (<Constant>type).values !== undefined;
-}
-
-export function isLiteralValueType(type: PossibleType): type is LiteralType {
-  return isConstantType(type) || isPrimitiveType(type) || isStringType(type);
-}
-
-export function isPrimitiveType(type: PossibleType): type is Scalar {
-  return (<Scalar>type).typeName !== undefined;
-}
-
-export function isQualifiedType(type: PossibleType): type is QualifiedType {
-  return (<QualifiedType>type).exportName !== undefined;
-}
-
-export function isRawJSON(type: PossibleType): type is RawJSON {
-  return (<RawJSON>type).rawJSON !== undefined;
-}
-
-export function isStringType(type: PossibleType): type is String {
-  return (<String>type).isString !== undefined;
-}
-
-export function isTimeType(type: PossibleType): type is Time {
-  return (<Time>type).format !== undefined;
-}
-
-export function isMapType(type: PossibleType): type is Map {
-  return (<Map>type).valueType !== undefined;
-}
-
-export function isModelType(type: PossibleType): type is Model {
-  return (<Model>type).fields !== undefined;
-}
-
-export function isPolymorphicType(type: PossibleType): type is PolymorphicModel {
-  return (<PolymorphicModel>type).interface !== undefined;
-}
-
-export function isSliceType(type: PossibleType): type is Slice {
-  return (<Slice>type).elementType !== undefined;
-}
-
-export function isInterfaceType(type: PossibleType): type is Interface {
-  return (<Interface>type).possibleTypes !== undefined;
-}
-
-export function isLiteralValue(type: PossibleType): type is Literal {
-  return (<Literal>type).literal !== undefined;
-}
-
-export function getLiteralValueTypeName(literal: LiteralType): string {
-  if (isBytesType(literal)) {
-    return '[]byte';
-  } else if (isConstantType(literal)) {
-    return literal.name;
-  } else if (isPrimitiveType(literal)) {
-    return literal.typeName;
-  } else if (isStringType(literal)) {
-    return 'string';
-  } else if (isTimeType(literal)) {
-    return 'time.Time';
-  } else {
-    throw new CodeModelError(`unhandled LiteralValueType ${getTypeDeclaration(literal)}`);
+/**
+ * returns the Go type declaration for the specified LiteralType
+ * 
+ * @param literal the type for which to emit the declaration
+ * @returns the Go type declaration
+ */
+export function getLiteralTypeDeclaration(literal: LiteralType): string {
+  switch (literal.kind) {
+    case 'constant':
+      return literal.name;
+    case 'encodedBytes':
+      return '[]byte';
+    case 'scalar':
+      return literal.type;
+    case 'string':
+      return literal.kind;
+    case 'time':
+      return 'time.Time';
   }
 }
 
+/**
+ * returns the Go type declaration for the specified type.
+ * any value in pkgName is prefixed to the underlying type name.
+ * 
+ * @param type the type for which to emit the declaration
+ * @param pkgName optional package name prefix for the type
+ * @returns the Go type declaration
+ */
 export function getTypeDeclaration(type: PossibleType, pkgName?: string): string {
-  if (isAnyType(type)) {
-    return 'any';
-  } else if (isPrimitiveType(type)) {
-    return type.typeName;
-  } else if (isQualifiedType(type)) {
-    let pkg = type.packageName;
-    const pathChar = pkg.lastIndexOf('/');
-    if (pathChar) {
-      pkg = pkg.substring(pathChar+1);
+  switch (type.kind) {
+    case 'any':
+    case 'string':
+      return type.kind;
+    case 'constant':
+    case 'interface':
+    case 'model':
+    case 'polymorphicModel':
+      if (pkgName) {
+        return `${pkgName}.${type.name}`;
+      }
+      return type.name;
+    case 'encodedBytes':
+    case 'rawJSON':
+      return '[]byte';
+    case 'literal':
+      return getTypeDeclaration(type.type, pkgName);
+    case 'map':
+      return `map[string]${type.valueTypeByValue ? '' : '*'}` + getTypeDeclaration(type.valueType, pkgName);
+    case 'qualifiedType': {
+      // strip packageName to just the leaf package as required
+      let pkg = type.packageName;
+      const pathChar = pkg.lastIndexOf('/');
+      if (pathChar) {
+        pkg = pkg.substring(pathChar+1);
+      }
+      return pkg + '.' + type.exportName;
     }
-    return pkg + '.' + type.exportName;
-  } else if (isConstantType(type) || isInterfaceType(type) || isModelType(type) || isPolymorphicType(type)) {
-    if (pkgName) {
-      return `${pkgName}.${type.name}`;
-    }
-    return type.name;
-  } else if (isBytesType(type) || isRawJSON(type)) {
-    return '[]byte';
-  } else if (isLiteralValue(type)) {
-    return getTypeDeclaration(type.type, pkgName);
-  } else if (isMapType(type)) {
-    let pointer = '*';
-    if (type.valueTypeByValue) {
-      pointer = '';
-    }
-    return `map[string]${pointer}` + getTypeDeclaration(type.valueType, pkgName);
-  } else if (isSliceType(type)) {
-    let pointer = '*';
-    if (type.elementTypeByValue) {
-      pointer = '';
-    }
-    return `[]${pointer}` + getTypeDeclaration(type.elementType, pkgName);
-  } else if (isStringType(type)) {
-    return 'string';
-  } else if (isTimeType(type)) {
-    return 'time.Time';
-  } else {
-    throw new CodeModelError(`unhandled type ${typeof(type)}`);
+    case 'scalar':
+      return type.type;
+    case 'slice':
+      return `[]${type.elementTypeByValue ? '' : '*'}` + getTypeDeclaration(type.elementType, pkgName);
+    case 'time':
+      return 'time.Time';
+  }
+}
+
+/** narrows type to a LiteralType within the conditional block */
+export function isLiteralValueType(type: PossibleType): type is LiteralType {
+  switch (type.kind) {
+    case 'constant':
+    case 'encodedBytes':
+    case 'scalar':
+    case 'string':
+    case 'time':
+      return true;
+    default:
+      return false;
   }
 }
 
@@ -380,17 +407,41 @@ export class Struct implements Struct {
   }
 }
 
+interface ModelBase extends Struct {
+  /** the fields in this model. can be empty */
+  fields: Array<ModelField>;
+
+  /** any annotations for this model */
+  annotations: ModelAnnotations;
+
+  /** usage flags for this model */
+  usage: UsageFlags;
+
+  /** any XML metadata */
+  xml?: XMLInfo;
+}
+
+class ModelBase extends Struct implements ModelBase {
+  constructor(name: string, annotations: ModelAnnotations, usage: UsageFlags) {
+    super(name);
+    this.annotations = annotations;
+    this.usage = usage;
+    this.fields = new Array<ModelField>();
+  }
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 export class Any implements Any {
   constructor() {
-    this.isAny = true;
+    this.kind = 'any';
   }
 }
 
 export class Constant implements Constant {
   constructor(name: string, type: ConstantType, valuesFuncName: string) {
+    this.kind = 'constant';
     this.name = name;
     this.type = type;
     this.values = new Array<ConstantValue>();
@@ -401,6 +452,7 @@ export class Constant implements Constant {
 
 export class ConstantValue implements ConstantValue {
   constructor(name: string, type: Constant, value: ConstantValueType) {
+    this.kind = 'constantValue';
     this.name = name;
     this.type = type;
     this.value = value;
@@ -410,6 +462,7 @@ export class ConstantValue implements ConstantValue {
 
 export class EncodedBytes implements EncodedBytes {
   constructor(encoding: BytesEncoding) {
+    this.kind = 'encodedBytes';
     this.encoding = encoding;
   }
 }
@@ -419,6 +472,7 @@ export class Interface implements Interface {
   // problem as creating a PolymorphicType requires the necessary InterfaceType.
   // so these fields MUST be populated after creating the InterfaceType.
   constructor(name: string, discriminatorField: string) {
+    this.kind = 'interface';
     this.name = name;
     this.discriminatorField = discriminatorField;
     this.possibleTypes = new Array<PolymorphicModel>();
@@ -429,6 +483,7 @@ export class Interface implements Interface {
 export class Literal implements Literal {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   constructor(type: LiteralType, literal: any) {
+    this.kind = 'literal';
     this.type = type;
     /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */
     this.literal = literal;
@@ -437,6 +492,7 @@ export class Literal implements Literal {
 
 export class Map implements Map {
   constructor(valueType: MapValueType, valueTypeByValue: boolean) {
+    this.kind = 'map';
     this.valueType = valueType;
     this.valueTypeByValue = valueTypeByValue;
   }
@@ -466,24 +522,25 @@ export class ModelFieldAnnotations implements ModelFieldAnnotations {
   }
 }
 
-export class Model extends Struct implements Model {
+export class Model extends ModelBase implements Model {
   constructor(name: string, annotations: ModelAnnotations, usage: UsageFlags) {
-    super(name);
-    this.annotations = annotations;
-    this.usage = usage;
+    super(name, annotations, usage);
+    this.kind = 'model';
     this.fields = new Array<ModelField>();
   }
 }
 
-export class PolymorphicModel extends Model implements PolymorphicModel {
+export class PolymorphicModel extends ModelBase implements PolymorphicModel {
   constructor(name: string, iface: Interface, annotations: ModelAnnotations, usage: UsageFlags) {
     super(name, annotations, usage);
+    this.kind = 'polymorphicModel';
     this.interface = iface;
   }
 }
 
 export class QualifiedType implements QualifiedType {
   constructor(exportName: string, packageName: string) {
+    this.kind = 'qualifiedType';
     this.exportName = exportName;
     this.packageName = packageName;
   }
@@ -491,19 +548,21 @@ export class QualifiedType implements QualifiedType {
 
 export class RawJSON implements RawJSON {
   constructor() {
-    this.rawJSON = true;
+    this.kind = 'rawJSON';
   }
 }
 
 export class Scalar implements Scalar {
-  constructor(typeName: ScalarType, encodeAsString?: boolean) {
-    this.typeName = typeName;
-    this.encodeAsString = encodeAsString ?? false;
+  constructor(type: ScalarType, encodeAsString: boolean) {
+    this.kind = 'scalar';
+    this.type = type;
+    this.encodeAsString = encodeAsString;
   }
 }
 
 export class Slice implements Slice {
   constructor(elementType: SliceElementType, elementTypeByValue: boolean) {
+    this.kind = 'slice';
     this.elementType = elementType;
     this.elementTypeByValue = elementTypeByValue;
   }
@@ -511,12 +570,13 @@ export class Slice implements Slice {
 
 export class String implements String {
   constructor() {
-    this.isString = true;
+    this.kind = 'string';
   }
 }
 
 export class Time implements Time {
   constructor(format: TimeFormat, utc: boolean) {
+    this.kind = 'time';
     this.format = format;
     this.utc = utc;
   }

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -167,12 +167,12 @@ export class clientAdapter {
 
   private adaptURIParam(sdkParam: tcgc.SdkPathParameter): go.URIParameter {
     const paramType = this.ta.getPossibleType(sdkParam.type, true, false);
-    if (!go.isConstantType(paramType) && !go.isPrimitiveType(paramType) && !go.isStringType(paramType)) {
-      throw new AdapterError('UnsupportedTsp', `unsupported URI parameter type ${go.getTypeDeclaration(paramType)}`, sdkParam.__raw?.node ?? NoTarget);
+    if (go.isURIParameterType(paramType)) {
+      // TODO: follow up with tcgc if serializedName should actually be optional
+      return new go.URIParameter(sdkParam.name, sdkParam.serializedName ? sdkParam.serializedName : sdkParam.name, paramType,
+        this.adaptParameterStyle(sdkParam), isTypePassedByValue(sdkParam.type) || !sdkParam.optional, 'client');
     }
-    // TODO: follow up with tcgc if serializedName should actually be optional
-    return new go.URIParameter(sdkParam.name, sdkParam.serializedName ? sdkParam.serializedName : sdkParam.name, paramType,
-      this.adaptParameterStyle(sdkParam), isTypePassedByValue(sdkParam.type) || !sdkParam.optional, 'client');
+    throw new AdapterError('UnsupportedTsp', `unsupported URI parameter type ${paramType.kind}`, sdkParam.__raw?.node ?? NoTarget);
   }
 
   private adaptMethod(sdkMethod: tcgc.SdkServiceMethod<tcgc.SdkHttpOperation>, goClient: go.Client) {
@@ -537,7 +537,7 @@ export class clientAdapter {
         }
         // TODO: is hard-coded false for element type by value correct?
         const type = this.ta.getPossibleType(param.type, true, false);
-        if (!go.isSliceType(type)) {
+        if (type.kind !== 'slice') {
           throw new AdapterError('InternalError', `unexpected type ${go.getTypeDeclaration(type)} for HeaderCollectionParameter ${param.name}`, param.__raw?.node ?? NoTarget);
         }
         adaptedParam = new go.HeaderCollectionParameter(paramName, param.serializedName, type, param.collectionFormat === 'simple' ? 'csv' : param.collectionFormat, paramStyle, byVal, location);
@@ -552,7 +552,7 @@ export class clientAdapter {
     } else {
       if (param.collectionFormat) {
         const type = this.ta.getPossibleType(param.type, true, false);
-        if (!go.isSliceType(type)) {
+        if (type.kind !== 'slice') {
           throw new AdapterError('InternalError', `unexpected type ${go.getTypeDeclaration(type)} for QueryCollectionParameter ${param.name}`, param.__raw?.node ?? NoTarget);
         }
         // TODO: unencoded query param
@@ -675,7 +675,7 @@ export class clientAdapter {
       respEnv.result.docs.summary = 'Body contains the streaming response.';
       return respEnv;
     } else if (sdkResponseType.kind === 'model') {
-      let modelType: go.Model | undefined;
+      let modelType: go.Model | go.PolymorphicModel | undefined;
       const modelName = ensureNameCase(sdkResponseType.name).toUpperCase();
       for (const model of this.ta.codeModel.models) {
         if (model.name.toUpperCase() === modelName) {
@@ -686,7 +686,7 @@ export class clientAdapter {
       if (!modelType) {
         throw new AdapterError('InternalError', `didn't find model type name ${sdkResponseType.name} for response envelope ${respEnv.name}`, sdkResponseType.__raw?.node ?? NoTarget);
       }
-      if (go.isPolymorphicType(modelType)) {
+      if (modelType.kind === 'polymorphicModel') {
         respEnv.result = new go.PolymorphicResult(modelType.interface);
       } else {
         if (contentType !== 'JSON' && contentType !== 'XML') {
@@ -698,10 +698,11 @@ export class clientAdapter {
       respEnv.result.docs.description = sdkResponseType.doc;
     } else {
       const resultType = this.ta.getPossibleType(sdkResponseType, false, false);
-      if (go.isInterfaceType(resultType) || go.isLiteralValue(resultType) || go.isModelType(resultType) || go.isPolymorphicType(resultType) || go.isQualifiedType(resultType)) {
-        throw new AdapterError('InternalError', `invalid monomorphic result type ${go.getTypeDeclaration(resultType)}`, sdkResponseType.__raw?.node ?? NoTarget);
+      if (go.isMonomorphicResultType(resultType)) {
+        respEnv.result = new go.MonomorphicResult(this.recursiveTypeName(sdkResponseType, false), contentType, resultType, isTypePassedByValue(sdkResponseType));
+      } else {
+        throw new AdapterError('InternalError', `invalid monomorphic result type ${resultType.kind}`, sdkResponseType.__raw?.node ?? NoTarget);
       }
-      respEnv.result = new go.MonomorphicResult(this.recursiveTypeName(sdkResponseType, false), contentType, resultType, isTypePassedByValue(sdkResponseType));
     }
 
     return respEnv;
@@ -793,26 +794,26 @@ export class clientAdapter {
   private adaptHeaderScalarType(sdkType: tcgc.SdkType, forParam: boolean): go.HeaderScalarType {
     // for header params, we never pass the element type by pointer
     const type = this.ta.getPossibleType(sdkType, forParam, false);
-    if (go.isAnyType(type) || go.isInterfaceType(type) || go.isMapType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isRawJSON(type) || go.isSliceType(type) || go.isQualifiedType(type)) {
-      throw new AdapterError('InternalError', `unexpected header parameter type ${sdkType.kind}`, sdkType.__raw?.node ?? NoTarget);
+    if (go.isHeaderScalarType(type)) {
+      return type;
     }
-    return type;
+    throw new AdapterError('InternalError', `unexpected header scalar parameter type ${sdkType.kind}`, sdkType.__raw?.node ?? NoTarget);
   }
 
   private adaptPathScalarParameterType(sdkType: tcgc.SdkType): go.PathScalarParameterType {
     const type = this.ta.getPossibleType(sdkType, false, false);
-    if (go.isAnyType(type) || go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isRawJSON(type) || go.isSliceType(type) || go.isQualifiedType(type)) {
-      throw new AdapterError('InternalError', `unexpected path parameter type ${sdkType.kind}`, sdkType.__raw?.node ?? NoTarget);
+    if (go.isPathScalarParameterType(type)) {
+      return type;
     }
-    return type;
+    throw new AdapterError('InternalError', `unexpected path scalar parameter type ${sdkType.kind}`, sdkType.__raw?.node ?? NoTarget);
   }
 
   private adaptQueryScalarParameterType(sdkType: tcgc.SdkType): go.QueryScalarParameterType {
     const type = this.ta.getPossibleType(sdkType, false, false);
-    if (go.isAnyType(type) || go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isRawJSON(type) || go.isSliceType(type) || go.isQualifiedType(type)) {
-      throw new AdapterError('InternalError', `unexpected query parameter type ${sdkType.kind}`, sdkType.__raw?.node ?? NoTarget);
+    if (go.isQueryScalarParameterType(type)) {
+      return type;
     }
-    return type;
+    throw new AdapterError('InternalError', `unexpected query scalar parameter type ${sdkType.kind}`, sdkType.__raw?.node ?? NoTarget);
   }
 
   private adaptParameterStyle(param: tcgc.SdkBodyParameter | tcgc.SdkEndpointParameter | tcgc.SdkHeaderParameter | tcgc.SdkMethodParameter | tcgc.SdkPathParameter | tcgc.SdkQueryParameter | tcgc.SdkCookieParameter): go.ParameterStyle {
@@ -888,7 +889,7 @@ export class clientAdapter {
                 goExample.responseEnvelope.result = this.adaptExampleType(response.bodyValue, new go.Any());
                 break;
               case 'binaryResult':
-                goExample.responseEnvelope.result = this.adaptExampleType(response.bodyValue, new go.Scalar('byte'));
+                goExample.responseEnvelope.result = this.adaptExampleType(response.bodyValue, new go.Scalar('byte', false));
                 break;
               case 'modelResult':
                 goExample.responseEnvelope.result = this.adaptExampleType(response.bodyValue, method.responseEnvelope.result.modelType);
@@ -910,32 +911,43 @@ export class clientAdapter {
   private adaptExampleType(exampleType: tcgc.SdkExampleValue, goType: go.PossibleType): go.ExampleType {
     switch (exampleType.kind) {
       case 'string':
-        if (go.isConstantType(goType) || go.isBytesType(goType) || go.isLiteralValue(goType) || go.isTimeType(goType) || go.isStringType(goType)) {
-          return new go.StringExample(exampleType.value, goType);
-        }
-        if (go.isQualifiedType(goType)) {
-          return new go.QualifiedExample(goType, exampleType.value);
+        switch (goType.kind) {
+          case 'constant':
+          case 'encodedBytes':
+          case 'literal':
+          case 'string':
+          case 'time':
+            return new go.StringExample(exampleType.value, goType);
+          case 'qualifiedType':
+            return new go.QualifiedExample(goType, exampleType.value);
         }
         break;
       case 'number':
-        if (go.isConstantType(goType) || go.isLiteralValue(goType) || go.isTimeType(goType) || go.isPrimitiveType(goType)) {
-          return new go.NumberExample(exampleType.value, goType);
+        switch (goType.kind) {
+          case 'constant':
+          case 'literal':
+          case 'scalar':
+          case 'time':
+            return new go.NumberExample(exampleType.value, goType);
         }
         break;
       case 'boolean':
-        if (go.isConstantType(goType) || go.isLiteralValue(goType) || go.isPrimitiveType(goType)) {
-          return new go.BooleanExample(exampleType.value, goType);
+        switch (goType.kind) {
+          case 'constant':
+          case 'literal':
+          case 'scalar':
+            return new go.BooleanExample(exampleType.value, goType);
         }
         break;
       case 'null':
         return new go.NullExample(goType);
       case 'unknown':
-        if (go.isAnyType(goType)) {
+        if (goType.kind === 'any') {
           return new go.AnyExample(exampleType.value);
         }
         break;
       case 'array':
-        if (go.isSliceType(goType)) {
+        if (goType.kind === 'slice') {
           const ret = new go.ArrayExample(goType);
           for (const v of exampleType.value) {
             ret.value.push(this.adaptExampleType(v, goType.elementType));
@@ -944,7 +956,7 @@ export class clientAdapter {
         }
         break;
       case 'dict':
-        if (go.isMapType(goType)) {
+        if (goType.kind === 'map') {
           const ret = new go.DictionaryExample(goType);
           for (const [k, v] of Object.entries(exampleType.value)) {
             ret.value[k] = this.adaptExampleType(v, goType.valueType);
@@ -955,9 +967,9 @@ export class clientAdapter {
       case 'union':
         throw new AdapterError('UnsupportedTsp', 'unsupported example type kind union', NoTarget);
       case 'model':
-        if (go.isModelType(goType) || go.isInterfaceType(goType)) {
+        if (goType.kind === 'interface' || goType.kind === 'model' || goType.kind === 'polymorphicModel') {
           let concreteType: go.Model | go.PolymorphicModel | undefined;
-          if (go.isInterfaceType(goType)) {
+          if (goType.kind === 'interface') {
             /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access */
             concreteType = goType.possibleTypes.find(t => t.discriminatorValue?.literal === exampleType.type.discriminatorValue || t.discriminatorValue?.literal.value === exampleType.type.discriminatorValue)!;
             if (concreteType === undefined) {
@@ -979,7 +991,7 @@ export class clientAdapter {
             ret.additionalProperties = {};
             for (const [k, v] of Object.entries(exampleType.additionalPropertiesValue)) {
               const filed = concreteType.fields.find(f => f.annotations.isAdditionalProperties)!;
-              if (go.isMapType(filed.type)) {
+              if (filed.type.kind === 'map') {
                 ret.additionalProperties[k] = this.adaptExampleType(v, filed.type.valueType);
               } else {
                 throw new AdapterError('InternalError', `additional properties field type should be map type`, NoTarget);


### PR DESCRIPTION
Switch to using discriminated unions to distinguish types. Switch on type.kind instead of if/else blocks where applicable. Consolidated some type narrowing code across emitters. The encodeAsString param in the Scalar class constructor is now required and properly set.