### PR TITLE
Change unpopulate to restore null sentinel values from JSON null

### DIFF
--- a/packages/autorest.go/test/acr/azacr/zz_models_serde.go
+++ b/packages/autorest.go/test/acr/azacr/zz_models_serde.go
@@ -1509,8 +1509,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/additionalpropsgroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/additionalpropsgroup/zz_models_serde.go
@@ -325,8 +325,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/arraygroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/arraygroup/zz_models_serde.go
@@ -53,8 +53,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/azurespecialsgroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/azurespecialsgroup/zz_models_serde.go
@@ -53,8 +53,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/complexgroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/complexgroup/zz_models_serde.go
@@ -1138,8 +1138,12 @@ func populateByteArray[T any](m map[string]any, k string, b []T, convert func() 
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/complexmodelgroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/complexmodelgroup/zz_models_serde.go
@@ -173,8 +173,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/dictionarygroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/dictionarygroup/zz_models_serde.go
@@ -53,8 +53,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/errorsgroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/errorsgroup/zz_models_serde.go
@@ -80,8 +80,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/extenumsgroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/extenumsgroup/zz_models_serde.go
@@ -57,8 +57,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/httpinfrastructuregroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/httpinfrastructuregroup/zz_models_serde.go
@@ -134,8 +134,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/lrogroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/lrogroup/zz_models_serde.go
@@ -193,8 +193,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/mediatypesgroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/mediatypesgroup/zz_models_serde.go
@@ -49,8 +49,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/mediatypesgroupwithnormailzedoperationname/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/mediatypesgroupwithnormailzedoperationname/zz_models_serde.go
@@ -49,8 +49,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/migroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/migroup/zz_models_serde.go
@@ -193,8 +193,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/noopsgroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/noopsgroup/zz_models_serde.go
@@ -53,8 +53,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/optionalgroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/optionalgroup/zz_models_serde.go
@@ -269,8 +269,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/paginggroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/paginggroup/zz_models_serde.go
@@ -231,8 +231,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/stringgroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/stringgroup/zz_models_serde.go
@@ -53,8 +53,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/validationgroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/validationgroup/zz_models_serde.go
@@ -139,8 +139,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/autorest/xmlgroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/zz_models_serde.go
@@ -415,8 +415,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_models_serde.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_models_serde.go
@@ -17053,8 +17053,12 @@ func populateAny(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_models_serde.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_models_serde.go
@@ -4391,8 +4391,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_models_serde.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_models_serde.go
@@ -5909,8 +5909,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/keyvault/azkeyvault/zz_models_serde.go
+++ b/packages/autorest.go/test/keyvault/azkeyvault/zz_models_serde.go
@@ -4542,8 +4542,12 @@ func populateByteArray[T any](m map[string]any, k string, b []T, convert func() 
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_models_serde.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_models_serde.go
@@ -14543,8 +14543,12 @@ func populateAny(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/maps/azalias/zz_models_serde.go
+++ b/packages/autorest.go/test/maps/azalias/zz_models_serde.go
@@ -706,8 +706,12 @@ func populateAny(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/misc/azarrayofrawjson/zz_models_serde.go
+++ b/packages/autorest.go/test/misc/azarrayofrawjson/zz_models_serde.go
@@ -49,8 +49,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_models_serde.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_models_serde.go
@@ -33190,8 +33190,12 @@ func populateAny(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/storage/azblob/zz_models_serde.go
+++ b/packages/autorest.go/test/storage/azblob/zz_models_serde.go
@@ -454,8 +454,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/synapse/azartifacts/zz_models_serde.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_models_serde.go
@@ -51143,8 +51143,12 @@ func populateAny(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/synapse/azspark/zz_models_serde.go
+++ b/packages/autorest.go/test/synapse/azspark/zz_models_serde.go
@@ -971,8 +971,12 @@ func populateAny(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/autorest.go/test/tables/aztables/zz_models_serde.go
+++ b/packages/autorest.go/test/tables/aztables/zz_models_serde.go
@@ -306,8 +306,12 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v any) error {
-	if data == nil || string(data) == "null" {
+func unpopulate[T any](data json.RawMessage, fn string, v *T) error {
+	if data == nil {
+		return nil
+	}
+	if string(data) == "null" && v != nil {
+		*v = azcore.NullValue[T]()
 		return nil
 	}
 	if err := json.Unmarshal(data, v); err != nil {

--- a/packages/codegen.go/src/models.ts
+++ b/packages/codegen.go/src/models.ts
@@ -114,8 +114,12 @@ export async function generateModels(codeModel: go.CodeModel): Promise<ModelsSer
   }
   if (needsJSONUnpopulate) {
     serdeImports.add('fmt');
-    serdeTextBody += 'func unpopulate(data json.RawMessage, fn string, v any) error {\n';
-    serdeTextBody += '\tif data == nil || string(data) == "null" {\n';
+    serdeTextBody += 'func unpopulate[T any](data json.RawMessage, fn string, v *T) error {\n';
+    serdeTextBody += '\tif data == nil {\n';
+    serdeTextBody += '\t\treturn nil\n';
+    serdeTextBody += '\t}\n';
+    serdeTextBody += '\tif string(data) == "null" && v != nil {\n';
+    serdeTextBody += '\t\t*v = azcore.NullValue[T]()\n';
     serdeTextBody += '\t\treturn nil\n';
     serdeTextBody += '\t}\n';
     serdeTextBody += '\tif err := json.Unmarshal(data, v); err != nil {\n';


### PR DESCRIPTION
Currently in Autorest-generated Go code, the `populate` function [detects a null sentinel value](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore#IsNullValue) and encodes it as a JSON "null" value.

However, the `unpopulate` function does not do the reverse.  When it detects a JSON "null" value, it leaves the destination value unchanged instead of restoring it to the null sentinel value.  Consequently code that relies on `unpopulate` cannot distinguish between the absence of a field in a request or response body and it being provided with a "null" value.

I understand this may be irrelevant for clients, but my team is also using the generated code in a Resource Provider (just `models.go` and `models_serde.go`) and this issue is impeding our ability to properly handle JSON Merge Patch requests.

I have modified `models.ts` to generate an `unpopulate` function that sets the target value to the null sentinel value for JSON "null" values.  If there are backward-compatibility concerns with this change, perhaps it could be gated behind a new configuration option?

Note: This pull request is merely a suggested start.  I may need some guidance to bring it up to acceptable quality.

