### PR TITLE
Smarter renaming of the options parameter

### DIFF
--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Other Changes
 
 * Non-ARM clients always have an `endpoint` field.
+* Only rename the `options` parameter when it collides with another required parameter with the same name.
 
 ## 0.7.0 (2025-07-17)
 

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -293,9 +293,9 @@ export class clientAdapter {
       optionalParamsGroupName = uncapitalize(optionalParamsGroupName);
     }
     let optsGroupName = 'options';
-    // if there's an existing parameter with the name options then pick something else
+    // if there's an existing required parameter with the name options then pick something else
     for (const param of sdkMethod.parameters) {
-      if (param.name === optsGroupName) {
+      if (!param.optional && param.name === optsGroupName) {
         optsGroupName = 'opts';
         break;
       }

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -293,7 +293,8 @@ export class clientAdapter {
       optionalParamsGroupName = uncapitalize(optionalParamsGroupName);
     }
     let optsGroupName = 'options';
-    // if there's an existing required parameter with the name options then pick something else
+    // if there's an existing required parameter with the name options then pick something else.
+    // optional params will be inside the options type, so they can never collide.
     for (const param of sdkMethod.parameters) {
       if (!param.optional && param.name === optsGroupName) {
         optsGroupName = 'opts';


### PR DESCRIPTION
Only rename it when it collides with a required parameter with the same name (it will never collide with an optional parameter).