### PR TITLE
Improved generic client doc comment

### DIFF
--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Non-ARM clients always have an `endpoint` field.
 * Only rename the `options` parameter when it collides with another required parameter with the same name.
+* Improve generic doc comment for clients when the name is simply `Client`.
 
 ## 0.7.0 (2025-07-17)
 

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -79,10 +79,13 @@ export class clientAdapter {
       docs.summary = `${clientName} - ${docs.summary}`;
     } else if (docs.description) {
       docs.description = `${clientName} - ${docs.description}`;
-    } else {
+    } else if (clientName.length > 6) {
       // strip clientName's "Client" suffix
       const groupName = clientName.substring(0, clientName.length - 6);
       docs.summary = `${clientName} contains the methods for the ${groupName} group.`;
+    } else {
+      // the client name is simply "Client"
+      docs.summary = `${clientName} contains the methods for the service.`;
     }
 
     const goClient = new go.Client(clientName, docs, go.newClientOptions(this.ta.codeModel.type, clientName));

--- a/packages/typespec-go/test/local/armlargeinstance/zz_client.go
+++ b/packages/typespec-go/test/local/armlargeinstance/zz_client.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 )
 
-// Client contains the methods for the group.
+// Client contains the methods for the service.
 // Don't use this type directly, use NewClient() instead.
 type Client struct {
 	internal       *arm.Client

--- a/packages/typespec-go/test/local/armrandom/zz_client.go
+++ b/packages/typespec-go/test/local/armrandom/zz_client.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 )
 
-// Client contains the methods for the group.
+// Client contains the methods for the service.
 // Don't use this type directly, use NewClient() instead.
 type Client struct {
 	internal       *arm.Client

--- a/packages/typespec-go/test/local/nooptionalbody/zz_client.go
+++ b/packages/typespec-go/test/local/nooptionalbody/zz_client.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 )
 
-// Client contains the methods for the group.
+// Client contains the methods for the service.
 // Don't use this type directly, use a constructor function instead.
 type Client struct {
 	internal *azcore.Client


### PR DESCRIPTION
Don't remove the "Client" suffix when the client name is "Client".