### PR TITLE
Rename PossibleType to WireType

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/types.ts
+++ b/packages/autorest.go/src/m4togocodemodel/types.ts
@@ -15,7 +15,7 @@ export function hasDescription(lang: m4.Language): boolean {
 }
 
 // cache of previously created types
-const types = new Map<string, go.PossibleType>();
+const types = new Map<string, go.WireType>();
 const constValues = new Map<string, go.ConstantValue>();
 
 export function adaptConstantType(choice: m4.ChoiceSchema | m4.SealedChoiceSchema): go.Constant {
@@ -172,7 +172,7 @@ function getDiscriminatorLiteral(discriminatorValue: string): go.Literal {
 }
 
 export function adaptModelField(prop: m4.Property, obj: m4.ObjectSchema): go.ModelField {
-  const fieldType = adaptPossibleType(prop.schema);
+  const fieldType = adaptWireType(prop.schema);
   let required = prop.required === true;
   if (fieldType.kind === 'literal') {
     // for OpenAPI, literal values are always considered required
@@ -270,7 +270,7 @@ export function adaptXMLInfo(obj: m4.Schema): go.XMLInfo | undefined {
 }
 
 // converts an M4 schema type to a Go code model type
-export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolean): go.PossibleType {
+export function adaptWireType(schema: m4.Schema, elementTypeByValue?: boolean): go.WireType {
   const rawJSONAsBytes = <boolean>schema.language.go!.rawJSONAsBytes;
   switch (schema.type) {
     case m4.SchemaType.Any: {
@@ -330,7 +330,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (arrayType) {
         return arrayType;
       }
-      arrayType = new go.Slice(adaptPossibleType((<m4.ArraySchema>schema).elementType, elementTypeByValue), myElementTypeByValue);
+      arrayType = new go.Slice(adaptWireType((<m4.ArraySchema>schema).elementType, elementTypeByValue), myElementTypeByValue);
       types.set(keyName, arrayType);
       return arrayType;
     }
@@ -395,7 +395,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (mapType) {
         return mapType;
       }
-      mapType = new go.Map(adaptPossibleType((<m4.DictionarySchema>schema).elementType, elementTypeByValue), valueTypeByValue);
+      mapType = new go.Map(adaptWireType((<m4.DictionarySchema>schema).elementType, elementTypeByValue), valueTypeByValue);
       types.set(keyName, mapType);
       return mapType;
     }

--- a/packages/codegen.go/src/example.ts
+++ b/packages/codegen.go/src/example.ts
@@ -360,7 +360,7 @@ function getTimeValue(type: go.Time, value: any, imports?: ImportManager): strin
   }
 }
 
-function getPointerValue(type: go.PossibleType, valueString: string, byValue: boolean, imports?: ImportManager): string {
+function getPointerValue(type: go.WireType, valueString: string, byValue: boolean, imports?: ImportManager): string {
   if (byValue) {
     return valueString;
   }
@@ -423,7 +423,7 @@ function jsonToGo(value: any, indent: string): string {
   return '';
 }
 
-function generateFakeExample(goType: go.PossibleType, name?: string): go.ExampleType {
+function generateFakeExample(goType: go.WireType, name?: string): go.ExampleType {
   switch (goType.kind) {
     case 'any':
       return new go.NullExample(goType);

--- a/packages/codegen.go/src/fake/servers.ts
+++ b/packages/codegen.go/src/fake/servers.ts
@@ -564,16 +564,16 @@ function dispatchForOperationBody(clientPkg: string, receiverName: string, metho
       return parsingCode;
     };
 
-    const isMultipartContentType = function (type: go.PossibleType): boolean {
+    const isMultipartContentType = function (type: go.WireType): boolean {
       type = helpers.recursiveUnwrapMapSlice(type);
       return (type.kind === 'qualifiedType' && type.exportName === 'MultipartContent');
     };
 
-    const isModelType = function (type: go.PossibleType): type is go.Model | go.PolymorphicModel {
+    const isModelType = function (type: go.WireType): type is go.Model | go.PolymorphicModel {
       return type.kind === 'model' || type.kind === 'polymorphicModel';
     }
 
-    const emitCase = function (caseValue: string, paramVar: string, type: go.PossibleType): string {
+    const emitCase = function (caseValue: string, paramVar: string, type: go.WireType): string {
       let caseContent = `\t\tcase "${caseValue}":\n`;
       caseContent += '\t\t\tcontent, err = io.ReadAll(part)\n';
       caseContent += '\t\t\tif err != nil {\n\t\t\t\treturn nil, err\n\t\t\t}\n';

--- a/packages/codegen.go/src/helpers.ts
+++ b/packages/codegen.go/src/helpers.ts
@@ -277,7 +277,7 @@ export function getDelimiterForCollectionFormat(cf: go.CollectionFormat): string
   }
 }
 
-export function formatValue(paramName: string, type: go.PossibleType, imports: ImportManager, defef?: boolean): string {
+export function formatValue(paramName: string, type: go.WireType, imports: ImportManager, defef?: boolean): string {
   // callers don't have enough context to know if paramName needs to be
   // deferenced so we track that here when specified. note that not all
   // cases will require paramName to be dereferenced.
@@ -654,7 +654,7 @@ export function getBitSizeForNumber(intSize: 'float32' | 'float64' | 'int8' | 'i
 
 // returns the underlying map/slice element/value type
 // if item isn't a map or slice, item is returned
-export function recursiveUnwrapMapSlice(item: go.PossibleType): go.PossibleType {
+export function recursiveUnwrapMapSlice(item: go.WireType): go.WireType {
   switch (item.kind) {
     case 'map':
       return recursiveUnwrapMapSlice(item.valueType);
@@ -689,7 +689,7 @@ export function getSerDeFormat(model: go.Model | go.PolymorphicModel, codeModel:
   }
 
   // recursively walks the fields in model, updating serDeFormatCache with the model name and specified format
-  const recursiveWalkModelFields = function(type: go.PossibleType, serDeFormat: SerDeFormat): void {
+  const recursiveWalkModelFields = function(type: go.WireType, serDeFormat: SerDeFormat): void {
     type = recursiveUnwrapMapSlice(type);
     switch (type.kind) {
       case 'interface':

--- a/packages/codegen.go/src/imports.ts
+++ b/packages/codegen.go/src/imports.ts
@@ -50,7 +50,7 @@ export class ImportManager {
     return text;
   }
 
-  addImportForType(type: go.PossibleType) {
+  addImportForType(type: go.WireType) {
     switch (type.kind) {
       case 'map':
         this.addImportForType(type.valueType);

--- a/packages/codegen.go/src/models.ts
+++ b/packages/codegen.go/src/models.ts
@@ -531,7 +531,7 @@ function generateJSONUnmarshallerBody(modelType: go.Model | go.PolymorphicModel,
 
 // returns true if item has a discriminator interface.
 // recursively called for arrays and dictionaries.
-function hasDiscriminatorInterface(item: go.PossibleType): boolean {
+function hasDiscriminatorInterface(item: go.WireType): boolean {
   switch (item.kind) {
     case 'interface':
       return true;
@@ -587,7 +587,7 @@ function generateDiscriminatorUnmarshaller(field: go.ModelField, receiver: strin
 // constructs the type name for a nested discriminated type
 // raw e.g. map[string]json.RawMessage, []json.RawMessage etc
 // !raw e.g. map[string]map[string]InterfaceType, [][]InterfaceType etc
-function recursiveGetDiscriminatorTypeName(item: go.PossibleType, raw: boolean): string {
+function recursiveGetDiscriminatorTypeName(item: go.WireType, raw: boolean): string {
   // when raw is true, stop recursing at the level before the leaf schema
   if (item.kind === 'slice') {
     if (!raw || item.elementType.kind !== 'interface') {
@@ -605,7 +605,7 @@ function recursiveGetDiscriminatorTypeName(item: go.PossibleType, raw: boolean):
 }
 
 // recursively constructs the text to populate a nested discriminator
-function recursivePopulateDiscriminator(item: go.PossibleType, receiver: string, rawSrc: string, dest: string, indent: string, nesting: number): string {
+function recursivePopulateDiscriminator(item: go.WireType, receiver: string, rawSrc: string, dest: string, indent: string, nesting: number): string {
   let text = '';
   let interfaceName = '';
   let targetType = '';

--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -973,7 +973,7 @@ function emitClientSideDefault(param: go.HeaderCollectionParameter | go.HeaderSc
   return text;
 }
 
-function getMediaFormat(type: go.PossibleType, mediaType: 'JSON' | 'XML', param: string): string {
+function getMediaFormat(type: go.WireType, mediaType: 'JSON' | 'XML', param: string): string {
   let marshaller: 'JSON' | 'XML' | 'ByteArray' = mediaType;
   let format = '';
   if (type.kind === 'encodedBytes') {
@@ -983,7 +983,7 @@ function getMediaFormat(type: go.PossibleType, mediaType: 'JSON' | 'XML', param:
   return `${marshaller}(${param}${format})`;
 }
 
-function isArrayOfDateTimeForMarshalling(paramType: go.PossibleType): { format: go.TimeFormat, elemByVal: boolean } | undefined {
+function isArrayOfDateTimeForMarshalling(paramType: go.WireType): { format: go.TimeFormat, elemByVal: boolean } | undefined {
   if (paramType.kind !== 'slice') {
     return undefined;
   }
@@ -1011,7 +1011,7 @@ function needsResponseHandler(method: go.MethodType): boolean {
   return helpers.hasSchemaResponse(method) || method.responseEnvelope.headers.length > 0;
 }
 
-function generateResponseUnmarshaller(method: go.MethodType, type: go.PossibleType, format: go.ResultFormat, unmarshalTarget: string): string {
+function generateResponseUnmarshaller(method: go.MethodType, type: go.WireType, format: go.ResultFormat, unmarshalTarget: string): string {
   let unmarshallerText = '';
   const zeroValue = getZeroReturnValue(method, 'handler');
   if (type.kind === 'time') {
@@ -1156,7 +1156,7 @@ function createProtocolResponse(client: go.Client, method: go.Method | go.LROPag
   return text;
 }
 
-function isArrayOfDateTime(paramType: go.PossibleType): { format: go.TimeFormat, elemByVal: boolean } | undefined {
+function isArrayOfDateTime(paramType: go.WireType): { format: go.TimeFormat, elemByVal: boolean } | undefined {
   if (paramType.kind !== 'slice') {
     return undefined;
   }
@@ -1169,7 +1169,7 @@ function isArrayOfDateTime(paramType: go.PossibleType): { format: go.TimeFormat,
   };
 }
 
-function isMapOfDateTime(paramType: go.PossibleType): string | undefined {
+function isMapOfDateTime(paramType: go.WireType): string | undefined {
   if (paramType.kind !== 'map') {
     return undefined;
   }

--- a/packages/codegen.go/src/polymorphics.ts
+++ b/packages/codegen.go/src/polymorphics.ts
@@ -32,7 +32,7 @@ export async function generatePolymorphicHelpers(codeModel: go.CodeModel, fakeSe
   // we know there are polymorphic types but we don't know how they're used.
   // i.e. are they vanilla fields, elements in a slice, or values in a map.
   // polymorphic types within maps/slices will also need the scalar helpers.
-  const trackDisciminator = function(type: go.PossibleType) {
+  const trackDisciminator = function(type: go.WireType) {
     switch (type.kind) {
       case 'interface':
         scalars.add(type.name);

--- a/packages/codemodel.go/src/examples.ts
+++ b/packages/codemodel.go/src/examples.ts
@@ -52,7 +52,7 @@ export interface MethodExample {
 export interface NullExample {
   kind: 'null';
   value: null;
-  type: type.PossibleType;
+  type: type.WireType;
 }
 
 export interface NumberExample {
@@ -142,7 +142,7 @@ export class MethodExample implements MethodExample {
 }
 
 export class NullExample implements NullExample {
-  constructor(type: type.PossibleType) {
+  constructor(type: type.WireType) {
     this.kind = 'null';
     this.type = type;
   }

--- a/packages/codemodel.go/src/param.ts
+++ b/packages/codemodel.go/src/param.ts
@@ -278,7 +278,7 @@ export function isHeaderParameter(param: MethodParameter): param is HeaderParame
 }
 
 /** narrows type to a HeaderScalarType within the conditional block */
-export function isHeaderScalarType(type: type.PossibleType): type is HeaderScalarType {
+export function isHeaderScalarType(type: type.WireType): type is HeaderScalarType {
   switch (type.kind) {
     case 'constant':
     case 'encodedBytes':
@@ -298,7 +298,7 @@ export function isPathParameter(param: MethodParameter): param is PathParameter 
 }
 
 /** narrows type to a PathScalarParameterType within the conditional block */
-export function isPathScalarParameterType(type: type.PossibleType): type is PathScalarParameterType {
+export function isPathScalarParameterType(type: type.WireType): type is PathScalarParameterType {
   switch (type.kind) {
     case 'constant':
     case 'encodedBytes':
@@ -318,7 +318,7 @@ export function isQueryParameter(param: MethodParameter): param is QueryParamete
 }
 
 /** narrows type to a QueryScalarParameterType within the conditional block */
-export function isQueryScalarParameterType(type: type.PossibleType): type is QueryScalarParameterType {
+export function isQueryScalarParameterType(type: type.WireType): type is QueryScalarParameterType {
   switch (type.kind) {
     case 'constant':
     case 'encodedBytes':
@@ -342,7 +342,7 @@ export function isRequiredParameter(param: MethodParameter | Parameter): boolean
 }
 
 /** narrows type to a URIParameterType within the conditional block */
-export function isURIParameterType(type: type.PossibleType): type is URIParameterType {
+export function isURIParameterType(type: type.WireType): type is URIParameterType {
   switch (type.kind) {
     case 'constant':
     case 'scalar':
@@ -376,7 +376,7 @@ interface ParameterBase {
    * the parameter's type.
    * NOTE: if the type is a LiteralValue the style will either be literal or flag
    */
-  type: type.PossibleType;
+  type: type.WireType;
 
   /** kind will have value literal or flag when type is a LiteralValue (see above comment) */
   style: ParameterStyle;
@@ -392,7 +392,7 @@ interface ParameterBase {
 }
 
 class ParameterBase implements ParameterBase {
-  constructor(name: string, type: type.PossibleType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
+  constructor(name: string, type: type.WireType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     this.name = name;
     this.type = type;
     this.style = style;
@@ -406,7 +406,7 @@ class ParameterBase implements ParameterBase {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 export class BodyParameter extends ParameterBase implements BodyParameter {
-  constructor(name: string, bodyFormat: BodyFormat, contentType: string, type: type.PossibleType, style: ParameterStyle, byValue: boolean) {
+  constructor(name: string, bodyFormat: BodyFormat, contentType: string, type: type.WireType, style: ParameterStyle, byValue: boolean) {
     super(name, type, style, byValue, 'method');
     this.kind = 'bodyParam';
     this.bodyFormat = bodyFormat;
@@ -430,7 +430,7 @@ export class FormBodyCollectionParameter extends ParameterBase implements FormBo
 }
 
 export class FormBodyScalarParameter extends ParameterBase implements FormBodyScalarParameter {
-  constructor(name: string, formDataName: string, type: type.PossibleType, style: ParameterStyle, byValue: boolean) {
+  constructor(name: string, formDataName: string, type: type.WireType, style: ParameterStyle, byValue: boolean) {
     super(name, type, style, byValue, 'method');
     this.kind = 'formBodyScalarParam';
     this.formDataName = formDataName;
@@ -463,14 +463,14 @@ export class HeaderScalarParameter extends ParameterBase implements HeaderScalar
 }
 
 export class MultipartFormBodyParameter extends ParameterBase implements MultipartFormBodyParameter {
-  constructor(name: string, type: type.PossibleType, style: ParameterStyle, byValue: boolean) {
+  constructor(name: string, type: type.WireType, style: ParameterStyle, byValue: boolean) {
     super(name, type, style, byValue, 'method');
     this.kind = 'multipartFormBodyParam';
   }
 }
 
 export class Parameter extends ParameterBase implements Parameter {
-  constructor(name: string, type: type.PossibleType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
+  constructor(name: string, type: type.WireType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, style, byValue, location);
     this.kind = 'parameter';
   }
@@ -490,7 +490,7 @@ export class ParameterGroup implements ParameterGroup {
 }
 
 export class PartialBodyParameter extends ParameterBase implements PartialBodyParameter{
-  constructor(name: string, serializedName: string, format: 'JSON' | 'XML', type: type.PossibleType, style: ParameterStyle, byValue: boolean) {
+  constructor(name: string, serializedName: string, format: 'JSON' | 'XML', type: type.WireType, style: ParameterStyle, byValue: boolean) {
     super(name, type, style, byValue, 'method');
     this.kind = 'partialBodyParam';
     this.format = format;

--- a/packages/codemodel.go/src/result.ts
+++ b/packages/codemodel.go/src/result.ts
@@ -24,7 +24,7 @@ export interface AnyResult {
    * maps an HTTP status code to a result type.
    * status codes that don't return a schema will be absent.
    */
-  httpStatusCodeType: Record<number, type.PossibleType>;
+  httpStatusCodeType: Record<number, type.WireType>;
 
   /** the format in which the result is returned */
   format: ResultFormat;
@@ -207,7 +207,7 @@ export function getResultType(result: Result): type.Interface | type.Model | Mon
 }
 
 /** narrows type to a MonomorphicResultType within the conditional block */
-export function isMonomorphicResultType(type: type.PossibleType): type is MonomorphicResultType {
+export function isMonomorphicResultType(type: type.WireType): type is MonomorphicResultType {
   switch (type.kind) {
     case 'any':
     case 'constant':
@@ -228,7 +228,7 @@ export function isMonomorphicResultType(type: type.PossibleType): type is Monomo
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 export class AnyResult implements AnyResult {
-  constructor(fieldName: string, format: ResultFormat, resultTypes: Record<number, type.PossibleType>) {
+  constructor(fieldName: string, format: ResultFormat, resultTypes: Record<number, type.WireType>) {
     this.kind = 'anyResult';
     this.fieldName = fieldName;
     this.format = format;

--- a/packages/codemodel.go/src/type.ts
+++ b/packages/codemodel.go/src/type.ts
@@ -13,7 +13,7 @@ export interface Docs {
 }
 
 /** defines types that go across the wire */
-export type PossibleType = Any | Constant | EncodedBytes | Interface | Literal | Map | Model | PolymorphicModel | QualifiedType | RawJSON | Scalar | Slice | String | Time;
+export type WireType = Any | Constant | EncodedBytes | Interface | Literal | Map | Model | PolymorphicModel | QualifiedType | RawJSON | Scalar | Slice | String | Time;
 
 /** the Go any type */
 export interface Any {
@@ -124,7 +124,7 @@ export interface Map {
 }
 
 /** the set of map value types */
-export type MapValueType = PossibleType;
+export type MapValueType = WireType;
 
 /** a field within a model */
 export interface ModelField extends StructField {
@@ -227,7 +227,7 @@ export interface Slice {
 }
 
 /** the set of slice element types */
-export type SliceElementType = PossibleType;
+export type SliceElementType = WireType;
 
 /** a Go string */
 export interface String {
@@ -255,7 +255,7 @@ export interface StructField {
   docs: Docs;
 
   /** the field's underlying type */
-  type: PossibleType;
+  type: WireType;
 
   /** indicates if the field is pointer-to-type or not */
   byValue: boolean;
@@ -334,7 +334,7 @@ export function getLiteralTypeDeclaration(literal: LiteralType): string {
  * @param pkgName optional package name prefix for the type
  * @returns the Go type declaration
  */
-export function getTypeDeclaration(type: PossibleType, pkgName?: string): string {
+export function getTypeDeclaration(type: WireType, pkgName?: string): string {
   switch (type.kind) {
     case 'any':
     case 'string':
@@ -373,7 +373,7 @@ export function getTypeDeclaration(type: PossibleType, pkgName?: string): string
 }
 
 /** narrows type to a LiteralType within the conditional block */
-export function isLiteralValueType(type: PossibleType): type is LiteralType {
+export function isLiteralValueType(type: WireType): type is LiteralType {
   switch (type.kind) {
     case 'constant':
     case 'encodedBytes':
@@ -391,7 +391,7 @@ export function isLiteralValueType(type: PossibleType): type is LiteralType {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 export class StructField implements StructField {
-  constructor(name: string, type: PossibleType, byValue: boolean) {
+  constructor(name: string, type: WireType, byValue: boolean) {
     this.name = name;
     this.type = type;
     this.byValue = byValue;
@@ -468,7 +468,7 @@ export class EncodedBytes implements EncodedBytes {
 }
 
 export class Interface implements Interface {
-  // possibleTypes and rootType are required. however, we have a chicken-and-egg
+  // WireTypes and rootType are required. however, we have a chicken-and-egg
   // problem as creating a PolymorphicType requires the necessary InterfaceType.
   // so these fields MUST be populated after creating the InterfaceType.
   constructor(name: string, discriminatorField: string) {
@@ -506,7 +506,7 @@ export class ModelAnnotations implements ModelAnnotations {
 }
 
 export class ModelField extends StructField implements ModelField {
-  constructor(name: string, type: PossibleType, byValue: boolean, serializedName: string, annotations: ModelFieldAnnotations) {
+  constructor(name: string, type: WireType, byValue: boolean, serializedName: string, annotations: ModelFieldAnnotations) {
     super(name, type, byValue);
     this.serializedName = serializedName;
     this.annotations = annotations;


### PR DESCRIPTION
This will allow for future split between types that are used in the SDK but aren't sent across the wire.