### PR TITLE
Report NameCollision diagnostic for duplicate const values

### DIFF
--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Other Changes
 
 * Updated the minimum version of `azcore` to `v1.19.0`.
+* Report a `NameCollision` diagnostic if two `const` values have the same name.
 
 ## 0.8.0 (2025-08-12)
 


### PR DESCRIPTION
This will require the tsp author to explicitly define the names.