### PR TITLE
Remove no-optional-body switch

### DIFF
--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -5,10 +5,7 @@
 ### Breaking Changes
 
 * Fixed some cases where a client name could stutter.
-
-### Other Changes
-
-* Added switch `no-optional-body` to make optional body parameters required.
+* Force the body paramter to be required for `PATCH` and `PUT` operations.
 
 ## 0.5.1 (2025-06-26)
 

--- a/packages/typespec-go/src/lib.ts
+++ b/packages/typespec-go/src/lib.ts
@@ -14,7 +14,6 @@ export interface GoEmitterOptions {
   'inject-spans'?: boolean;
   'module'?: string;
   'module-version'?: string;
-  'no-optional-body'?: boolean;
   'rawjson-as-bytes'?: boolean;
   'slice-elements-byval'?: boolean;
   'single-client'?: boolean;
@@ -71,11 +70,6 @@ const EmitterOptionsSchema: JSONSchemaType<GoEmitterOptions> = {
       type: 'string',
       nullable: true,
       description: 'Semantic version of the Go module without the leading \'v\' written to constants.go. (e.g. 1.2.3). When module-version is specified, module must also be specified.',
-    },
-    'no-optional-body': {
-      type: 'boolean',
-      nullable: true,
-      description: 'When true, optional body parameters are forced to be required. The default is false.'
     },
     'rawjson-as-bytes': {
       type: 'boolean',

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -408,7 +408,7 @@ export class clientAdapter {
             throw new AdapterError('UnsupportedTsp', `unsupported spread param content type ${contentType}`, opParam.__raw?.node ?? NoTarget);
         }
       } else {
-        adaptedParam = this.adaptMethodParameter(opParam);
+        adaptedParam = this.adaptMethodParameter(opParam, method.httpMethod);
       }
 
       adaptedParam.docs.summary = param.summary;
@@ -433,7 +433,7 @@ export class clientAdapter {
     // look for them in the operation parameters.
     for (const opParam of allOpParams) {
       if (opParam.onClient) {
-        const adaptedParam = this.adaptMethodParameter(opParam);
+        const adaptedParam = this.adaptMethodParameter(opParam, method.httpMethod);
         adaptedParam.docs.summary = opParam.summary;
         adaptedParam.docs.description = opParam.doc;
         method.parameters.unshift(adaptedParam);
@@ -476,7 +476,7 @@ export class clientAdapter {
     return contentType;
   }
 
-  private adaptMethodParameter(param: tcgc.SdkBodyParameter | tcgc.SdkHeaderParameter | tcgc.SdkPathParameter | tcgc.SdkQueryParameter | tcgc.SdkCookieParameter): go.MethodParameter {
+  private adaptMethodParameter(param: tcgc.SdkBodyParameter | tcgc.SdkHeaderParameter | tcgc.SdkPathParameter | tcgc.SdkQueryParameter | tcgc.SdkCookieParameter, verb: go.HTTPMethod): go.MethodParameter {
     if (param.isApiVersionParam && param.clientDefaultValue) {
       // we emit the api version param inline as a literal, never as a param.
       // the ClientOptions.APIVersion setting is used to change the version.
@@ -510,7 +510,7 @@ export class clientAdapter {
 
     let adaptedParam: go.MethodParameter;
     let paramStyle = this.adaptParameterStyle(param);
-    if (param.kind === 'body' && this.opts['no-optional-body'] === true) {
+    if (param.kind === 'body' && (verb === 'patch' || verb === 'put')) {
       paramStyle = 'required';
     }
     const paramName = getEscapedReservedName(ensureNameCase(param.name, paramStyle === 'required'), 'Param');

--- a/packages/typespec-go/test/http-specs/payload/jmergepatchgroup/fake/zz_jsonmergepatch_server.go
+++ b/packages/typespec-go/test/http-specs/payload/jmergepatchgroup/fake/zz_jsonmergepatch_server.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"jmergepatchgroup"
 	"net/http"
-	"reflect"
 )
 
 // JSONMergePatchServer is a fake server for instances of the jmergepatchgroup.JSONMergePatchClient type.
@@ -24,7 +23,7 @@ type JSONMergePatchServer struct {
 
 	// UpdateOptionalResource is the fake for method JSONMergePatchClient.UpdateOptionalResource
 	// HTTP status codes to indicate success: http.StatusOK
-	UpdateOptionalResource func(ctx context.Context, options *jmergepatchgroup.JSONMergePatchClientUpdateOptionalResourceOptions) (resp azfake.Responder[jmergepatchgroup.JSONMergePatchClientUpdateOptionalResourceResponse], errResp azfake.ErrorResponder)
+	UpdateOptionalResource func(ctx context.Context, body jmergepatchgroup.ResourcePatch, options *jmergepatchgroup.JSONMergePatchClientUpdateOptionalResourceOptions) (resp azfake.Responder[jmergepatchgroup.JSONMergePatchClientUpdateOptionalResourceResponse], errResp azfake.ErrorResponder)
 
 	// UpdateResource is the fake for method JSONMergePatchClient.UpdateResource
 	// HTTP status codes to indicate success: http.StatusOK
@@ -123,13 +122,7 @@ func (j *JSONMergePatchServerTransport) dispatchUpdateOptionalResource(req *http
 	if err != nil {
 		return nil, err
 	}
-	var options *jmergepatchgroup.JSONMergePatchClientUpdateOptionalResourceOptions
-	if !reflect.ValueOf(body).IsZero() {
-		options = &jmergepatchgroup.JSONMergePatchClientUpdateOptionalResourceOptions{
-			Body: &body,
-		}
-	}
-	respr, errRespr := j.srv.UpdateOptionalResource(req.Context(), options)
+	respr, errRespr := j.srv.UpdateOptionalResource(req.Context(), body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/typespec-go/test/http-specs/payload/jmergepatchgroup/jsonmergepatch_client_test.go
+++ b/packages/typespec-go/test/http-specs/payload/jmergepatchgroup/jsonmergepatch_client_test.go
@@ -76,8 +76,8 @@ func TestJsonMergePatchClient_CreateResource(t *testing.T) {
 func TestJsonMergePatchClient_UpdateOptionalResource(t *testing.T) {
 	client, err := jmergepatchgroup.NewJSONMergePatchClient(nil)
 	require.NoError(t, err)
-	resp, err := client.UpdateOptionalResource(context.Background(), &jmergepatchgroup.JSONMergePatchClientUpdateOptionalResourceOptions{
-		Body: &jmergepatchgroup.ResourcePatch{
+	resp, err := client.UpdateOptionalResource(context.Background(),
+		jmergepatchgroup.ResourcePatch{
 			Description: azcore.NullValue[*string](),
 			Map: map[string]*jmergepatchgroup.InnerModel{
 				"key": {
@@ -90,8 +90,7 @@ func TestJsonMergePatchClient_UpdateOptionalResource(t *testing.T) {
 			FloatValue: azcore.NullValue[*float32](),
 			InnerModel: azcore.NullValue[*jmergepatchgroup.InnerModel](),
 			IntArray:   azcore.NullValue[[]*int32](),
-		},
-	})
+		}, nil)
 	require.NoError(t, err)
 	require.Equal(t, jmergepatchgroup.Resource{
 		Name: to.Ptr("Madge"),

--- a/packages/typespec-go/test/http-specs/payload/jmergepatchgroup/zz_jsonmergepatch_client.go
+++ b/packages/typespec-go/test/http-specs/payload/jmergepatchgroup/zz_jsonmergepatch_client.go
@@ -72,13 +72,13 @@ func (client *JSONMergePatchClient) createResourceHandleResponse(resp *http.Resp
 // If the operation fails it returns an *azcore.ResponseError type.
 //   - options - JSONMergePatchClientUpdateOptionalResourceOptions contains the optional parameters for the JSONMergePatchClient.UpdateOptionalResource
 //     method.
-func (client *JSONMergePatchClient) UpdateOptionalResource(ctx context.Context, options *JSONMergePatchClientUpdateOptionalResourceOptions) (JSONMergePatchClientUpdateOptionalResourceResponse, error) {
+func (client *JSONMergePatchClient) UpdateOptionalResource(ctx context.Context, body ResourcePatch, options *JSONMergePatchClientUpdateOptionalResourceOptions) (JSONMergePatchClientUpdateOptionalResourceResponse, error) {
 	var err error
 	const operationName = "JSONMergePatchClient.UpdateOptionalResource"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.updateOptionalResourceCreateRequest(ctx, options)
+	req, err := client.updateOptionalResourceCreateRequest(ctx, body, options)
 	if err != nil {
 		return JSONMergePatchClientUpdateOptionalResourceResponse{}, err
 	}
@@ -95,19 +95,16 @@ func (client *JSONMergePatchClient) UpdateOptionalResource(ctx context.Context, 
 }
 
 // updateOptionalResourceCreateRequest creates the UpdateOptionalResource request.
-func (client *JSONMergePatchClient) updateOptionalResourceCreateRequest(ctx context.Context, options *JSONMergePatchClientUpdateOptionalResourceOptions) (*policy.Request, error) {
+func (client *JSONMergePatchClient) updateOptionalResourceCreateRequest(ctx context.Context, body ResourcePatch, _ *JSONMergePatchClientUpdateOptionalResourceOptions) (*policy.Request, error) {
 	urlPath := "/json-merge-patch/update/resource/optional"
 	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if options != nil && options.Body != nil {
-		req.Raw().Header["Content-Type"] = []string{"application/merge-patch+json"}
-		if err := runtime.MarshalAsJSON(req, *options.Body); err != nil {
-			return nil, err
-		}
-		return req, nil
+	req.Raw().Header["Content-Type"] = []string{"application/merge-patch+json"}
+	if err := runtime.MarshalAsJSON(req, body); err != nil {
+		return nil, err
 	}
 	return req, nil
 }

--- a/packages/typespec-go/test/http-specs/payload/jmergepatchgroup/zz_options.go
+++ b/packages/typespec-go/test/http-specs/payload/jmergepatchgroup/zz_options.go
@@ -13,7 +13,7 @@ type JSONMergePatchClientCreateResourceOptions struct {
 // JSONMergePatchClientUpdateOptionalResourceOptions contains the optional parameters for the JSONMergePatchClient.UpdateOptionalResource
 // method.
 type JSONMergePatchClientUpdateOptionalResourceOptions struct {
-	Body *ResourcePatch
+	// placeholder for future optional parameters
 }
 
 // JSONMergePatchClientUpdateResourceOptions contains the optional parameters for the JSONMergePatchClient.UpdateResource

--- a/packages/typespec-go/test/local/nooptionalbody/zz_options.go
+++ b/packages/typespec-go/test/local/nooptionalbody/zz_options.go
@@ -4,6 +4,16 @@
 
 package nooptionalbody
 
+// ClientPatchOptions contains the optional parameters for the Client.Patch method.
+type ClientPatchOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ClientPostOptions contains the optional parameters for the Client.Post method.
+type ClientPostOptions struct {
+	Body *Widget
+}
+
 // ClientPutOptions contains the optional parameters for the Client.Put method.
 type ClientPutOptions struct {
 	// placeholder for future optional parameters

--- a/packages/typespec-go/test/local/nooptionalbody/zz_responses.go
+++ b/packages/typespec-go/test/local/nooptionalbody/zz_responses.go
@@ -4,6 +4,16 @@
 
 package nooptionalbody
 
+// ClientPatchResponse contains the response from method Client.Patch.
+type ClientPatchResponse struct {
+	// placeholder for future response values
+}
+
+// ClientPostResponse contains the response from method Client.Post.
+type ClientPostResponse struct {
+	// placeholder for future response values
+}
+
 // ClientPutResponse contains the response from method Client.Put.
 type ClientPutResponse struct {
 	// placeholder for future response values

--- a/packages/typespec-go/test/tsp/NoOptionalBody/main.tsp
+++ b/packages/typespec-go/test/tsp/NoOptionalBody/main.tsp
@@ -13,5 +13,14 @@ model Widget {
   weight: int32;
 }
 
+/** body should not be optional */
+@patch
+op patch(@body body?: Widget): void;
+
+/** body should not be optional */
 @put
 op put(@body body?: Widget): void;
+
+/** body should be optional */
+@post
+op post(@body body?: Widget): void;


### PR DESCRIPTION
For PATCH and PUT, force body parameter to be required.

Addendum to https://github.com/Azure/autorest.go/pull/1630