### PR TITLE
Execute steps post code generation

### DIFF
--- a/packages/typespec-go/.scripts/tspcompile.js
+++ b/packages/typespec-go/.scripts/tspcompile.js
@@ -294,7 +294,6 @@ function generate(moduleName, input, outputDir, perTestOptions) {
         logResult(error, stdout, stderr);
         // format on success
         if (error === null) {
-          execSync('gofmt -w .', { cwd: fullOutputDir});
           // Force emitter version to a constant in _metadata.json to avoid unnecessary version drift in committed files
           const metadataPath = `${fullOutputDir}/testdata/_metadata.json`;
           if (existsSync(metadataPath)) {

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -7,6 +7,13 @@
 * Fixed some cases where a client name could stutter.
 * Force the body paramter to be required for `PATCH` and `PUT` operations.
 
+### Features Added
+
+* When Go tools are found on the path, the following steps happen after successfully generating code.
+  * Execute `gofmt -w .`.
+  * If `/internal/generate/transforms.go` exists in the output directory, `go run` it from the output directory.
+  * If Go tools are not found, the above steps are skipped and a warning is displayed.
+
 ## 0.5.1 (2025-06-26)
 
 ### Other Changes

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/templatesgroup/fake/zz_optionalbody_server.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/templatesgroup/fake/zz_optionalbody_server.go
@@ -26,7 +26,7 @@ type OptionalBodyServer struct {
 
 	// Patch is the fake for method OptionalBodyClient.Patch
 	// HTTP status codes to indicate success: http.StatusOK
-	Patch func(ctx context.Context, resourceGroupName string, widgetName string, options *templatesgroup.OptionalBodyClientPatchOptions) (resp azfake.Responder[templatesgroup.OptionalBodyClientPatchResponse], errResp azfake.ErrorResponder)
+	Patch func(ctx context.Context, resourceGroupName string, widgetName string, properties templatesgroup.Widget, options *templatesgroup.OptionalBodyClientPatchOptions) (resp azfake.Responder[templatesgroup.OptionalBodyClientPatchResponse], errResp azfake.ErrorResponder)
 
 	// Post is the fake for method OptionalBodyClient.Post
 	// HTTP status codes to indicate success: http.StatusOK
@@ -155,13 +155,7 @@ func (o *OptionalBodyServerTransport) dispatchPatch(req *http.Request) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	var options *templatesgroup.OptionalBodyClientPatchOptions
-	if !reflect.ValueOf(body).IsZero() {
-		options = &templatesgroup.OptionalBodyClientPatchOptions{
-			Properties: &body,
-		}
-	}
-	respr, errRespr := o.srv.Patch(req.Context(), resourceGroupNameParam, widgetNameParam, options)
+	respr, errRespr := o.srv.Patch(req.Context(), resourceGroupNameParam, widgetNameParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/templatesgroup/zz_optionalbody_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/templatesgroup/zz_optionalbody_client.go
@@ -109,14 +109,15 @@ func (client *OptionalBodyClient) getHandleResponse(resp *http.Response) (Option
 // Generated from API version 2023-12-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - widgetName - The name of the Widget
+//   - properties - The resource properties to be updated.
 //   - options - OptionalBodyClientPatchOptions contains the optional parameters for the OptionalBodyClient.Patch method.
-func (client *OptionalBodyClient) Patch(ctx context.Context, resourceGroupName string, widgetName string, options *OptionalBodyClientPatchOptions) (OptionalBodyClientPatchResponse, error) {
+func (client *OptionalBodyClient) Patch(ctx context.Context, resourceGroupName string, widgetName string, properties Widget, options *OptionalBodyClientPatchOptions) (OptionalBodyClientPatchResponse, error) {
 	var err error
 	const operationName = "OptionalBodyClient.Patch"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.patchCreateRequest(ctx, resourceGroupName, widgetName, options)
+	req, err := client.patchCreateRequest(ctx, resourceGroupName, widgetName, properties, options)
 	if err != nil {
 		return OptionalBodyClientPatchResponse{}, err
 	}
@@ -133,7 +134,7 @@ func (client *OptionalBodyClient) Patch(ctx context.Context, resourceGroupName s
 }
 
 // patchCreateRequest creates the Patch request.
-func (client *OptionalBodyClient) patchCreateRequest(ctx context.Context, resourceGroupName string, widgetName string, options *OptionalBodyClientPatchOptions) (*policy.Request, error) {
+func (client *OptionalBodyClient) patchCreateRequest(ctx context.Context, resourceGroupName string, widgetName string, properties Widget, _ *OptionalBodyClientPatchOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Azure.ResourceManager.OperationTemplates/widgets/{widgetName}"
 	if client.subscriptionID == "" {
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
@@ -155,12 +156,9 @@ func (client *OptionalBodyClient) patchCreateRequest(ctx context.Context, resour
 	reqQP.Set("api-version", "2023-12-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if options != nil && options.Properties != nil {
-		req.Raw().Header["Content-Type"] = []string{"application/json"}
-		if err := runtime.MarshalAsJSON(req, *options.Properties); err != nil {
-			return nil, err
-		}
-		return req, nil
+	req.Raw().Header["Content-Type"] = []string{"application/json"}
+	if err := runtime.MarshalAsJSON(req, properties); err != nil {
+		return nil, err
 	}
 	return req, nil
 }

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/templatesgroup/zz_options.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/templatesgroup/zz_options.go
@@ -46,8 +46,7 @@ type OptionalBodyClientGetOptions struct {
 
 // OptionalBodyClientPatchOptions contains the optional parameters for the OptionalBodyClient.Patch method.
 type OptionalBodyClientPatchOptions struct {
-	// The resource properties to be updated.
-	Properties *Widget
+	// placeholder for future optional parameters
 }
 
 // OptionalBodyClientPostOptions contains the optional parameters for the OptionalBodyClient.Post method.

--- a/packages/typespec-go/test/local/nooptionalbody/internal/generate/transforms.go
+++ b/packages/typespec-go/test/local/nooptionalbody/internal/generate/transforms.go
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package main
+
+import (
+	"log"
+	"os"
+	"regexp"
+)
+
+func regexReplace(fileName string, regex string, replace string) {
+	file, err := os.ReadFile(fileName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	r := regexp.MustCompile(regex)
+	file = r.ReplaceAll(file, []byte(replace))
+
+	err = os.WriteFile(fileName, file, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func main() {
+	regexReplace("zz_models.go", `REQUIRED`, "REQUIRED (transformed)")
+}

--- a/packages/typespec-go/test/local/nooptionalbody/zz_models.go
+++ b/packages/typespec-go/test/local/nooptionalbody/zz_models.go
@@ -5,6 +5,6 @@
 package nooptionalbody
 
 type Widget struct {
-	// REQUIRED
+	// REQUIRED (transformed)
 	Weight *int32
 }


### PR DESCRIPTION
Format and run the transforms program when available after successfully emitting code.
Regenerate some missing content.