### PR TITLE
Use method param data as source of truth

### DIFF
--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.8.1 (unreleased)
 
+### Bugs Fixed
+
+* Fixed some edge cases where a method parameter's optionality wasn't correctly handled.
+
 ### Other Changes
 
 * Updated the minimum version of `azcore` to `v1.19.0`.

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -5,7 +5,7 @@
 
 import { values } from '@azure-tools/linq';
 import * as tcgc from '@azure-tools/typespec-client-generator-core';
-import { NoTarget } from '@typespec/compiler';
+import { ModelProperty, NoTarget } from '@typespec/compiler';
 import * as go from '../../../codemodel.go/src/index.js';
 import { capitalize, createOptionsTypeDescription, createResponseEnvelopeDescription, ensureNameCase, getEscapedReservedName, uncapitalize } from '../../../naming.go/src/naming.js';
 import { AdapterError } from './errors.js';
@@ -397,7 +397,9 @@ export class clientAdapter {
         // a flag which isn't what we want. so, we mark it as required. we ONLY do this
         // if the content-type is a constant (i.e. literal value).
         // the content-type will be conditionally set based on the requiredness of the body.
-        opParam.optional = false;
+        // NOTE: we set this on the corresponding method param as it's used when adapting the style.
+        // header param will only have one corresponding method param.
+        opParam.correspondingMethodParams[0].optional = false;
       }
 
       let adaptedParam: go.MethodParameter;
@@ -517,104 +519,120 @@ export class clientAdapter {
   /**
    * adapts the provided operation parameter to a Go method parameter
    * 
-   * @param param the operation parameter to adapt
+   * @param opParam the operation parameter to adapt
    * @param verb the HTTP verb used for the operation to which the parameter belongs
    * @returns the adapted Go method parameter
    */
-  private adaptMethodParameter(param: tcgc.SdkBodyParameter | tcgc.SdkCookieParameter | tcgc.SdkHeaderParameter | tcgc.SdkPathParameter | tcgc.SdkQueryParameter, verb: go.HTTPMethod): go.MethodParameter {
-    if (param.isApiVersionParam && param.clientDefaultValue) {
+  private adaptMethodParameter(opParam: tcgc.SdkBodyParameter | tcgc.SdkCookieParameter | tcgc.SdkHeaderParameter | tcgc.SdkPathParameter | tcgc.SdkQueryParameter, verb: go.HTTPMethod): go.MethodParameter {
+    if (opParam.isApiVersionParam && opParam.clientDefaultValue) {
       // we emit the api version param inline as a literal, never as a param.
       // the ClientOptions.APIVersion setting is used to change the version.
-      const paramType = new go.Literal(new go.String(), param.clientDefaultValue);
-      switch (param.kind) {
+      const paramType = new go.Literal(new go.String(), opParam.clientDefaultValue);
+      switch (opParam.kind) {
         case 'header':
-          return new go.HeaderScalarParameter(param.name, param.serializedName, paramType, 'literal', true, 'method');
+          return new go.HeaderScalarParameter(opParam.name, opParam.serializedName, paramType, 'literal', true, 'method');
         case 'path':
-          return new go.PathScalarParameter(param.name, param.serializedName, true, paramType, 'literal', true, 'method');
+          return new go.PathScalarParameter(opParam.name, opParam.serializedName, true, paramType, 'literal', true, 'method');
         case 'query':
-          return new go.QueryScalarParameter(param.name, param.serializedName, true, paramType, 'literal', true, 'method');
+          return new go.QueryScalarParameter(opParam.name, opParam.serializedName, true, paramType, 'literal', true, 'method');
         default:
-          throw new AdapterError('UnsupportedTsp', `unsupported API version param kind ${param.kind}`, param.__raw?.node ?? NoTarget);
+          throw new AdapterError('UnsupportedTsp', `unsupported API version param kind ${opParam.kind}`, opParam.__raw?.node ?? NoTarget);
       }
     }
 
     let location: go.ParameterLocation = 'method';
-    const getClientParamsKey = function (param: tcgc.SdkBodyParameter | tcgc.SdkCookieParameter | tcgc.SdkHeaderParameter | tcgc.SdkPathParameter | tcgc.SdkQueryParameter): string {
+    const getClientParamsKey = function (opParam: tcgc.SdkBodyParameter | tcgc.SdkCookieParameter | tcgc.SdkHeaderParameter | tcgc.SdkPathParameter | tcgc.SdkQueryParameter): string {
       // include the param kind in the key name as a client param can be used
       // in different places across methods (path/query)
-      return `${param.name}-${param.kind}`;
+      return `${opParam.name}-${opParam.kind}`;
     };
-    if (param.onClient) {
+
+    // note that client params only show up in the operation
+    // params which is why we check opParam.onClient.
+    if (opParam.onClient) {
       // check if we've already adapted this client parameter
-      const clientParam = this.clientParams.get(getClientParamsKey(param));
+      const clientParam = this.clientParams.get(getClientParamsKey(opParam));
       if (clientParam) {
         return clientParam;
       }
       location = 'client';
     }
 
-    let paramStyle = this.adaptParameterStyle(param);
-    if (param.kind === 'body' && (verb === 'patch' || verb === 'put')) {
+    // we use the operation param's corresponding method
+    // param as the source of truth during adaptation.
+    // however, note that some things are only on the
+    // operation param.
+    if (opParam.correspondingMethodParams.length > 1) {
+      // this is only applicable to spread params
+      // which should have been handled earlier.
+      // so, if we get here, we have a bug elsewhere
+      throw new AdapterError('InternalError', `unexpected correspondingMethodParams.length of ${opParam.correspondingMethodParams.length}`, opParam.__raw?.node ?? NoTarget);
+    }
+
+    const methodParam = opParam.correspondingMethodParams[0];
+
+    let paramStyle = this.adaptParameterStyle(methodParam);
+    if (opParam.kind === 'body' && (verb === 'patch' || verb === 'put')) {
       paramStyle = 'required';
     }
-    const paramName = getEscapedReservedName(ensureNameCase(param.name, paramStyle === 'required'), 'Param');
-    const byVal = isTypePassedByValue(param.type);
+    const paramName = getEscapedReservedName(ensureNameCase(methodParam.name, paramStyle === 'required'), 'Param');
+    const byVal = isTypePassedByValue(methodParam.type);
 
     let adaptedParam: go.MethodParameter;
-    switch (param.kind) {
+    switch (opParam.kind) {
       case 'body':
         // TODO: form data? (non-multipart)
-        if (param.defaultContentType.match(/multipart/i)) {
-          adaptedParam = new go.MultipartFormBodyParameter(paramName, this.ta.getWireType(param.type, false, true), paramStyle, byVal);
+        if (opParam.defaultContentType.match(/multipart/i)) {
+          adaptedParam = new go.MultipartFormBodyParameter(paramName, this.ta.getWireType(methodParam.type, false, true), paramStyle, byVal);
         } else {
-          const contentType = this.adaptContentType(param.defaultContentType);
-          let bodyType = this.ta.getWireType(param.type, false, true);
+          const contentType = this.adaptContentType(opParam.defaultContentType);
+          let bodyType = this.ta.getWireType(methodParam.type, false, true);
           if (contentType === 'binary') {
             // tcgc models binary params as 'bytes' but we want an io.ReadSeekCloser
-            bodyType = this.ta.getReadSeekCloser(param.type.kind === 'array');
+            bodyType = this.ta.getReadSeekCloser(methodParam.type.kind === 'array');
           }
-          adaptedParam = new go.BodyParameter(paramName, contentType, `"${param.defaultContentType}"`, bodyType, paramStyle, byVal);
+          adaptedParam = new go.BodyParameter(paramName, contentType, `"${opParam.defaultContentType}"`, bodyType, paramStyle, byVal);
         }
         break;
       case 'cookie':
         // TODO: currently we don't have Azure service using cookie parameter. need to add support if needed in the future.
-        throw new AdapterError('UnsupportedTsp', 'unsupported parameter type cookie', param.__raw?.node ?? NoTarget);
+        throw new AdapterError('UnsupportedTsp', 'unsupported parameter type cookie', opParam.__raw?.node ?? NoTarget);
       case 'header':
-        if (param.collectionFormat) {
-          if (param.collectionFormat === 'multi' || param.collectionFormat === 'form') {
-            throw new AdapterError('InternalError', `unexpected collection format ${param.collectionFormat} for HeaderCollectionParameter`, param.__raw?.node ?? NoTarget);
+        if (opParam.collectionFormat) {
+          if (opParam.collectionFormat === 'multi' || opParam.collectionFormat === 'form') {
+            throw new AdapterError('InternalError', `unexpected collection format ${opParam.collectionFormat} for HeaderCollectionParameter`, opParam.__raw?.node ?? NoTarget);
           }
           // TODO: is hard-coded false for element type by value correct?
-          const type = this.ta.getWireType(param.type, true, false);
+          const type = this.ta.getWireType(methodParam.type, true, false);
           if (type.kind !== 'slice') {
-            throw new AdapterError('InternalError', `unexpected type ${go.getTypeDeclaration(type)} for HeaderCollectionParameter ${param.name}`, param.__raw?.node ?? NoTarget);
+            throw new AdapterError('InternalError', `unexpected type ${go.getTypeDeclaration(type)} for HeaderCollectionParameter ${methodParam.name}`, opParam.__raw?.node ?? NoTarget);
           }
-          adaptedParam = new go.HeaderCollectionParameter(paramName, param.serializedName, type, param.collectionFormat === 'simple' ? 'csv' : param.collectionFormat, paramStyle, byVal, location);
+          adaptedParam = new go.HeaderCollectionParameter(paramName, opParam.serializedName, type, opParam.collectionFormat === 'simple' ? 'csv' : opParam.collectionFormat, paramStyle, byVal, location);
         } else {
-          adaptedParam = new go.HeaderScalarParameter(paramName, param.serializedName, this.adaptHeaderScalarType(param.type, true), paramStyle, byVal, location);
+          adaptedParam = new go.HeaderScalarParameter(paramName, opParam.serializedName, this.adaptHeaderScalarType(methodParam.type, true), paramStyle, byVal, location);
         }
         break;
       case 'path':
-        adaptedParam = new go.PathScalarParameter(paramName, param.serializedName, !param.allowReserved, this.adaptPathScalarParameterType(param.type), paramStyle, byVal, location);
+        adaptedParam = new go.PathScalarParameter(paramName, opParam.serializedName, !opParam.allowReserved, this.adaptPathScalarParameterType(methodParam.type), paramStyle, byVal, location);
         break;
       case 'query':
-        if (param.collectionFormat) {
-          const type = this.ta.getWireType(param.type, true, false);
+        if (opParam.collectionFormat) {
+          const type = this.ta.getWireType(methodParam.type, true, false);
           if (type.kind !== 'slice') {
-            throw new AdapterError('InternalError', `unexpected type ${go.getTypeDeclaration(type)} for QueryCollectionParameter ${param.name}`, param.__raw?.node ?? NoTarget);
+            throw new AdapterError('InternalError', `unexpected type ${go.getTypeDeclaration(type)} for QueryCollectionParameter ${methodParam.name}`, opParam.__raw?.node ?? NoTarget);
           }
           // TODO: unencoded query param
-          adaptedParam = new go.QueryCollectionParameter(paramName, param.serializedName, true, type, param.collectionFormat === 'simple' ? 'csv' : (param.collectionFormat === 'form' ? 'multi' : param.collectionFormat), paramStyle, byVal, location);
+          adaptedParam = new go.QueryCollectionParameter(paramName, opParam.serializedName, true, type, opParam.collectionFormat === 'simple' ? 'csv' : (opParam.collectionFormat === 'form' ? 'multi' : opParam.collectionFormat), paramStyle, byVal, location);
         } else {
           // TODO: unencoded query param
-          adaptedParam = new go.QueryScalarParameter(paramName, param.serializedName, true, this.adaptQueryScalarParameterType(param.type), paramStyle, byVal, location);
+          adaptedParam = new go.QueryScalarParameter(paramName, opParam.serializedName, true, this.adaptQueryScalarParameterType(methodParam.type), paramStyle, byVal, location);
         }
         break;
     }
 
     if (adaptedParam.location === 'client') {
       // track client parameter for later use
-      this.clientParams.set(getClientParamsKey(param), adaptedParam);
+      this.clientParams.set(getClientParamsKey(opParam), adaptedParam);
     }
 
     return adaptedParam;
@@ -865,7 +883,7 @@ export class clientAdapter {
     throw new AdapterError('InternalError', `unexpected query scalar parameter type ${sdkType.kind}`, sdkType.__raw?.node ?? NoTarget);
   }
 
-  private adaptParameterStyle(param: tcgc.SdkBodyParameter | tcgc.SdkEndpointParameter | tcgc.SdkHeaderParameter | tcgc.SdkMethodParameter | tcgc.SdkPathParameter | tcgc.SdkQueryParameter | tcgc.SdkCookieParameter): go.ParameterStyle {
+  private adaptParameterStyle(param: ParameterStyleInfo): go.ParameterStyle {
     // NOTE: must check for constant type first as it will also set clientDefaultValue
     if (param.type.kind === 'constant') {
       if (param.optional) {
@@ -1063,3 +1081,12 @@ interface HttpStatusCodeRange {
 function isHttpStatusCodeRange(statusCode: HttpStatusCodeRange | number): statusCode is HttpStatusCodeRange {
   return (<HttpStatusCodeRange>statusCode).start !== undefined;
 }
+
+/** contains the common set of param info needed to adapt the parameter's style */
+interface ParameterStyleInfo {
+  __raw?: ModelProperty;
+  clientDefaultValue?: unknown;
+  name: string;
+  optional: boolean;
+  type: tcgc.SdkType;
+};

--- a/packages/typespec-go/test/local/azkeys/fake/zz_server.go
+++ b/packages/typespec-go/test/local/azkeys/fake/zz_server.go
@@ -22,35 +22,39 @@ import (
 type Server struct {
 	// BackupKey is the fake for method Client.BackupKey
 	// HTTP status codes to indicate success: http.StatusOK
-	BackupKey func(ctx context.Context, keyName string, options *azkeys.BackupKeyOptions) (resp azfake.Responder[azkeys.BackupKeyResponse], errResp azfake.ErrorResponder)
+	BackupKey func(ctx context.Context, name string, options *azkeys.BackupKeyOptions) (resp azfake.Responder[azkeys.BackupKeyResponse], errResp azfake.ErrorResponder)
 
 	// CreateKey is the fake for method Client.CreateKey
 	// HTTP status codes to indicate success: http.StatusOK
-	CreateKey func(ctx context.Context, keyName string, parameters azkeys.CreateKeyParameters, options *azkeys.CreateKeyOptions) (resp azfake.Responder[azkeys.CreateKeyResponse], errResp azfake.ErrorResponder)
+	CreateKey func(ctx context.Context, name string, parameters azkeys.CreateKeyParameters, options *azkeys.CreateKeyOptions) (resp azfake.Responder[azkeys.CreateKeyResponse], errResp azfake.ErrorResponder)
 
 	// Decrypt is the fake for method Client.Decrypt
 	// HTTP status codes to indicate success: http.StatusOK
-	Decrypt func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeyOperationParameters, options *azkeys.DecryptOptions) (resp azfake.Responder[azkeys.DecryptResponse], errResp azfake.ErrorResponder)
+	Decrypt func(ctx context.Context, name string, version string, parameters azkeys.KeyOperationParameters, options *azkeys.DecryptOptions) (resp azfake.Responder[azkeys.DecryptResponse], errResp azfake.ErrorResponder)
 
 	// DeleteKey is the fake for method Client.DeleteKey
 	// HTTP status codes to indicate success: http.StatusOK
-	DeleteKey func(ctx context.Context, keyName string, options *azkeys.DeleteKeyOptions) (resp azfake.Responder[azkeys.DeleteKeyResponse], errResp azfake.ErrorResponder)
+	DeleteKey func(ctx context.Context, name string, options *azkeys.DeleteKeyOptions) (resp azfake.Responder[azkeys.DeleteKeyResponse], errResp azfake.ErrorResponder)
 
 	// Encrypt is the fake for method Client.Encrypt
 	// HTTP status codes to indicate success: http.StatusOK
-	Encrypt func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeyOperationParameters, options *azkeys.EncryptOptions) (resp azfake.Responder[azkeys.EncryptResponse], errResp azfake.ErrorResponder)
+	Encrypt func(ctx context.Context, name string, version string, parameters azkeys.KeyOperationParameters, options *azkeys.EncryptOptions) (resp azfake.Responder[azkeys.EncryptResponse], errResp azfake.ErrorResponder)
 
 	// GetDeletedKey is the fake for method Client.GetDeletedKey
 	// HTTP status codes to indicate success: http.StatusOK
-	GetDeletedKey func(ctx context.Context, keyName string, options *azkeys.GetDeletedKeyOptions) (resp azfake.Responder[azkeys.GetDeletedKeyResponse], errResp azfake.ErrorResponder)
+	GetDeletedKey func(ctx context.Context, name string, options *azkeys.GetDeletedKeyOptions) (resp azfake.Responder[azkeys.GetDeletedKeyResponse], errResp azfake.ErrorResponder)
 
 	// GetKey is the fake for method Client.GetKey
 	// HTTP status codes to indicate success: http.StatusOK
-	GetKey func(ctx context.Context, keyName string, keyVersion string, options *azkeys.GetKeyOptions) (resp azfake.Responder[azkeys.GetKeyResponse], errResp azfake.ErrorResponder)
+	GetKey func(ctx context.Context, name string, version string, options *azkeys.GetKeyOptions) (resp azfake.Responder[azkeys.GetKeyResponse], errResp azfake.ErrorResponder)
+
+	// GetKeyAttestation is the fake for method Client.GetKeyAttestation
+	// HTTP status codes to indicate success: http.StatusOK
+	GetKeyAttestation func(ctx context.Context, name string, version string, options *azkeys.GetKeyAttestationOptions) (resp azfake.Responder[azkeys.GetKeyAttestationResponse], errResp azfake.ErrorResponder)
 
 	// GetKeyRotationPolicy is the fake for method Client.GetKeyRotationPolicy
 	// HTTP status codes to indicate success: http.StatusOK
-	GetKeyRotationPolicy func(ctx context.Context, keyName string, options *azkeys.GetKeyRotationPolicyOptions) (resp azfake.Responder[azkeys.GetKeyRotationPolicyResponse], errResp azfake.ErrorResponder)
+	GetKeyRotationPolicy func(ctx context.Context, name string, options *azkeys.GetKeyRotationPolicyOptions) (resp azfake.Responder[azkeys.GetKeyRotationPolicyResponse], errResp azfake.ErrorResponder)
 
 	// GetRandomBytes is the fake for method Client.GetRandomBytes
 	// HTTP status codes to indicate success: http.StatusOK
@@ -58,7 +62,7 @@ type Server struct {
 
 	// ImportKey is the fake for method Client.ImportKey
 	// HTTP status codes to indicate success: http.StatusOK
-	ImportKey func(ctx context.Context, keyName string, parameters azkeys.ImportKeyParameters, options *azkeys.ImportKeyOptions) (resp azfake.Responder[azkeys.ImportKeyResponse], errResp azfake.ErrorResponder)
+	ImportKey func(ctx context.Context, name string, parameters azkeys.ImportKeyParameters, options *azkeys.ImportKeyOptions) (resp azfake.Responder[azkeys.ImportKeyResponse], errResp azfake.ErrorResponder)
 
 	// NewListDeletedKeyPropertiesPager is the fake for method Client.NewListDeletedKeyPropertiesPager
 	// HTTP status codes to indicate success: http.StatusOK
@@ -70,19 +74,19 @@ type Server struct {
 
 	// NewListKeyPropertiesVersionsPager is the fake for method Client.NewListKeyPropertiesVersionsPager
 	// HTTP status codes to indicate success: http.StatusOK
-	NewListKeyPropertiesVersionsPager func(keyName string, options *azkeys.ListKeyPropertiesVersionsOptions) (resp azfake.PagerResponder[azkeys.ListKeyPropertiesVersionsResponse])
+	NewListKeyPropertiesVersionsPager func(name string, options *azkeys.ListKeyPropertiesVersionsOptions) (resp azfake.PagerResponder[azkeys.ListKeyPropertiesVersionsResponse])
 
 	// PurgeDeletedKey is the fake for method Client.PurgeDeletedKey
 	// HTTP status codes to indicate success: http.StatusNoContent
-	PurgeDeletedKey func(ctx context.Context, keyName string, options *azkeys.PurgeDeletedKeyOptions) (resp azfake.Responder[azkeys.PurgeDeletedKeyResponse], errResp azfake.ErrorResponder)
+	PurgeDeletedKey func(ctx context.Context, name string, options *azkeys.PurgeDeletedKeyOptions) (resp azfake.Responder[azkeys.PurgeDeletedKeyResponse], errResp azfake.ErrorResponder)
 
 	// RecoverDeletedKey is the fake for method Client.RecoverDeletedKey
 	// HTTP status codes to indicate success: http.StatusOK
-	RecoverDeletedKey func(ctx context.Context, keyName string, options *azkeys.RecoverDeletedKeyOptions) (resp azfake.Responder[azkeys.RecoverDeletedKeyResponse], errResp azfake.ErrorResponder)
+	RecoverDeletedKey func(ctx context.Context, name string, options *azkeys.RecoverDeletedKeyOptions) (resp azfake.Responder[azkeys.RecoverDeletedKeyResponse], errResp azfake.ErrorResponder)
 
 	// Release is the fake for method Client.Release
 	// HTTP status codes to indicate success: http.StatusOK
-	Release func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.ReleaseParameters, options *azkeys.ReleaseOptions) (resp azfake.Responder[azkeys.ReleaseResponse], errResp azfake.ErrorResponder)
+	Release func(ctx context.Context, name string, version string, parameters azkeys.ReleaseParameters, options *azkeys.ReleaseOptions) (resp azfake.Responder[azkeys.ReleaseResponse], errResp azfake.ErrorResponder)
 
 	// RestoreKey is the fake for method Client.RestoreKey
 	// HTTP status codes to indicate success: http.StatusOK
@@ -90,31 +94,31 @@ type Server struct {
 
 	// RotateKey is the fake for method Client.RotateKey
 	// HTTP status codes to indicate success: http.StatusOK
-	RotateKey func(ctx context.Context, keyName string, options *azkeys.RotateKeyOptions) (resp azfake.Responder[azkeys.RotateKeyResponse], errResp azfake.ErrorResponder)
+	RotateKey func(ctx context.Context, name string, options *azkeys.RotateKeyOptions) (resp azfake.Responder[azkeys.RotateKeyResponse], errResp azfake.ErrorResponder)
 
 	// Sign is the fake for method Client.Sign
 	// HTTP status codes to indicate success: http.StatusOK
-	Sign func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.SignParameters, options *azkeys.SignOptions) (resp azfake.Responder[azkeys.SignResponse], errResp azfake.ErrorResponder)
+	Sign func(ctx context.Context, name string, version string, parameters azkeys.SignParameters, options *azkeys.SignOptions) (resp azfake.Responder[azkeys.SignResponse], errResp azfake.ErrorResponder)
 
 	// UnwrapKey is the fake for method Client.UnwrapKey
 	// HTTP status codes to indicate success: http.StatusOK
-	UnwrapKey func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeyOperationParameters, options *azkeys.UnwrapKeyOptions) (resp azfake.Responder[azkeys.UnwrapKeyResponse], errResp azfake.ErrorResponder)
+	UnwrapKey func(ctx context.Context, name string, version string, parameters azkeys.KeyOperationParameters, options *azkeys.UnwrapKeyOptions) (resp azfake.Responder[azkeys.UnwrapKeyResponse], errResp azfake.ErrorResponder)
 
 	// UpdateKey is the fake for method Client.UpdateKey
 	// HTTP status codes to indicate success: http.StatusOK
-	UpdateKey func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.UpdateKeyParameters, options *azkeys.UpdateKeyOptions) (resp azfake.Responder[azkeys.UpdateKeyResponse], errResp azfake.ErrorResponder)
+	UpdateKey func(ctx context.Context, name string, version string, parameters azkeys.UpdateKeyParameters, options *azkeys.UpdateKeyOptions) (resp azfake.Responder[azkeys.UpdateKeyResponse], errResp azfake.ErrorResponder)
 
 	// UpdateKeyRotationPolicy is the fake for method Client.UpdateKeyRotationPolicy
 	// HTTP status codes to indicate success: http.StatusOK
-	UpdateKeyRotationPolicy func(ctx context.Context, keyName string, keyRotationPolicy azkeys.KeyRotationPolicy, options *azkeys.UpdateKeyRotationPolicyOptions) (resp azfake.Responder[azkeys.UpdateKeyRotationPolicyResponse], errResp azfake.ErrorResponder)
+	UpdateKeyRotationPolicy func(ctx context.Context, name string, keyRotationPolicy azkeys.KeyRotationPolicy, options *azkeys.UpdateKeyRotationPolicyOptions) (resp azfake.Responder[azkeys.UpdateKeyRotationPolicyResponse], errResp azfake.ErrorResponder)
 
 	// Verify is the fake for method Client.Verify
 	// HTTP status codes to indicate success: http.StatusOK
-	Verify func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.VerifyParameters, options *azkeys.VerifyOptions) (resp azfake.Responder[azkeys.VerifyResponse], errResp azfake.ErrorResponder)
+	Verify func(ctx context.Context, name string, version string, parameters azkeys.VerifyParameters, options *azkeys.VerifyOptions) (resp azfake.Responder[azkeys.VerifyResponse], errResp azfake.ErrorResponder)
 
 	// WrapKey is the fake for method Client.WrapKey
 	// HTTP status codes to indicate success: http.StatusOK
-	WrapKey func(ctx context.Context, keyName string, keyVersion string, parameters azkeys.KeyOperationParameters, options *azkeys.WrapKeyOptions) (resp azfake.Responder[azkeys.WrapKeyResponse], errResp azfake.ErrorResponder)
+	WrapKey func(ctx context.Context, name string, version string, parameters azkeys.KeyOperationParameters, options *azkeys.WrapKeyOptions) (resp azfake.Responder[azkeys.WrapKeyResponse], errResp azfake.ErrorResponder)
 }
 
 // NewServerTransport creates a new instance of ServerTransport with the provided implementation.
@@ -175,6 +179,8 @@ func (s *ServerTransport) dispatchToMethodFake(req *http.Request, method string)
 				res.resp, res.err = s.dispatchGetDeletedKey(req)
 			case "Client.GetKey":
 				res.resp, res.err = s.dispatchGetKey(req)
+			case "Client.GetKeyAttestation":
+				res.resp, res.err = s.dispatchGetKeyAttestation(req)
 			case "Client.GetKeyRotationPolicy":
 				res.resp, res.err = s.dispatchGetKeyRotationPolicy(req)
 			case "Client.GetRandomBytes":
@@ -238,11 +244,11 @@ func (s *ServerTransport) dispatchBackupKey(req *http.Request) (*http.Response, 
 	if len(matches) < 2 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.BackupKey(req.Context(), keyNameParam, nil)
+	respr, errRespr := s.srv.BackupKey(req.Context(), nameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -271,11 +277,11 @@ func (s *ServerTransport) dispatchCreateKey(req *http.Request) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.CreateKey(req.Context(), keyNameParam, body, nil)
+	respr, errRespr := s.srv.CreateKey(req.Context(), nameParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -304,15 +310,15 @@ func (s *ServerTransport) dispatchDecrypt(req *http.Request) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	keyVersionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
+	versionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.Decrypt(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.Decrypt(req.Context(), nameParam, versionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -337,11 +343,11 @@ func (s *ServerTransport) dispatchDeleteKey(req *http.Request) (*http.Response, 
 	if len(matches) < 2 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.DeleteKey(req.Context(), keyNameParam, nil)
+	respr, errRespr := s.srv.DeleteKey(req.Context(), nameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -370,15 +376,15 @@ func (s *ServerTransport) dispatchEncrypt(req *http.Request) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	keyVersionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
+	versionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.Encrypt(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.Encrypt(req.Context(), nameParam, versionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -403,11 +409,11 @@ func (s *ServerTransport) dispatchGetDeletedKey(req *http.Request) (*http.Respon
 	if len(matches) < 2 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.GetDeletedKey(req.Context(), keyNameParam, nil)
+	respr, errRespr := s.srv.GetDeletedKey(req.Context(), nameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -432,15 +438,48 @@ func (s *ServerTransport) dispatchGetKey(req *http.Request) (*http.Response, err
 	if len(matches) < 3 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	keyVersionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
+	versionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.GetKey(req.Context(), keyNameParam, keyVersionParam, nil)
+	respr, errRespr := s.srv.GetKey(req.Context(), nameParam, versionParam, nil)
+	if respErr := server.GetError(errRespr, req); respErr != nil {
+		return nil, respErr
+	}
+	respContent := server.GetResponseContent(respr)
+	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
+		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
+	}
+	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).KeyBundle, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (s *ServerTransport) dispatchGetKeyAttestation(req *http.Request) (*http.Response, error) {
+	if s.srv.GetKeyAttestation == nil {
+		return nil, &nonRetriableError{errors.New("fake for method GetKeyAttestation not implemented")}
+	}
+	const regexStr = `/keys/(?P<key_name>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/(?P<key_version>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/attestation`
+	regex := regexp.MustCompile(regexStr)
+	matches := regex.FindStringSubmatch(req.URL.EscapedPath())
+	if len(matches) < 3 {
+		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
+	}
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	if err != nil {
+		return nil, err
+	}
+	versionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
+	if err != nil {
+		return nil, err
+	}
+	respr, errRespr := s.srv.GetKeyAttestation(req.Context(), nameParam, versionParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -465,11 +504,11 @@ func (s *ServerTransport) dispatchGetKeyRotationPolicy(req *http.Request) (*http
 	if len(matches) < 2 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.GetKeyRotationPolicy(req.Context(), keyNameParam, nil)
+	respr, errRespr := s.srv.GetKeyRotationPolicy(req.Context(), nameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -521,11 +560,11 @@ func (s *ServerTransport) dispatchImportKey(req *http.Request) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.ImportKey(req.Context(), keyNameParam, body, nil)
+	respr, errRespr := s.srv.ImportKey(req.Context(), nameParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -606,11 +645,11 @@ func (s *ServerTransport) dispatchNewListKeyPropertiesVersionsPager(req *http.Re
 		if len(matches) < 2 {
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
-		keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+		nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 		if err != nil {
 			return nil, err
 		}
-		resp := s.srv.NewListKeyPropertiesVersionsPager(keyNameParam, nil)
+		resp := s.srv.NewListKeyPropertiesVersionsPager(nameParam, nil)
 		newListKeyPropertiesVersionsPager = &resp
 		s.newListKeyPropertiesVersionsPager.add(req, newListKeyPropertiesVersionsPager)
 		server.PagerResponderInjectNextLinks(newListKeyPropertiesVersionsPager, req, func(page *azkeys.ListKeyPropertiesVersionsResponse, createLink func() string) {
@@ -641,11 +680,11 @@ func (s *ServerTransport) dispatchPurgeDeletedKey(req *http.Request) (*http.Resp
 	if len(matches) < 2 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.PurgeDeletedKey(req.Context(), keyNameParam, nil)
+	respr, errRespr := s.srv.PurgeDeletedKey(req.Context(), nameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -670,11 +709,11 @@ func (s *ServerTransport) dispatchRecoverDeletedKey(req *http.Request) (*http.Re
 	if len(matches) < 2 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.RecoverDeletedKey(req.Context(), keyNameParam, nil)
+	respr, errRespr := s.srv.RecoverDeletedKey(req.Context(), nameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -703,15 +742,15 @@ func (s *ServerTransport) dispatchRelease(req *http.Request) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	keyVersionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
+	versionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.Release(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.Release(req.Context(), nameParam, versionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -759,11 +798,11 @@ func (s *ServerTransport) dispatchRotateKey(req *http.Request) (*http.Response, 
 	if len(matches) < 2 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.RotateKey(req.Context(), keyNameParam, nil)
+	respr, errRespr := s.srv.RotateKey(req.Context(), nameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -792,15 +831,15 @@ func (s *ServerTransport) dispatchSign(req *http.Request) (*http.Response, error
 	if err != nil {
 		return nil, err
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	keyVersionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
+	versionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.Sign(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.Sign(req.Context(), nameParam, versionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -829,15 +868,15 @@ func (s *ServerTransport) dispatchUnwrapKey(req *http.Request) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	keyVersionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
+	versionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.UnwrapKey(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.UnwrapKey(req.Context(), nameParam, versionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -866,15 +905,15 @@ func (s *ServerTransport) dispatchUpdateKey(req *http.Request) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	keyVersionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
+	versionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.UpdateKey(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.UpdateKey(req.Context(), nameParam, versionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -903,11 +942,11 @@ func (s *ServerTransport) dispatchUpdateKeyRotationPolicy(req *http.Request) (*h
 	if err != nil {
 		return nil, err
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.UpdateKeyRotationPolicy(req.Context(), keyNameParam, body, nil)
+	respr, errRespr := s.srv.UpdateKeyRotationPolicy(req.Context(), nameParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -936,15 +975,15 @@ func (s *ServerTransport) dispatchVerify(req *http.Request) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	keyVersionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
+	versionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.Verify(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.Verify(req.Context(), nameParam, versionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -973,15 +1012,15 @@ func (s *ServerTransport) dispatchWrapKey(req *http.Request) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
-	keyNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
+	nameParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_name")])
 	if err != nil {
 		return nil, err
 	}
-	keyVersionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
+	versionParam, err := url.PathUnescape(matches[regex.SubexpIndex("key_version")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.WrapKey(req.Context(), keyNameParam, keyVersionParam, body, nil)
+	respr, errRespr := s.srv.WrapKey(req.Context(), nameParam, versionParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/typespec-go/test/local/azkeys/testdata/_metadata.json
+++ b/packages/typespec-go/test/local/azkeys/testdata/_metadata.json
@@ -1,4 +1,4 @@
 {
-  "apiVersion": "7.6-preview.1",
+  "apiVersion": "2025-06-01-preview",
   "emitterVersion": "0.0.0"
 }

--- a/packages/typespec-go/test/local/azkeys/zz_client.go
+++ b/packages/typespec-go/test/local/azkeys/zz_client.go
@@ -15,8 +15,7 @@ import (
 	"strings"
 )
 
-// Client - The key vault client performs cryptographic key operations and vault operations
-// against the Key Vault service.
+// Client - The key vault client performs cryptographic key operations and vault operations against the Key Vault service.
 // Don't use this type directly, use a constructor function instead.
 type Client struct {
 	internal     *azcore.Client
@@ -25,31 +24,26 @@ type Client struct {
 
 // BackupKey - Requests that a backup of the specified key be downloaded to the client.
 //
-// The Key Backup operation exports a key from Azure Key Vault in a protected
-// form. Note that this operation does NOT return key material in a form that can
-// be used outside the Azure Key Vault system, the returned key material is either
-// protected to a Azure Key Vault HSM or to Azure Key Vault itself. The intent of
-// this operation is to allow a client to GENERATE a key in one Azure Key Vault
-// instance, BACKUP the key, and then RESTORE it into another Azure Key Vault
-// instance. The BACKUP operation may be used to export, in protected form, any
-// key type from Azure Key Vault. Individual versions of a key cannot be backed
-// up. BACKUP / RESTORE can be performed within geographical boundaries only;
-// meaning that a BACKUP from one geographical area cannot be restored to another
-// geographical area. For example, a backup from the US geographical area cannot
-// be restored in an EU geographical area. This operation requires the key/backup
-// permission.
+// The Key Backup operation exports a key from Azure Key Vault in a protected form. Note that this operation does NOT return
+// key material in a form that can be used outside the Azure Key Vault system, the returned key material is either protected
+// to a Azure Key Vault HSM or to Azure Key Vault itself. The intent of this operation is to allow a client to GENERATE a
+// key in one Azure Key Vault instance, BACKUP the key, and then RESTORE it into another Azure Key Vault instance. The BACKUP
+// operation may be used to export, in protected form, any key type from Azure Key Vault. Individual versions of a key cannot
+// be backed up. BACKUP / RESTORE can be performed within geographical boundaries only; meaning that a BACKUP from one geographical
+// area cannot be restored to another geographical area. For example, a backup from the US geographical area cannot be restored
+// in an EU geographical area. This operation requires the key/backup permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key.
 //   - options - BackupKeyOptions contains the optional parameters for the Client.BackupKey method.
-func (client *Client) BackupKey(ctx context.Context, keyName string, options *BackupKeyOptions) (BackupKeyResponse, error) {
+func (client *Client) BackupKey(ctx context.Context, name string, options *BackupKeyOptions) (BackupKeyResponse, error) {
 	var err error
 	const operationName = "Client.BackupKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.backupKeyCreateRequest(ctx, keyName, options)
+	req, err := client.backupKeyCreateRequest(ctx, name, options)
 	if err != nil {
 		return BackupKeyResponse{}, err
 	}
@@ -66,18 +60,18 @@ func (client *Client) BackupKey(ctx context.Context, keyName string, options *Ba
 }
 
 // backupKeyCreateRequest creates the BackupKey request.
-func (client *Client) backupKeyCreateRequest(ctx context.Context, keyName string, _ *BackupKeyOptions) (*policy.Request, error) {
+func (client *Client) backupKeyCreateRequest(ctx context.Context, name string, _ *BackupKeyOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}/backup"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -92,28 +86,25 @@ func (client *Client) backupKeyHandleResponse(resp *http.Response) (BackupKeyRes
 	return result, nil
 }
 
-// CreateKey - Creates a new key, stores it, then returns key parameters and attributes to the
-// client.
+// CreateKey - Creates a new key, stores it, then returns key parameters and attributes to the client.
 //
-// The create key operation can be used to create any key type in Azure Key Vault.
-// If the named key already exists, Azure Key Vault creates a new version of the
-// key. It requires the keys/create permission.
+// The create key operation can be used to create any key type in Azure Key Vault. If the named key already exists, Azure
+// Key Vault creates a new version of the key. It requires the keys/create permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name for the new key. The system will generate the version name for the new
-//     key. The value you provide may be copied globally for the purpose of running
-//     the service. The value provided should not include personally identifiable or
+// Generated from API version 2025-06-01-preview
+//   - name - The name for the new key. The system will generate the version name for the new key. The value you provide may be
+//     copied globally for the purpose of running the service. The value provided should not include personally identifiable or
 //     sensitive information.
 //   - parameters - The parameters to create a key.
 //   - options - CreateKeyOptions contains the optional parameters for the Client.CreateKey method.
-func (client *Client) CreateKey(ctx context.Context, keyName string, parameters CreateKeyParameters, options *CreateKeyOptions) (CreateKeyResponse, error) {
+func (client *Client) CreateKey(ctx context.Context, name string, parameters CreateKeyParameters, options *CreateKeyOptions) (CreateKeyResponse, error) {
 	var err error
 	const operationName = "Client.CreateKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.createKeyCreateRequest(ctx, keyName, parameters, options)
+	req, err := client.createKeyCreateRequest(ctx, name, parameters, options)
 	if err != nil {
 		return CreateKeyResponse{}, err
 	}
@@ -130,18 +121,18 @@ func (client *Client) CreateKey(ctx context.Context, keyName string, parameters 
 }
 
 // createKeyCreateRequest creates the CreateKey request.
-func (client *Client) createKeyCreateRequest(ctx context.Context, keyName string, parameters CreateKeyParameters, _ *CreateKeyOptions) (*policy.Request, error) {
+func (client *Client) createKeyCreateRequest(ctx context.Context, name string, parameters CreateKeyParameters, _ *CreateKeyOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}/create"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -162,31 +153,26 @@ func (client *Client) createKeyHandleResponse(resp *http.Response) (CreateKeyRes
 
 // Decrypt - Decrypts a single block of encrypted data.
 //
-// The DECRYPT operation decrypts a well-formed block of ciphertext using the
-// target encryption key and specified algorithm. This operation is the reverse of
-// the ENCRYPT operation; only a single block of data may be decrypted, the size
-// of this block is dependent on the target key and the algorithm to be used. The
-// DECRYPT operation applies to asymmetric and symmetric keys stored in Azure Key
-// Vault since it uses the private portion of the key. This operation requires the
-// keys/decrypt permission. Microsoft recommends not to use CBC algorithms for
-// decryption without first ensuring the integrity of the ciphertext using an
-// HMAC, for example. See
-// https://docs.microsoft.com/dotnet/standard/security/vulnerabilities-cbc-mode
-// for more information.
+// The DECRYPT operation decrypts a well-formed block of ciphertext using the target encryption key and specified algorithm.
+// This operation is the reverse of the ENCRYPT operation; only a single block of data may be decrypted, the size of this
+// block is dependent on the target key and the algorithm to be used. The DECRYPT operation applies to asymmetric and symmetric
+// keys stored in Azure Key Vault since it uses the private portion of the key. This operation requires the keys/decrypt permission.
+// Microsoft recommends not to use CBC algorithms for decryption without first ensuring the integrity of the ciphertext using
+// an HMAC, for example. See https://learn.microsoft.com/dotnet/standard/security/vulnerabilities-cbc-mode for more information.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key.
-//   - keyVersion - The version of the key.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key.
+//   - version - The version of the key.
 //   - parameters - The parameters for the decryption operation.
 //   - options - DecryptOptions contains the optional parameters for the Client.Decrypt method.
-func (client *Client) Decrypt(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, options *DecryptOptions) (DecryptResponse, error) {
+func (client *Client) Decrypt(ctx context.Context, name string, version string, parameters KeyOperationParameters, options *DecryptOptions) (DecryptResponse, error) {
 	var err error
 	const operationName = "Client.Decrypt"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.decryptCreateRequest(ctx, keyName, keyVersion, parameters, options)
+	req, err := client.decryptCreateRequest(ctx, name, version, parameters, options)
 	if err != nil {
 		return DecryptResponse{}, err
 	}
@@ -203,22 +189,22 @@ func (client *Client) Decrypt(ctx context.Context, keyName string, keyVersion st
 }
 
 // decryptCreateRequest creates the Decrypt request.
-func (client *Client) decryptCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, _ *DecryptOptions) (*policy.Request, error) {
+func (client *Client) decryptCreateRequest(ctx context.Context, name string, version string, parameters KeyOperationParameters, _ *DecryptOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}/{key-version}/decrypt"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
-	if keyVersion == "" {
-		return nil, errors.New("parameter keyVersion cannot be empty")
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
+	if version == "" {
+		return nil, errors.New("parameter version cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(keyVersion))
+	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(version))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -239,22 +225,21 @@ func (client *Client) decryptHandleResponse(resp *http.Response) (DecryptRespons
 
 // DeleteKey - Deletes a key of any type from storage in Azure Key Vault.
 //
-// The delete key operation cannot be used to remove individual versions of a key.
-// This operation removes the cryptographic material associated with the key,
-// which means the key is not usable for Sign/Verify, Wrap/Unwrap or
-// Encrypt/Decrypt operations. This operation requires the keys/delete permission.
+// The delete key operation cannot be used to remove individual versions of a key. This operation removes the cryptographic
+// material associated with the key, which means the key is not usable for Sign/Verify, Wrap/Unwrap or Encrypt/Decrypt operations.
+// This operation requires the keys/delete permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key to delete.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key to delete.
 //   - options - DeleteKeyOptions contains the optional parameters for the Client.DeleteKey method.
-func (client *Client) DeleteKey(ctx context.Context, keyName string, options *DeleteKeyOptions) (DeleteKeyResponse, error) {
+func (client *Client) DeleteKey(ctx context.Context, name string, options *DeleteKeyOptions) (DeleteKeyResponse, error) {
 	var err error
 	const operationName = "Client.DeleteKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.deleteKeyCreateRequest(ctx, keyName, options)
+	req, err := client.deleteKeyCreateRequest(ctx, name, options)
 	if err != nil {
 		return DeleteKeyResponse{}, err
 	}
@@ -271,18 +256,18 @@ func (client *Client) DeleteKey(ctx context.Context, keyName string, options *De
 }
 
 // deleteKeyCreateRequest creates the DeleteKey request.
-func (client *Client) deleteKeyCreateRequest(ctx context.Context, keyName string, _ *DeleteKeyOptions) (*policy.Request, error) {
+func (client *Client) deleteKeyCreateRequest(ctx context.Context, name string, _ *DeleteKeyOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -297,32 +282,28 @@ func (client *Client) deleteKeyHandleResponse(resp *http.Response) (DeleteKeyRes
 	return result, nil
 }
 
-// Encrypt - Encrypts an arbitrary sequence of bytes using an encryption key that is stored
-// in a key vault.
+// Encrypt - Encrypts an arbitrary sequence of bytes using an encryption key that is stored in a key vault.
 //
-// The ENCRYPT operation encrypts an arbitrary sequence of bytes using an
-// encryption key that is stored in Azure Key Vault. Note that the ENCRYPT
-// operation only supports a single block of data, the size of which is dependent
-// on the target key and the encryption algorithm to be used. The ENCRYPT
-// operation is only strictly necessary for symmetric keys stored in Azure Key
-// Vault since protection with an asymmetric key can be performed using public
-// portion of the key. This operation is supported for asymmetric keys as a
-// convenience for callers that have a key-reference but do not have access to the
-// public key material. This operation requires the keys/encrypt permission.
+// The ENCRYPT operation encrypts an arbitrary sequence of bytes using an encryption key that is stored in Azure Key Vault.
+// Note that the ENCRYPT operation only supports a single block of data, the size of which is dependent on the target key
+// and the encryption algorithm to be used. The ENCRYPT operation is only strictly necessary for symmetric keys stored in
+// Azure Key Vault since protection with an asymmetric key can be performed using public portion of the key. This operation
+// is supported for asymmetric keys as a convenience for callers that have a key-reference but do not have access to the public
+// key material. This operation requires the keys/encrypt permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key.
-//   - keyVersion - The version of the key.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key.
+//   - version - The version of the key.
 //   - parameters - The parameters for the encryption operation.
 //   - options - EncryptOptions contains the optional parameters for the Client.Encrypt method.
-func (client *Client) Encrypt(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, options *EncryptOptions) (EncryptResponse, error) {
+func (client *Client) Encrypt(ctx context.Context, name string, version string, parameters KeyOperationParameters, options *EncryptOptions) (EncryptResponse, error) {
 	var err error
 	const operationName = "Client.Encrypt"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.encryptCreateRequest(ctx, keyName, keyVersion, parameters, options)
+	req, err := client.encryptCreateRequest(ctx, name, version, parameters, options)
 	if err != nil {
 		return EncryptResponse{}, err
 	}
@@ -339,22 +320,22 @@ func (client *Client) Encrypt(ctx context.Context, keyName string, keyVersion st
 }
 
 // encryptCreateRequest creates the Encrypt request.
-func (client *Client) encryptCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, _ *EncryptOptions) (*policy.Request, error) {
+func (client *Client) encryptCreateRequest(ctx context.Context, name string, version string, parameters KeyOperationParameters, _ *EncryptOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}/{key-version}/encrypt"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
-	if keyVersion == "" {
-		return nil, errors.New("parameter keyVersion cannot be empty")
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
+	if version == "" {
+		return nil, errors.New("parameter version cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(keyVersion))
+	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(version))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -375,22 +356,20 @@ func (client *Client) encryptHandleResponse(resp *http.Response) (EncryptRespons
 
 // GetDeletedKey - Gets the public part of a deleted key.
 //
-// The Get Deleted Key operation is applicable for soft-delete enabled vaults.
-// While the operation can be invoked on any vault, it will return an error if
-// invoked on a non soft-delete enabled vault. This operation requires the
-// keys/get permission.
+// The Get Deleted Key operation is applicable for soft-delete enabled vaults. While the operation can be invoked on any vault,
+// it will return an error if invoked on a non soft-delete enabled vault. This operation requires the keys/get permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key.
 //   - options - GetDeletedKeyOptions contains the optional parameters for the Client.GetDeletedKey method.
-func (client *Client) GetDeletedKey(ctx context.Context, keyName string, options *GetDeletedKeyOptions) (GetDeletedKeyResponse, error) {
+func (client *Client) GetDeletedKey(ctx context.Context, name string, options *GetDeletedKeyOptions) (GetDeletedKeyResponse, error) {
 	var err error
 	const operationName = "Client.GetDeletedKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.getDeletedKeyCreateRequest(ctx, keyName, options)
+	req, err := client.getDeletedKeyCreateRequest(ctx, name, options)
 	if err != nil {
 		return GetDeletedKeyResponse{}, err
 	}
@@ -407,18 +386,18 @@ func (client *Client) GetDeletedKey(ctx context.Context, keyName string, options
 }
 
 // getDeletedKeyCreateRequest creates the GetDeletedKey request.
-func (client *Client) getDeletedKeyCreateRequest(ctx context.Context, keyName string, _ *GetDeletedKeyOptions) (*policy.Request, error) {
+func (client *Client) getDeletedKeyCreateRequest(ctx context.Context, name string, _ *GetDeletedKeyOptions) (*policy.Request, error) {
 	urlPath := "/deletedkeys/{key-name}"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -435,24 +414,22 @@ func (client *Client) getDeletedKeyHandleResponse(resp *http.Response) (GetDelet
 
 // GetKey - Gets the public part of a stored key.
 //
-// The get key operation is applicable to all key types. If the requested key is
-// symmetric, then no key material is released in the response. This operation
-// requires the keys/get permission.
+// The get key operation is applicable to all key types. If the requested key is symmetric, then no key material is released
+// in the response. This operation requires the keys/get permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key to get.
-//   - keyVersion - Adding the version parameter retrieves a specific version of a key. This URI
-//     fragment is optional. If not specified, the latest version of the key is
-//     returned.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key to get.
+//   - version - Adding the version parameter retrieves a specific version of a key. This URI fragment is optional. If not specified,
+//     the latest version of the key is returned.
 //   - options - GetKeyOptions contains the optional parameters for the Client.GetKey method.
-func (client *Client) GetKey(ctx context.Context, keyName string, keyVersion string, options *GetKeyOptions) (GetKeyResponse, error) {
+func (client *Client) GetKey(ctx context.Context, name string, version string, options *GetKeyOptions) (GetKeyResponse, error) {
 	var err error
 	const operationName = "Client.GetKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.getKeyCreateRequest(ctx, keyName, keyVersion, options)
+	req, err := client.getKeyCreateRequest(ctx, name, version, options)
 	if err != nil {
 		return GetKeyResponse{}, err
 	}
@@ -469,22 +446,22 @@ func (client *Client) GetKey(ctx context.Context, keyName string, keyVersion str
 }
 
 // getKeyCreateRequest creates the GetKey request.
-func (client *Client) getKeyCreateRequest(ctx context.Context, keyName string, keyVersion string, _ *GetKeyOptions) (*policy.Request, error) {
+func (client *Client) getKeyCreateRequest(ctx context.Context, name string, version string, _ *GetKeyOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}/{key-version}"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
-	if keyVersion == "" {
-		return nil, errors.New("parameter keyVersion cannot be empty")
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
+	if version == "" {
+		return nil, errors.New("parameter version cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(keyVersion))
+	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(version))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -499,22 +476,86 @@ func (client *Client) getKeyHandleResponse(resp *http.Response) (GetKeyResponse,
 	return result, nil
 }
 
-// GetKeyRotationPolicy - Lists the policy for a key.
+// GetKeyAttestation - Gets the public part of a stored key along with its attestation blob.
 //
-// The GetKeyRotationPolicy operation returns the specified key policy resources
-// in the specified key vault. This operation requires the keys/get permission.
+// The get key attestation operation returns the key along with its attestation blob. This operation requires the keys/get
+// permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key in a given key vault.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key to retrieve attestation for.
+//   - version - Adding the version parameter retrieves attestation blob for specific version of a key. This URI fragment is optional.
+//     If not specified, the latest version of the key attestation blob is returned.
+//   - options - GetKeyAttestationOptions contains the optional parameters for the Client.GetKeyAttestation method.
+func (client *Client) GetKeyAttestation(ctx context.Context, name string, version string, options *GetKeyAttestationOptions) (GetKeyAttestationResponse, error) {
+	var err error
+	const operationName = "Client.GetKeyAttestation"
+	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
+	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
+	req, err := client.getKeyAttestationCreateRequest(ctx, name, version, options)
+	if err != nil {
+		return GetKeyAttestationResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return GetKeyAttestationResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
+		err = runtime.NewResponseError(httpResp)
+		return GetKeyAttestationResponse{}, err
+	}
+	resp, err := client.getKeyAttestationHandleResponse(httpResp)
+	return resp, err
+}
+
+// getKeyAttestationCreateRequest creates the GetKeyAttestation request.
+func (client *Client) getKeyAttestationCreateRequest(ctx context.Context, name string, version string, _ *GetKeyAttestationOptions) (*policy.Request, error) {
+	urlPath := "/keys/{key-name}/{key-version}/attestation"
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
+	if version == "" {
+		return nil, errors.New("parameter version cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(version))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2025-06-01-preview")
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
+}
+
+// getKeyAttestationHandleResponse handles the GetKeyAttestation response.
+func (client *Client) getKeyAttestationHandleResponse(resp *http.Response) (GetKeyAttestationResponse, error) {
+	result := GetKeyAttestationResponse{}
+	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
+		return GetKeyAttestationResponse{}, err
+	}
+	return result, nil
+}
+
+// GetKeyRotationPolicy - Lists the policy for a key.
+//
+// The GetKeyRotationPolicy operation returns the specified key policy resources in the specified key vault. This operation
+// requires the keys/get permission.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key in a given key vault.
 //   - options - GetKeyRotationPolicyOptions contains the optional parameters for the Client.GetKeyRotationPolicy method.
-func (client *Client) GetKeyRotationPolicy(ctx context.Context, keyName string, options *GetKeyRotationPolicyOptions) (GetKeyRotationPolicyResponse, error) {
+func (client *Client) GetKeyRotationPolicy(ctx context.Context, name string, options *GetKeyRotationPolicyOptions) (GetKeyRotationPolicyResponse, error) {
 	var err error
 	const operationName = "Client.GetKeyRotationPolicy"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.getKeyRotationPolicyCreateRequest(ctx, keyName, options)
+	req, err := client.getKeyRotationPolicyCreateRequest(ctx, name, options)
 	if err != nil {
 		return GetKeyRotationPolicyResponse{}, err
 	}
@@ -531,18 +572,18 @@ func (client *Client) GetKeyRotationPolicy(ctx context.Context, keyName string, 
 }
 
 // getKeyRotationPolicyCreateRequest creates the GetKeyRotationPolicy request.
-func (client *Client) getKeyRotationPolicyCreateRequest(ctx context.Context, keyName string, _ *GetKeyRotationPolicyOptions) (*policy.Request, error) {
+func (client *Client) getKeyRotationPolicyCreateRequest(ctx context.Context, name string, _ *GetKeyRotationPolicyOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}/rotationpolicy"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -562,7 +603,7 @@ func (client *Client) getKeyRotationPolicyHandleResponse(resp *http.Response) (G
 // Get the requested number of bytes containing random values from a managed HSM.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
+// Generated from API version 2025-06-01-preview
 //   - parameters - The request object to get random bytes.
 //   - options - GetRandomBytesOptions contains the optional parameters for the Client.GetRandomBytes method.
 func (client *Client) GetRandomBytes(ctx context.Context, parameters GetRandomBytesParameters, options *GetRandomBytesOptions) (GetRandomBytesResponse, error) {
@@ -595,7 +636,7 @@ func (client *Client) getRandomBytesCreateRequest(ctx context.Context, parameter
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -614,27 +655,24 @@ func (client *Client) getRandomBytesHandleResponse(resp *http.Response) (GetRand
 	return result, nil
 }
 
-// ImportKey - Imports an externally created key, stores it, and returns key parameters and
-// attributes to the client.
+// ImportKey - Imports an externally created key, stores it, and returns key parameters and attributes to the client.
 //
-// The import key operation may be used to import any key type into an Azure Key
-// Vault. If the named key already exists, Azure Key Vault creates a new version
-// of the key. This operation requires the keys/import permission.
+// The import key operation may be used to import any key type into an Azure Key Vault. If the named key already exists, Azure
+// Key Vault creates a new version of the key. This operation requires the keys/import permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - Name for the imported key. The value you provide may be copied globally for the
-//     purpose of running the service. The value provided should not include
-//     personally identifiable or sensitive information.
+// Generated from API version 2025-06-01-preview
+//   - name - Name for the imported key. The value you provide may be copied globally for the purpose of running the service.
+//     The value provided should not include personally identifiable or sensitive information.
 //   - parameters - The parameters to import a key.
 //   - options - ImportKeyOptions contains the optional parameters for the Client.ImportKey method.
-func (client *Client) ImportKey(ctx context.Context, keyName string, parameters ImportKeyParameters, options *ImportKeyOptions) (ImportKeyResponse, error) {
+func (client *Client) ImportKey(ctx context.Context, name string, parameters ImportKeyParameters, options *ImportKeyOptions) (ImportKeyResponse, error) {
 	var err error
 	const operationName = "Client.ImportKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.importKeyCreateRequest(ctx, keyName, parameters, options)
+	req, err := client.importKeyCreateRequest(ctx, name, parameters, options)
 	if err != nil {
 		return ImportKeyResponse{}, err
 	}
@@ -651,18 +689,18 @@ func (client *Client) ImportKey(ctx context.Context, keyName string, parameters 
 }
 
 // importKeyCreateRequest creates the ImportKey request.
-func (client *Client) importKeyCreateRequest(ctx context.Context, keyName string, parameters ImportKeyParameters, _ *ImportKeyOptions) (*policy.Request, error) {
+func (client *Client) importKeyCreateRequest(ctx context.Context, name string, parameters ImportKeyParameters, _ *ImportKeyOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -683,14 +721,12 @@ func (client *Client) importKeyHandleResponse(resp *http.Response) (ImportKeyRes
 
 // NewListDeletedKeyPropertiesPager - Lists the deleted keys in the specified vault.
 //
-// Retrieves a list of the keys in the Key Vault as JSON Web Key structures that
-// contain the public part of a deleted key. This operation includes
-// deletion-specific information. The Get Deleted Keys operation is applicable for
-// vaults enabled for soft-delete. While the operation can be invoked on any
-// vault, it will return an error if invoked on a non soft-delete enabled vault.
-// This operation requires the keys/list permission.
+// Retrieves a list of the keys in the Key Vault as JSON Web Key structures that contain the public part of a deleted key.
+// This operation includes deletion-specific information. The Get Deleted Keys operation is applicable for vaults enabled
+// for soft-delete. While the operation can be invoked on any vault, it will return an error if invoked on a non soft-delete
+// enabled vault. This operation requires the keys/list permission.
 //
-// Generated from API version 7.6-preview.1
+// Generated from API version 2025-06-01-preview
 //   - options - ListDeletedKeyPropertiesOptions contains the optional parameters for the Client.NewListDeletedKeyPropertiesPager
 //     method.
 func (client *Client) NewListDeletedKeyPropertiesPager(options *ListDeletedKeyPropertiesOptions) *runtime.Pager[ListDeletedKeyPropertiesResponse] {
@@ -724,7 +760,7 @@ func (client *Client) listDeletedKeyPropertiesCreateRequest(ctx context.Context,
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -741,13 +777,11 @@ func (client *Client) listDeletedKeyPropertiesHandleResponse(resp *http.Response
 
 // NewListKeyPropertiesPager - List keys in the specified vault.
 //
-// Retrieves a list of the keys in the Key Vault as JSON Web Key structures that
-// contain the public part of a stored key. The LIST operation is applicable to
-// all key types, however only the base key identifier, attributes, and tags are
-// provided in the response. Individual versions of a key are not listed in the
-// response. This operation requires the keys/list permission.
+// Retrieves a list of the keys in the Key Vault as JSON Web Key structures that contain the public part of a stored key.
+// The LIST operation is applicable to all key types, however only the base key identifier, attributes, and tags are provided
+// in the response. Individual versions of a key are not listed in the response. This operation requires the keys/list permission.
 //
-// Generated from API version 7.6-preview.1
+// Generated from API version 2025-06-01-preview
 //   - options - ListKeyPropertiesOptions contains the optional parameters for the Client.NewListKeyPropertiesPager method.
 func (client *Client) NewListKeyPropertiesPager(options *ListKeyPropertiesOptions) *runtime.Pager[ListKeyPropertiesResponse] {
 	return runtime.NewPager(runtime.PagingHandler[ListKeyPropertiesResponse]{
@@ -780,7 +814,7 @@ func (client *Client) listKeyPropertiesCreateRequest(ctx context.Context, _ *Lis
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -797,14 +831,13 @@ func (client *Client) listKeyPropertiesHandleResponse(resp *http.Response) (List
 
 // NewListKeyPropertiesVersionsPager - Retrieves a list of individual key versions with the same key name.
 //
-// The full key identifier, attributes, and tags are provided in the response.
-// This operation requires the keys/list permission.
+// The full key identifier, attributes, and tags are provided in the response. This operation requires the keys/list permission.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key.
 //   - options - ListKeyPropertiesVersionsOptions contains the optional parameters for the Client.NewListKeyPropertiesVersionsPager
 //     method.
-func (client *Client) NewListKeyPropertiesVersionsPager(keyName string, options *ListKeyPropertiesVersionsOptions) *runtime.Pager[ListKeyPropertiesVersionsResponse] {
+func (client *Client) NewListKeyPropertiesVersionsPager(name string, options *ListKeyPropertiesVersionsOptions) *runtime.Pager[ListKeyPropertiesVersionsResponse] {
 	return runtime.NewPager(runtime.PagingHandler[ListKeyPropertiesVersionsResponse]{
 		More: func(page ListKeyPropertiesVersionsResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -816,7 +849,7 @@ func (client *Client) NewListKeyPropertiesVersionsPager(keyName string, options 
 				nextLink = *page.NextLink
 			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listKeyPropertiesVersionsCreateRequest(ctx, keyName, options)
+				return client.listKeyPropertiesVersionsCreateRequest(ctx, name, options)
 			}, nil)
 			if err != nil {
 				return ListKeyPropertiesVersionsResponse{}, err
@@ -828,18 +861,18 @@ func (client *Client) NewListKeyPropertiesVersionsPager(keyName string, options 
 }
 
 // listKeyPropertiesVersionsCreateRequest creates the ListKeyPropertiesVersions request.
-func (client *Client) listKeyPropertiesVersionsCreateRequest(ctx context.Context, keyName string, _ *ListKeyPropertiesVersionsOptions) (*policy.Request, error) {
+func (client *Client) listKeyPropertiesVersionsCreateRequest(ctx context.Context, name string, _ *ListKeyPropertiesVersionsOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}/versions"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -856,22 +889,20 @@ func (client *Client) listKeyPropertiesVersionsHandleResponse(resp *http.Respons
 
 // PurgeDeletedKey - Permanently deletes the specified key.
 //
-// The Purge Deleted Key operation is applicable for soft-delete enabled vaults.
-// While the operation can be invoked on any vault, it will return an error if
-// invoked on a non soft-delete enabled vault. This operation requires the
-// keys/purge permission.
+// The Purge Deleted Key operation is applicable for soft-delete enabled vaults. While the operation can be invoked on any
+// vault, it will return an error if invoked on a non soft-delete enabled vault. This operation requires the keys/purge permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key
 //   - options - PurgeDeletedKeyOptions contains the optional parameters for the Client.PurgeDeletedKey method.
-func (client *Client) PurgeDeletedKey(ctx context.Context, keyName string, options *PurgeDeletedKeyOptions) (PurgeDeletedKeyResponse, error) {
+func (client *Client) PurgeDeletedKey(ctx context.Context, name string, options *PurgeDeletedKeyOptions) (PurgeDeletedKeyResponse, error) {
 	var err error
 	const operationName = "Client.PurgeDeletedKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.purgeDeletedKeyCreateRequest(ctx, keyName, options)
+	req, err := client.purgeDeletedKeyCreateRequest(ctx, name, options)
 	if err != nil {
 		return PurgeDeletedKeyResponse{}, err
 	}
@@ -887,41 +918,39 @@ func (client *Client) PurgeDeletedKey(ctx context.Context, keyName string, optio
 }
 
 // purgeDeletedKeyCreateRequest creates the PurgeDeletedKey request.
-func (client *Client) purgeDeletedKeyCreateRequest(ctx context.Context, keyName string, _ *PurgeDeletedKeyOptions) (*policy.Request, error) {
+func (client *Client) purgeDeletedKeyCreateRequest(ctx context.Context, name string, _ *PurgeDeletedKeyOptions) (*policy.Request, error) {
 	urlPath := "/deletedkeys/{key-name}"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	return req, nil
 }
 
 // RecoverDeletedKey - Recovers the deleted key to its latest version.
 //
-// The Recover Deleted Key operation is applicable for deleted keys in soft-delete
-// enabled vaults. It recovers the deleted key back to its latest version under
-// /keys. An attempt to recover an non-deleted key will return an error. Consider
-// this the inverse of the delete operation on soft-delete enabled vaults. This
-// operation requires the keys/recover permission.
+// The Recover Deleted Key operation is applicable for deleted keys in soft-delete enabled vaults. It recovers the deleted
+// key back to its latest version under /keys. An attempt to recover an non-deleted key will return an error. Consider this
+// the inverse of the delete operation on soft-delete enabled vaults. This operation requires the keys/recover permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the deleted key.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the deleted key.
 //   - options - RecoverDeletedKeyOptions contains the optional parameters for the Client.RecoverDeletedKey method.
-func (client *Client) RecoverDeletedKey(ctx context.Context, keyName string, options *RecoverDeletedKeyOptions) (RecoverDeletedKeyResponse, error) {
+func (client *Client) RecoverDeletedKey(ctx context.Context, name string, options *RecoverDeletedKeyOptions) (RecoverDeletedKeyResponse, error) {
 	var err error
 	const operationName = "Client.RecoverDeletedKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.recoverDeletedKeyCreateRequest(ctx, keyName, options)
+	req, err := client.recoverDeletedKeyCreateRequest(ctx, name, options)
 	if err != nil {
 		return RecoverDeletedKeyResponse{}, err
 	}
@@ -938,18 +967,18 @@ func (client *Client) RecoverDeletedKey(ctx context.Context, keyName string, opt
 }
 
 // recoverDeletedKeyCreateRequest creates the RecoverDeletedKey request.
-func (client *Client) recoverDeletedKeyCreateRequest(ctx context.Context, keyName string, _ *RecoverDeletedKeyOptions) (*policy.Request, error) {
+func (client *Client) recoverDeletedKeyCreateRequest(ctx context.Context, name string, _ *RecoverDeletedKeyOptions) (*policy.Request, error) {
 	urlPath := "/deletedkeys/{key-name}/recover"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -966,22 +995,22 @@ func (client *Client) recoverDeletedKeyHandleResponse(resp *http.Response) (Reco
 
 // Release - Releases a key.
 //
-// The release key operation is applicable to all key types. The target key must
-// be marked exportable. This operation requires the keys/release permission.
+// The release key operation is applicable to all key types. The target key must be marked exportable. This operation requires
+// the keys/release permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key to get.
-//   - keyVersion - Adding the version parameter retrieves a specific version of a key.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key to get.
+//   - version - Adding the version parameter retrieves a specific version of a key.
 //   - parameters - The parameters for the key release operation.
 //   - options - ReleaseOptions contains the optional parameters for the Client.Release method.
-func (client *Client) Release(ctx context.Context, keyName string, keyVersion string, parameters ReleaseParameters, options *ReleaseOptions) (ReleaseResponse, error) {
+func (client *Client) Release(ctx context.Context, name string, version string, parameters ReleaseParameters, options *ReleaseOptions) (ReleaseResponse, error) {
 	var err error
 	const operationName = "Client.Release"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.releaseCreateRequest(ctx, keyName, keyVersion, parameters, options)
+	req, err := client.releaseCreateRequest(ctx, name, version, parameters, options)
 	if err != nil {
 		return ReleaseResponse{}, err
 	}
@@ -998,22 +1027,22 @@ func (client *Client) Release(ctx context.Context, keyName string, keyVersion st
 }
 
 // releaseCreateRequest creates the Release request.
-func (client *Client) releaseCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters ReleaseParameters, _ *ReleaseOptions) (*policy.Request, error) {
+func (client *Client) releaseCreateRequest(ctx context.Context, name string, version string, parameters ReleaseParameters, _ *ReleaseOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}/{key-version}/release"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
-	if keyVersion == "" {
-		return nil, errors.New("parameter keyVersion cannot be empty")
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
+	if version == "" {
+		return nil, errors.New("parameter version cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(keyVersion))
+	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(version))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -1034,21 +1063,17 @@ func (client *Client) releaseHandleResponse(resp *http.Response) (ReleaseRespons
 
 // RestoreKey - Restores a backed up key to a vault.
 //
-// Imports a previously backed up key into Azure Key Vault, restoring the key, its
-// key identifier, attributes and access control policies. The RESTORE operation
-// may be used to import a previously backed up key. Individual versions of a key
-// cannot be restored. The key is restored in its entirety with the same key name
-// as it had when it was backed up. If the key name is not available in the target
-// Key Vault, the RESTORE operation will be rejected. While the key name is
-// retained during restore, the final key identifier will change if the key is
-// restored to a different vault. Restore will restore all versions and preserve
-// version identifiers. The RESTORE operation is subject to security constraints:
-// The target Key Vault must be owned by the same Microsoft Azure Subscription as
-// the source Key Vault The user must have RESTORE permission in the target Key
+// Imports a previously backed up key into Azure Key Vault, restoring the key, its key identifier, attributes and access control
+// policies. The RESTORE operation may be used to import a previously backed up key. Individual versions of a key cannot be
+// restored. The key is restored in its entirety with the same key name as it had when it was backed up. If the key name is
+// not available in the target Key Vault, the RESTORE operation will be rejected. While the key name is retained during restore,
+// the final key identifier will change if the key is restored to a different vault. Restore will restore all versions and
+// preserve version identifiers. The RESTORE operation is subject to security constraints: The target Key Vault must be owned
+// by the same Microsoft Azure Subscription as the source Key Vault The user must have RESTORE permission in the target Key
 // Vault. This operation requires the keys/restore permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
+// Generated from API version 2025-06-01-preview
 //   - parameters - The parameters to restore the key.
 //   - options - RestoreKeyOptions contains the optional parameters for the Client.RestoreKey method.
 func (client *Client) RestoreKey(ctx context.Context, parameters RestoreKeyParameters, options *RestoreKeyOptions) (RestoreKeyResponse, error) {
@@ -1081,7 +1106,7 @@ func (client *Client) restoreKeyCreateRequest(ctx context.Context, parameters Re
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -1100,24 +1125,21 @@ func (client *Client) restoreKeyHandleResponse(resp *http.Response) (RestoreKeyR
 	return result, nil
 }
 
-// RotateKey - Creates a new key version, stores it, then returns key parameters, attributes
-// and policy to the client.
+// RotateKey - Creates a new key version, stores it, then returns key parameters, attributes and policy to the client.
 //
-// The operation will rotate the key based on the key policy. It requires the
-// keys/rotate permission.
+// The operation will rotate the key based on the key policy. It requires the keys/rotate permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of key to be rotated. The system will generate a new version in the
-//     specified key.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of key to be rotated. The system will generate a new version in the specified key.
 //   - options - RotateKeyOptions contains the optional parameters for the Client.RotateKey method.
-func (client *Client) RotateKey(ctx context.Context, keyName string, options *RotateKeyOptions) (RotateKeyResponse, error) {
+func (client *Client) RotateKey(ctx context.Context, name string, options *RotateKeyOptions) (RotateKeyResponse, error) {
 	var err error
 	const operationName = "Client.RotateKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.rotateKeyCreateRequest(ctx, keyName, options)
+	req, err := client.rotateKeyCreateRequest(ctx, name, options)
 	if err != nil {
 		return RotateKeyResponse{}, err
 	}
@@ -1134,18 +1156,18 @@ func (client *Client) RotateKey(ctx context.Context, keyName string, options *Ro
 }
 
 // rotateKeyCreateRequest creates the RotateKey request.
-func (client *Client) rotateKeyCreateRequest(ctx context.Context, keyName string, _ *RotateKeyOptions) (*policy.Request, error) {
+func (client *Client) rotateKeyCreateRequest(ctx context.Context, name string, _ *RotateKeyOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}/rotate"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
@@ -1162,23 +1184,22 @@ func (client *Client) rotateKeyHandleResponse(resp *http.Response) (RotateKeyRes
 
 // Sign - Creates a signature from a digest using the specified key.
 //
-// The SIGN operation is applicable to asymmetric and symmetric keys stored in
-// Azure Key Vault since this operation uses the private portion of the key. This
-// operation requires the keys/sign permission.
+// The SIGN operation is applicable to asymmetric and symmetric keys stored in Azure Key Vault since this operation uses the
+// private portion of the key. This operation requires the keys/sign permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key.
-//   - keyVersion - The version of the key.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key.
+//   - version - The version of the key.
 //   - parameters - The parameters for the signing operation.
 //   - options - SignOptions contains the optional parameters for the Client.Sign method.
-func (client *Client) Sign(ctx context.Context, keyName string, keyVersion string, parameters SignParameters, options *SignOptions) (SignResponse, error) {
+func (client *Client) Sign(ctx context.Context, name string, version string, parameters SignParameters, options *SignOptions) (SignResponse, error) {
 	var err error
 	const operationName = "Client.Sign"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.signCreateRequest(ctx, keyName, keyVersion, parameters, options)
+	req, err := client.signCreateRequest(ctx, name, version, parameters, options)
 	if err != nil {
 		return SignResponse{}, err
 	}
@@ -1195,22 +1216,22 @@ func (client *Client) Sign(ctx context.Context, keyName string, keyVersion strin
 }
 
 // signCreateRequest creates the Sign request.
-func (client *Client) signCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters SignParameters, _ *SignOptions) (*policy.Request, error) {
+func (client *Client) signCreateRequest(ctx context.Context, name string, version string, parameters SignParameters, _ *SignOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}/{key-version}/sign"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
-	if keyVersion == "" {
-		return nil, errors.New("parameter keyVersion cannot be empty")
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
+	if version == "" {
+		return nil, errors.New("parameter version cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(keyVersion))
+	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(version))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -1229,28 +1250,25 @@ func (client *Client) signHandleResponse(resp *http.Response) (SignResponse, err
 	return result, nil
 }
 
-// UnwrapKey - Unwraps a symmetric key using the specified key that was initially used for
-// wrapping that key.
+// UnwrapKey - Unwraps a symmetric key using the specified key that was initially used for wrapping that key.
 //
-// The UNWRAP operation supports decryption of a symmetric key using the target
-// key encryption key. This operation is the reverse of the WRAP operation. The
-// UNWRAP operation applies to asymmetric and symmetric keys stored in Azure Key
-// Vault since it uses the private portion of the key. This operation requires the
-// keys/unwrapKey permission.
+// The UNWRAP operation supports decryption of a symmetric key using the target key encryption key. This operation is the
+// reverse of the WRAP operation. The UNWRAP operation applies to asymmetric and symmetric keys stored in Azure Key Vault
+// since it uses the private portion of the key. This operation requires the keys/unwrapKey permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key.
-//   - keyVersion - The version of the key.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key.
+//   - version - The version of the key.
 //   - parameters - The parameters for the key operation.
 //   - options - UnwrapKeyOptions contains the optional parameters for the Client.UnwrapKey method.
-func (client *Client) UnwrapKey(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, options *UnwrapKeyOptions) (UnwrapKeyResponse, error) {
+func (client *Client) UnwrapKey(ctx context.Context, name string, version string, parameters KeyOperationParameters, options *UnwrapKeyOptions) (UnwrapKeyResponse, error) {
 	var err error
 	const operationName = "Client.UnwrapKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.unwrapKeyCreateRequest(ctx, keyName, keyVersion, parameters, options)
+	req, err := client.unwrapKeyCreateRequest(ctx, name, version, parameters, options)
 	if err != nil {
 		return UnwrapKeyResponse{}, err
 	}
@@ -1267,22 +1285,22 @@ func (client *Client) UnwrapKey(ctx context.Context, keyName string, keyVersion 
 }
 
 // unwrapKeyCreateRequest creates the UnwrapKey request.
-func (client *Client) unwrapKeyCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, _ *UnwrapKeyOptions) (*policy.Request, error) {
+func (client *Client) unwrapKeyCreateRequest(ctx context.Context, name string, version string, parameters KeyOperationParameters, _ *UnwrapKeyOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}/{key-version}/unwrapkey"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
-	if keyVersion == "" {
-		return nil, errors.New("parameter keyVersion cannot be empty")
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
+	if version == "" {
+		return nil, errors.New("parameter version cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(keyVersion))
+	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(version))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -1301,26 +1319,25 @@ func (client *Client) unwrapKeyHandleResponse(resp *http.Response) (UnwrapKeyRes
 	return result, nil
 }
 
-// UpdateKey - The update key operation changes specified attributes of a stored key and can
-// be applied to any key type and key version stored in Azure Key Vault.
+// UpdateKey - The update key operation changes specified attributes of a stored key and can be applied to any key type and
+// key version stored in Azure Key Vault.
 //
-// In order to perform this operation, the key must already exist in the Key
-// Vault. Note: The cryptographic material of a key itself cannot be changed. This
-// operation requires the keys/update permission.
+// In order to perform this operation, the key must already exist in the Key Vault. Note: The cryptographic material of a
+// key itself cannot be changed. This operation requires the keys/update permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of key to update.
-//   - keyVersion - The version of the key to update.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of key to update.
+//   - version - The version of the key to update.
 //   - parameters - The parameters of the key to update.
 //   - options - UpdateKeyOptions contains the optional parameters for the Client.UpdateKey method.
-func (client *Client) UpdateKey(ctx context.Context, keyName string, keyVersion string, parameters UpdateKeyParameters, options *UpdateKeyOptions) (UpdateKeyResponse, error) {
+func (client *Client) UpdateKey(ctx context.Context, name string, version string, parameters UpdateKeyParameters, options *UpdateKeyOptions) (UpdateKeyResponse, error) {
 	var err error
 	const operationName = "Client.UpdateKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.updateKeyCreateRequest(ctx, keyName, keyVersion, parameters, options)
+	req, err := client.updateKeyCreateRequest(ctx, name, version, parameters, options)
 	if err != nil {
 		return UpdateKeyResponse{}, err
 	}
@@ -1337,22 +1354,22 @@ func (client *Client) UpdateKey(ctx context.Context, keyName string, keyVersion 
 }
 
 // updateKeyCreateRequest creates the UpdateKey request.
-func (client *Client) updateKeyCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters UpdateKeyParameters, _ *UpdateKeyOptions) (*policy.Request, error) {
+func (client *Client) updateKeyCreateRequest(ctx context.Context, name string, version string, parameters UpdateKeyParameters, _ *UpdateKeyOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}/{key-version}"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
-	if keyVersion == "" {
-		return nil, errors.New("parameter keyVersion cannot be empty")
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
+	if version == "" {
+		return nil, errors.New("parameter version cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(keyVersion))
+	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(version))
 	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -1373,21 +1390,20 @@ func (client *Client) updateKeyHandleResponse(resp *http.Response) (UpdateKeyRes
 
 // UpdateKeyRotationPolicy - Updates the rotation policy for a key.
 //
-// Set specified members in the key policy. Leave others as undefined. This
-// operation requires the keys/update permission.
+// Set specified members in the key policy. Leave others as undefined. This operation requires the keys/update permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key in the given vault.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key in the given vault.
 //   - keyRotationPolicy - The policy for the key.
 //   - options - UpdateKeyRotationPolicyOptions contains the optional parameters for the Client.UpdateKeyRotationPolicy method.
-func (client *Client) UpdateKeyRotationPolicy(ctx context.Context, keyName string, keyRotationPolicy KeyRotationPolicy, options *UpdateKeyRotationPolicyOptions) (UpdateKeyRotationPolicyResponse, error) {
+func (client *Client) UpdateKeyRotationPolicy(ctx context.Context, name string, keyRotationPolicy KeyRotationPolicy, options *UpdateKeyRotationPolicyOptions) (UpdateKeyRotationPolicyResponse, error) {
 	var err error
 	const operationName = "Client.UpdateKeyRotationPolicy"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.updateKeyRotationPolicyCreateRequest(ctx, keyName, keyRotationPolicy, options)
+	req, err := client.updateKeyRotationPolicyCreateRequest(ctx, name, keyRotationPolicy, options)
 	if err != nil {
 		return UpdateKeyRotationPolicyResponse{}, err
 	}
@@ -1404,18 +1420,18 @@ func (client *Client) UpdateKeyRotationPolicy(ctx context.Context, keyName strin
 }
 
 // updateKeyRotationPolicyCreateRequest creates the UpdateKeyRotationPolicy request.
-func (client *Client) updateKeyRotationPolicyCreateRequest(ctx context.Context, keyName string, keyRotationPolicy KeyRotationPolicy, _ *UpdateKeyRotationPolicyOptions) (*policy.Request, error) {
+func (client *Client) updateKeyRotationPolicyCreateRequest(ctx context.Context, name string, keyRotationPolicy KeyRotationPolicy, _ *UpdateKeyRotationPolicyOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}/rotationpolicy"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -1436,26 +1452,24 @@ func (client *Client) updateKeyRotationPolicyHandleResponse(resp *http.Response)
 
 // Verify - Verifies a signature using a specified key.
 //
-// The VERIFY operation is applicable to symmetric keys stored in Azure Key Vault.
-// VERIFY is not strictly necessary for asymmetric keys stored in Azure Key Vault
-// since signature verification can be performed using the public portion of the
-// key but this operation is supported as a convenience for callers that only have
-// a key-reference and not the public portion of the key. This operation requires
-// the keys/verify permission.
+// The VERIFY operation is applicable to symmetric keys stored in Azure Key Vault. VERIFY is not strictly necessary for asymmetric
+// keys stored in Azure Key Vault since signature verification can be performed using the public portion of the key but this
+// operation is supported as a convenience for callers that only have a key-reference and not the public portion of the key.
+// This operation requires the keys/verify permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key.
-//   - keyVersion - The version of the key.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key.
+//   - version - The version of the key.
 //   - parameters - The parameters for verify operations.
 //   - options - VerifyOptions contains the optional parameters for the Client.Verify method.
-func (client *Client) Verify(ctx context.Context, keyName string, keyVersion string, parameters VerifyParameters, options *VerifyOptions) (VerifyResponse, error) {
+func (client *Client) Verify(ctx context.Context, name string, version string, parameters VerifyParameters, options *VerifyOptions) (VerifyResponse, error) {
 	var err error
 	const operationName = "Client.Verify"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.verifyCreateRequest(ctx, keyName, keyVersion, parameters, options)
+	req, err := client.verifyCreateRequest(ctx, name, version, parameters, options)
 	if err != nil {
 		return VerifyResponse{}, err
 	}
@@ -1472,22 +1486,22 @@ func (client *Client) Verify(ctx context.Context, keyName string, keyVersion str
 }
 
 // verifyCreateRequest creates the Verify request.
-func (client *Client) verifyCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters VerifyParameters, _ *VerifyOptions) (*policy.Request, error) {
+func (client *Client) verifyCreateRequest(ctx context.Context, name string, version string, parameters VerifyParameters, _ *VerifyOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}/{key-version}/verify"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
-	if keyVersion == "" {
-		return nil, errors.New("parameter keyVersion cannot be empty")
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
+	if version == "" {
+		return nil, errors.New("parameter version cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(keyVersion))
+	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(version))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
@@ -1508,27 +1522,25 @@ func (client *Client) verifyHandleResponse(resp *http.Response) (VerifyResponse,
 
 // WrapKey - Wraps a symmetric key using a specified key.
 //
-// The WRAP operation supports encryption of a symmetric key using a key
-// encryption key that has previously been stored in an Azure Key Vault. The WRAP
-// operation is only strictly necessary for symmetric keys stored in Azure Key
-// Vault since protection with an asymmetric key can be performed using the public
-// portion of the key. This operation is supported for asymmetric keys as a
-// convenience for callers that have a key-reference but do not have access to the
-// public key material. This operation requires the keys/wrapKey permission.
+// The WRAP operation supports encryption of a symmetric key using a key encryption key that has previously been stored in
+// an Azure Key Vault. The WRAP operation is only strictly necessary for symmetric keys stored in Azure Key Vault since protection
+// with an asymmetric key can be performed using the public portion of the key. This operation is supported for asymmetric
+// keys as a convenience for callers that have a key-reference but do not have access to the public key material. This operation
+// requires the keys/wrapKey permission.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
-// Generated from API version 7.6-preview.1
-//   - keyName - The name of the key.
-//   - keyVersion - The version of the key.
+// Generated from API version 2025-06-01-preview
+//   - name - The name of the key.
+//   - version - The version of the key.
 //   - parameters - The parameters for wrap operation.
 //   - options - WrapKeyOptions contains the optional parameters for the Client.WrapKey method.
-func (client *Client) WrapKey(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, options *WrapKeyOptions) (WrapKeyResponse, error) {
+func (client *Client) WrapKey(ctx context.Context, name string, version string, parameters KeyOperationParameters, options *WrapKeyOptions) (WrapKeyResponse, error) {
 	var err error
 	const operationName = "Client.WrapKey"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.wrapKeyCreateRequest(ctx, keyName, keyVersion, parameters, options)
+	req, err := client.wrapKeyCreateRequest(ctx, name, version, parameters, options)
 	if err != nil {
 		return WrapKeyResponse{}, err
 	}
@@ -1545,22 +1557,22 @@ func (client *Client) WrapKey(ctx context.Context, keyName string, keyVersion st
 }
 
 // wrapKeyCreateRequest creates the WrapKey request.
-func (client *Client) wrapKeyCreateRequest(ctx context.Context, keyName string, keyVersion string, parameters KeyOperationParameters, _ *WrapKeyOptions) (*policy.Request, error) {
+func (client *Client) wrapKeyCreateRequest(ctx context.Context, name string, version string, parameters KeyOperationParameters, _ *WrapKeyOptions) (*policy.Request, error) {
 	urlPath := "/keys/{key-name}/{key-version}/wrapkey"
-	if keyName == "" {
-		return nil, errors.New("parameter keyName cannot be empty")
+	if name == "" {
+		return nil, errors.New("parameter name cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(keyName))
-	if keyVersion == "" {
-		return nil, errors.New("parameter keyVersion cannot be empty")
+	urlPath = strings.ReplaceAll(urlPath, "{key-name}", url.PathEscape(name))
+	if version == "" {
+		return nil, errors.New("parameter version cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(keyVersion))
+	urlPath = strings.ReplaceAll(urlPath, "{key-version}", url.PathEscape(version))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.vaultBaseUrl, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "7.6-preview.1")
+	reqQP.Set("api-version", "2025-06-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}

--- a/packages/typespec-go/test/local/azkeys/zz_constants.go
+++ b/packages/typespec-go/test/local/azkeys/zz_constants.go
@@ -28,6 +28,59 @@ func PossibleCurveNameValues() []CurveName {
 	}
 }
 
+// DeletionRecoveryLevel - Reflects the deletion recovery level currently in effect for certificates in the current vault.
+// If it contains 'Purgeable', the certificate can be permanently deleted by a privileged user; otherwise, only the system
+// can purge the certificate, at the end of the retention interval.
+type DeletionRecoveryLevel string
+
+const (
+	// DeletionRecoveryLevelCustomizedRecoverable - Denotes a vault state in which deletion is recoverable without the possibility
+	// for immediate and permanent deletion (i.e. purge when 7 <= SoftDeleteRetentionInDays < 90).This level guarantees the recoverability
+	// of the deleted entity during the retention interval and while the subscription is still available.
+	DeletionRecoveryLevelCustomizedRecoverable DeletionRecoveryLevel = "CustomizedRecoverable"
+	// DeletionRecoveryLevelCustomizedRecoverableProtectedSubscription - Denotes a vault and subscription state in which deletion
+	// is recoverable, immediate and permanent deletion (i.e. purge) is not permitted, and in which the subscription itself cannot
+	// be permanently canceled when 7 <= SoftDeleteRetentionInDays < 90. This level guarantees the recoverability of the deleted
+	// entity during the retention interval, and also reflects the fact that the subscription itself cannot be cancelled.
+	DeletionRecoveryLevelCustomizedRecoverableProtectedSubscription DeletionRecoveryLevel = "CustomizedRecoverable+ProtectedSubscription"
+	// DeletionRecoveryLevelCustomizedRecoverablePurgeable - Denotes a vault state in which deletion is recoverable, and which
+	// also permits immediate and permanent deletion (i.e. purge when 7 <= SoftDeleteRetentionInDays < 90). This level guarantees
+	// the recoverability of the deleted entity during the retention interval, unless a Purge operation is requested, or the subscription
+	// is cancelled.
+	DeletionRecoveryLevelCustomizedRecoverablePurgeable DeletionRecoveryLevel = "CustomizedRecoverable+Purgeable"
+	// DeletionRecoveryLevelPurgeable - Denotes a vault state in which deletion is an irreversible operation, without the possibility
+	// for recovery. This level corresponds to no protection being available against a Delete operation; the data is irretrievably
+	// lost upon accepting a Delete operation at the entity level or higher (vault, resource group, subscription etc.)
+	DeletionRecoveryLevelPurgeable DeletionRecoveryLevel = "Purgeable"
+	// DeletionRecoveryLevelRecoverable - Denotes a vault state in which deletion is recoverable without the possibility for immediate
+	// and permanent deletion (i.e. purge). This level guarantees the recoverability of the deleted entity during the retention
+	// interval(90 days) and while the subscription is still available. System wil permanently delete it after 90 days, if not
+	// recovered
+	DeletionRecoveryLevelRecoverable DeletionRecoveryLevel = "Recoverable"
+	// DeletionRecoveryLevelRecoverableProtectedSubscription - Denotes a vault and subscription state in which deletion is recoverable
+	// within retention interval (90 days), immediate and permanent deletion (i.e. purge) is not permitted, and in which the subscription
+	// itself cannot be permanently canceled. System wil permanently delete it after 90 days, if not recovered
+	DeletionRecoveryLevelRecoverableProtectedSubscription DeletionRecoveryLevel = "Recoverable+ProtectedSubscription"
+	// DeletionRecoveryLevelRecoverablePurgeable - Denotes a vault state in which deletion is recoverable, and which also permits
+	// immediate and permanent deletion (i.e. purge). This level guarantees the recoverability of the deleted entity during the
+	// retention interval (90 days), unless a Purge operation is requested, or the subscription is cancelled. System wil permanently
+	// delete it after 90 days, if not recovered
+	DeletionRecoveryLevelRecoverablePurgeable DeletionRecoveryLevel = "Recoverable+Purgeable"
+)
+
+// PossibleDeletionRecoveryLevelValues returns the possible values for the DeletionRecoveryLevel const type.
+func PossibleDeletionRecoveryLevelValues() []DeletionRecoveryLevel {
+	return []DeletionRecoveryLevel{
+		DeletionRecoveryLevelCustomizedRecoverable,
+		DeletionRecoveryLevelCustomizedRecoverableProtectedSubscription,
+		DeletionRecoveryLevelCustomizedRecoverablePurgeable,
+		DeletionRecoveryLevelPurgeable,
+		DeletionRecoveryLevelRecoverable,
+		DeletionRecoveryLevelRecoverableProtectedSubscription,
+		DeletionRecoveryLevelRecoverablePurgeable,
+	}
+}
+
 // EncryptionAlgorithm - An algorithm used for encryption and decryption.
 type EncryptionAlgorithm string
 
@@ -60,15 +113,19 @@ const (
 	EncryptionAlgorithmCKMAESKEYWRAP EncryptionAlgorithm = "CKM_AES_KEY_WRAP"
 	// EncryptionAlgorithmCKMAESKEYWRAPPAD - CKM AES key wrap with padding.
 	EncryptionAlgorithmCKMAESKEYWRAPPAD EncryptionAlgorithm = "CKM_AES_KEY_WRAP_PAD"
-	// EncryptionAlgorithmRSA15 - RSAES-PKCS1-V1_5 key encryption, as described in https://tools.ietf.org/html/rfc3447.
+	// EncryptionAlgorithmRSA15 - [Not recommended] RSAES-PKCS1-V1_5 key encryption, as described in https://tools.ietf.org/html/rfc3447.
+	// Microsoft recommends using RSA_OAEP_256 or stronger algorithms for enhanced security. Microsoft does *not* recommend RSA_1_5,
+	// which is included solely for backwards compatibility. Cryptographic standards no longer consider RSA with the PKCS#1 v1.5
+	// padding scheme secure for encryption.
 	EncryptionAlgorithmRSA15 EncryptionAlgorithm = "RSA1_5"
-	// EncryptionAlgorithmRSAOAEP - RSAES using Optimal Asymmetric Encryption Padding (OAEP), as described in
-	// https://tools.ietf.org/html/rfc3447, with the default parameters specified by
-	// RFC 3447 in Section A.2.1. Those default parameters are using a hash function
-	// of SHA-1 and a mask generation function of MGF1 with SHA-1.
+	// EncryptionAlgorithmRSAOAEP - [Not recommended] RSAES using Optimal Asymmetric Encryption Padding (OAEP), as described in
+	// https://tools.ietf.org/html/rfc3447, with the default parameters specified by RFC 3447 in Section A.2.1. Those default
+	// parameters are using a hash function of SHA-1 and a mask generation function of MGF1 with SHA-1. Microsoft recommends using
+	// RSA_OAEP_256 or stronger algorithms for enhanced security. Microsoft does *not* recommend RSA_OAEP, which is included solely
+	// for backwards compatibility. RSA_OAEP utilizes SHA1, which has known collision problems.
 	EncryptionAlgorithmRSAOAEP EncryptionAlgorithm = "RSA-OAEP"
-	// EncryptionAlgorithmRSAOAEP256 - RSAES using Optimal Asymmetric Encryption Padding with a hash function of SHA-256
-	// and a mask generation function of MGF1 with SHA-256.
+	// EncryptionAlgorithmRSAOAEP256 - RSAES using Optimal Asymmetric Encryption Padding with a hash function of SHA-256 and a
+	// mask generation function of MGF1 with SHA-256.
 	EncryptionAlgorithmRSAOAEP256 EncryptionAlgorithm = "RSA-OAEP-256"
 )
 
@@ -170,8 +227,7 @@ func PossibleKeyRotationPolicyActionValues() []KeyRotationPolicyAction {
 	}
 }
 
-// KeyType - JsonWebKey Key Type (kty), as defined in
-// https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.
+// KeyType - JsonWebKey Key Type (kty), as defined in https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.
 type KeyType string
 
 const (
@@ -201,40 +257,36 @@ func PossibleKeyTypeValues() []KeyType {
 	}
 }
 
-// SignatureAlgorithm - The signing/verification algorithm identifier. For more information on possible
-// algorithm types, see JsonWebKeySignatureAlgorithm.
+// SignatureAlgorithm - The signing/verification algorithm identifier. For more information on possible algorithm types, see
+// JsonWebKeySignatureAlgorithm.
 type SignatureAlgorithm string
 
 const (
-	// SignatureAlgorithmES256 - ECDSA using P-256 and SHA-256, as described in
-	// https://tools.ietf.org/html/rfc7518.
+	// SignatureAlgorithmES256 - ECDSA using P-256 and SHA-256, as described in https://tools.ietf.org/html/rfc7518.
 	SignatureAlgorithmES256 SignatureAlgorithm = "ES256"
-	// SignatureAlgorithmES256K - ECDSA using P-256K and SHA-256, as described in
-	// https://tools.ietf.org/html/rfc7518
+	// SignatureAlgorithmES256K - ECDSA using P-256K and SHA-256, as described in https://tools.ietf.org/html/rfc7518
 	SignatureAlgorithmES256K SignatureAlgorithm = "ES256K"
-	// SignatureAlgorithmES384 - ECDSA using P-384 and SHA-384, as described in
-	// https://tools.ietf.org/html/rfc7518
+	// SignatureAlgorithmES384 - ECDSA using P-384 and SHA-384, as described in https://tools.ietf.org/html/rfc7518
 	SignatureAlgorithmES384 SignatureAlgorithm = "ES384"
-	// SignatureAlgorithmES512 - ECDSA using P-521 and SHA-512, as described in
-	// https://tools.ietf.org/html/rfc7518
+	// SignatureAlgorithmES512 - ECDSA using P-521 and SHA-512, as described in https://tools.ietf.org/html/rfc7518
 	SignatureAlgorithmES512 SignatureAlgorithm = "ES512"
-	// SignatureAlgorithmPS256 - RSASSA-PSS using SHA-256 and MGF1 with SHA-256, as described in
-	// https://tools.ietf.org/html/rfc7518
+	// SignatureAlgorithmHS256 - HMAC using SHA-256, as described in https://tools.ietf.org/html/rfc7518
+	SignatureAlgorithmHS256 SignatureAlgorithm = "HS256"
+	// SignatureAlgorithmHS384 - HMAC using SHA-384, as described in https://tools.ietf.org/html/rfc7518
+	SignatureAlgorithmHS384 SignatureAlgorithm = "HS384"
+	// SignatureAlgorithmHS512 - HMAC using SHA-512, as described in https://tools.ietf.org/html/rfc7518
+	SignatureAlgorithmHS512 SignatureAlgorithm = "HS512"
+	// SignatureAlgorithmPS256 - RSASSA-PSS using SHA-256 and MGF1 with SHA-256, as described in https://tools.ietf.org/html/rfc7518
 	SignatureAlgorithmPS256 SignatureAlgorithm = "PS256"
-	// SignatureAlgorithmPS384 - RSASSA-PSS using SHA-384 and MGF1 with SHA-384, as described in
-	// https://tools.ietf.org/html/rfc7518
+	// SignatureAlgorithmPS384 - RSASSA-PSS using SHA-384 and MGF1 with SHA-384, as described in https://tools.ietf.org/html/rfc7518
 	SignatureAlgorithmPS384 SignatureAlgorithm = "PS384"
-	// SignatureAlgorithmPS512 - RSASSA-PSS using SHA-512 and MGF1 with SHA-512, as described in
-	// https://tools.ietf.org/html/rfc7518
+	// SignatureAlgorithmPS512 - RSASSA-PSS using SHA-512 and MGF1 with SHA-512, as described in https://tools.ietf.org/html/rfc7518
 	SignatureAlgorithmPS512 SignatureAlgorithm = "PS512"
-	// SignatureAlgorithmRS256 - RSASSA-PKCS1-v1_5 using SHA-256, as described in
-	// https://tools.ietf.org/html/rfc7518
+	// SignatureAlgorithmRS256 - RSASSA-PKCS1-v1_5 using SHA-256, as described in https://tools.ietf.org/html/rfc7518
 	SignatureAlgorithmRS256 SignatureAlgorithm = "RS256"
-	// SignatureAlgorithmRS384 - RSASSA-PKCS1-v1_5 using SHA-384, as described in
-	// https://tools.ietf.org/html/rfc7518
+	// SignatureAlgorithmRS384 - RSASSA-PKCS1-v1_5 using SHA-384, as described in https://tools.ietf.org/html/rfc7518
 	SignatureAlgorithmRS384 SignatureAlgorithm = "RS384"
-	// SignatureAlgorithmRS512 - RSASSA-PKCS1-v1_5 using SHA-512, as described in
-	// https://tools.ietf.org/html/rfc7518
+	// SignatureAlgorithmRS512 - RSASSA-PKCS1-v1_5 using SHA-512, as described in https://tools.ietf.org/html/rfc7518
 	SignatureAlgorithmRS512 SignatureAlgorithm = "RS512"
 	// SignatureAlgorithmRSNULL - Reserved
 	SignatureAlgorithmRSNULL SignatureAlgorithm = "RSNULL"
@@ -247,6 +299,9 @@ func PossibleSignatureAlgorithmValues() []SignatureAlgorithm {
 		SignatureAlgorithmES256K,
 		SignatureAlgorithmES384,
 		SignatureAlgorithmES512,
+		SignatureAlgorithmHS256,
+		SignatureAlgorithmHS384,
+		SignatureAlgorithmHS512,
 		SignatureAlgorithmPS256,
 		SignatureAlgorithmPS384,
 		SignatureAlgorithmPS512,

--- a/packages/typespec-go/test/local/azkeys/zz_models.go
+++ b/packages/typespec-go/test/local/azkeys/zz_models.go
@@ -23,8 +23,7 @@ type CreateKeyParameters struct {
 	// The attributes of a key managed by the key vault service.
 	KeyAttributes *KeyAttributes
 
-	// Json web key operations. For more information on possible key operations, see
-	// JsonWebKeyOperation.
+	// Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.
 	KeyOps []*KeyOperation
 
 	// The key size in bits. For example: 2048, 3072, or 4096 for RSA.
@@ -60,16 +59,15 @@ type DeletedKey struct {
 	// READ-ONLY; The time when the key was deleted, in UTC
 	DeletedDate *time.Time
 
-	// READ-ONLY; True if the key's lifetime is managed by key vault. If this is a key backing a
-	// certificate, then managed will be true.
+	// READ-ONLY; True if the key's lifetime is managed by key vault. If this is a key backing a certificate, then managed will
+	// be true.
 	Managed *bool
 
 	// READ-ONLY; The time when the key is scheduled to be purged, in UTC
 	ScheduledPurgeDate *time.Time
 }
 
-// DeletedKeyProperties - The deleted key item containing the deleted key metadata and information about
-// deletion.
+// DeletedKeyProperties - The deleted key item containing the deleted key metadata and information about deletion.
 type DeletedKeyProperties struct {
 	// The key management attributes.
 	Attributes *KeyAttributes
@@ -86,8 +84,8 @@ type DeletedKeyProperties struct {
 	// READ-ONLY; The time when the key was deleted, in UTC
 	DeletedDate *time.Time
 
-	// READ-ONLY; True if the key's lifetime is managed by key vault. If this is a key backing a
-	// certificate, then managed will be true.
+	// READ-ONLY; True if the key's lifetime is managed by key vault. If this is a key backing a certificate, then managed will
+	// be true.
 	Managed *bool
 
 	// READ-ONLY; The time when the key is scheduled to be purged, in UTC
@@ -151,12 +149,10 @@ type JSONWebKey struct {
 	// Key identifier.
 	KID *string
 
-	// Json web key operations. For more information on possible key operations, see
-	// JsonWebKeyOperation.
+	// Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.
 	KeyOps []*string
 
-	// JsonWebKey Key Type (kty), as defined in
-	// https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.
+	// JsonWebKey Key Type (kty), as defined in https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.
 	Kty *KeyType
 
 	// RSA modulus.
@@ -181,6 +177,21 @@ type JSONWebKey struct {
 	Y []byte
 }
 
+// KeyAttestation - The key attestation information.
+type KeyAttestation struct {
+	// A base64url-encoded string containing certificates in PEM format, used for attestation validation.
+	CertificatePEMFile []byte
+
+	// The attestation blob bytes encoded as base64url string corresponding to a private key.
+	PrivateKeyAttestation []byte
+
+	// The attestation blob bytes encoded as base64url string corresponding to a public key in case of asymmetric key.
+	PublicKeyAttestation []byte
+
+	// The version of the attestation.
+	Version *string
+}
+
 // KeyAttributes - The attributes of a key managed by the key vault service.
 type KeyAttributes struct {
 	// Determines whether the object is enabled.
@@ -189,12 +200,15 @@ type KeyAttributes struct {
 	// Expiry date in UTC.
 	Expires *time.Time
 
-	// Indicates if the private key can be exported. Release policy must be provided
-	// when creating the first version of an exportable key.
+	// Indicates if the private key can be exported. Release policy must be provided when creating the first version of an exportable
+	// key.
 	Exportable *bool
 
 	// Not before date in UTC.
 	NotBefore *time.Time
+
+	// READ-ONLY; The key or key version attestation information.
+	Attestation *KeyAttestation
 
 	// READ-ONLY; Creation time in UTC.
 	Created *time.Time
@@ -202,15 +216,13 @@ type KeyAttributes struct {
 	// READ-ONLY; The underlying HSM Platform.
 	HSMPlatform *string
 
-	// READ-ONLY; softDelete data retention days. Value should be >=7 and <=90 when softDelete
-	// enabled, otherwise 0.
+	// READ-ONLY; softDelete data retention days. Value should be >=7 and <=90 when softDelete enabled, otherwise 0.
 	RecoverableDays *int32
 
-	// READ-ONLY; Reflects the deletion recovery level currently in effect for keys in the
-	// current vault. If it contains 'Purgeable' the key can be permanently deleted by
-	// a privileged user; otherwise, only the system can purge the key, at the end of
-	// the retention interval.
-	RecoveryLevel *string
+	// READ-ONLY; Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable'
+	// the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key, at the end of the
+	// retention interval.
+	RecoveryLevel *DeletionRecoveryLevel
 
 	// READ-ONLY; Last updated time in UTC.
 	Updated *time.Time
@@ -230,8 +242,8 @@ type KeyBundle struct {
 	// Application specific metadata in the form of key-value pairs.
 	Tags map[string]*string
 
-	// READ-ONLY; True if the key's lifetime is managed by key vault. If this is a key backing a
-	// certificate, then managed will be true.
+	// READ-ONLY; True if the key's lifetime is managed by key vault. If this is a key backing a certificate, then managed will
+	// be true.
 	Managed *bool
 }
 
@@ -243,31 +255,25 @@ type KeyOperationParameters struct {
 	// REQUIRED; The value to operate on.
 	Value []byte
 
-	// Additional data to authenticate but not encrypt/decrypt when using
-	// authenticated crypto algorithms.
+	// Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms.
 	AdditionalAuthenticatedData []byte
 
-	// The tag to authenticate when performing decryption with an authenticated
-	// algorithm.
+	// The tag to authenticate when performing decryption with an authenticated algorithm.
 	AuthenticationTag []byte
 
-	// Cryptographically random, non-repeating initialization vector for symmetric
-	// algorithms.
+	// Cryptographically random, non-repeating initialization vector for symmetric algorithms.
 	IV []byte
 }
 
 // KeyOperationResult - The key operation result.
 type KeyOperationResult struct {
-	// READ-ONLY; Additional data to authenticate but not encrypt/decrypt when using
-	// authenticated crypto algorithms.
+	// READ-ONLY; Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms.
 	AdditionalAuthenticatedData []byte
 
-	// READ-ONLY; The tag to authenticate when performing decryption with an authenticated
-	// algorithm.
+	// READ-ONLY; The tag to authenticate when performing decryption with an authenticated algorithm.
 	AuthenticationTag []byte
 
-	// READ-ONLY; Cryptographically random, non-repeating initialization vector for symmetric
-	// algorithms.
+	// READ-ONLY; Cryptographically random, non-repeating initialization vector for symmetric algorithms.
 	IV []byte
 
 	// READ-ONLY; Key identifier
@@ -288,8 +294,8 @@ type KeyProperties struct {
 	// Application specific metadata in the form of key-value pairs.
 	Tags map[string]*string
 
-	// READ-ONLY; True if the key's lifetime is managed by key vault. If this is a key backing a
-	// certificate, then managed will be true.
+	// READ-ONLY; True if the key's lifetime is managed by key vault. If this is a key backing a certificate, then managed will
+	// be true.
 	Managed *bool
 }
 
@@ -307,12 +313,11 @@ type KeyReleasePolicy struct {
 	// Content type and version of key release policy
 	ContentType *string
 
-	// Blob encoding the policy rules under which the key can be released. Blob must
-	// be base64 URL encoded.
+	// Blob encoding the policy rules under which the key can be released. Blob must be base64 URL encoded.
 	EncodedPolicy []byte
 
-	// Defines the mutability state of the policy. Once marked immutable, this flag
-	// cannot be reset and the policy cannot be changed under any circumstances.
+	// Defines the mutability state of the policy. Once marked immutable, this flag cannot be reset and the policy cannot be changed
+	// under any circumstances.
 	Immutable *bool
 }
 
@@ -327,10 +332,9 @@ type KeyRotationPolicy struct {
 	// The key rotation policy attributes.
 	Attributes *KeyRotationPolicyAttributes
 
-	// Actions that will be performed by Key Vault over the lifetime of a key. For
-	// preview, lifetimeActions can only have two items at maximum: one for rotate,
-	// one for notify. Notification time would be default to 30 days before expiry and
-	// it is not configurable.
+	// Actions that will be performed by Key Vault over the lifetime of a key. For preview, lifetimeActions can only have two
+	// items at maximum: one for rotate, one for notify. Notification time would be default to 30 days before expiry and it is
+	// not configurable.
 	LifetimeActions []*LifetimeAction
 
 	// READ-ONLY; The key policy id.
@@ -339,9 +343,8 @@ type KeyRotationPolicy struct {
 
 // KeyRotationPolicyAttributes - The key rotation policy attributes.
 type KeyRotationPolicyAttributes struct {
-	// The expiryTime will be applied on the new key version. It should be at least 28
-	// days. It will be in ISO 8601 Format. Examples: 90 days: P90D, 3 months: P3M, 48
-	// hours: PT48H, 1 year and 10 days: P1Y10D
+	// The expiryTime will be applied on the new key version. It should be at least 28 days. It will be in ISO 8601 Format. Examples:
+	// 90 days: P90D, 3 months: P3M, 48 hours: PT48H, 1 year and 10 days: P1Y10D
 	ExpiryTime *string
 
 	// READ-ONLY; The key rotation policy created time in UTC.
@@ -357,8 +360,7 @@ type KeyVerifyResult struct {
 	Value *bool
 }
 
-// LifetimeAction - Action and its trigger that will be performed by Key Vault over the lifetime of
-// a key.
+// LifetimeAction - Action and its trigger that will be performed by Key Vault over the lifetime of a key.
 type LifetimeAction struct {
 	// The action that will be executed.
 	Action *LifetimeActionType
@@ -369,12 +371,11 @@ type LifetimeAction struct {
 
 // LifetimeActionTrigger - A condition to be satisfied for an action to be executed.
 type LifetimeActionTrigger struct {
-	// Time after creation to attempt to rotate. It only applies to rotate. It will be
-	// in ISO 8601 duration format. Example: 90 days : "P90D"
+	// Time after creation to attempt to rotate. It only applies to rotate. It will be in ISO 8601 duration format. Example: 90
+	// days : "P90D"
 	TimeAfterCreate *string
 
-	// Time before expiry to attempt to rotate or notify. It will be in ISO 8601
-	// duration format. Example: 90 days : "P90D"
+	// Time before expiry to attempt to rotate or notify. It will be in ISO 8601 duration format. Example: 90 days : "P90D"
 	TimeBeforeExpiry *string
 }
 
@@ -410,8 +411,7 @@ type RestoreKeyParameters struct {
 
 // SignParameters - The key operations parameters.
 type SignParameters struct {
-	// REQUIRED; The signing/verification algorithm identifier. For more information on possible
-	// algorithm types, see JsonWebKeySignatureAlgorithm.
+	// REQUIRED; The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.
 	Algorithm *SignatureAlgorithm
 
 	// REQUIRED; The value to operate on.
@@ -423,8 +423,7 @@ type UpdateKeyParameters struct {
 	// The attributes of a key managed by the key vault service.
 	KeyAttributes *KeyAttributes
 
-	// Json web key operations. For more information on possible key operations, see
-	// JsonWebKeyOperation.
+	// Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.
 	KeyOps []*KeyOperation
 
 	// The policy rules under which the key can be exported.
@@ -436,8 +435,7 @@ type UpdateKeyParameters struct {
 
 // VerifyParameters - The key verify parameters.
 type VerifyParameters struct {
-	// REQUIRED; The signing/verification algorithm. For more information on possible algorithm
-	// types, see JsonWebKeySignatureAlgorithm.
+	// REQUIRED; The signing/verification algorithm. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.
 	Algorithm *SignatureAlgorithm
 
 	// REQUIRED; The digest used for signing.

--- a/packages/typespec-go/test/local/azkeys/zz_models_serde.go
+++ b/packages/typespec-go/test/local/azkeys/zz_models_serde.go
@@ -440,9 +440,61 @@ func (j *JSONWebKey) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type KeyAttestation.
+func (k KeyAttestation) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populateByteArray(objectMap, "certificatePemFile", k.CertificatePEMFile, func() any {
+		return runtime.EncodeByteArray(k.CertificatePEMFile, runtime.Base64URLFormat)
+	})
+	populateByteArray(objectMap, "privateKeyAttestation", k.PrivateKeyAttestation, func() any {
+		return runtime.EncodeByteArray(k.PrivateKeyAttestation, runtime.Base64URLFormat)
+	})
+	populateByteArray(objectMap, "publicKeyAttestation", k.PublicKeyAttestation, func() any {
+		return runtime.EncodeByteArray(k.PublicKeyAttestation, runtime.Base64URLFormat)
+	})
+	populate(objectMap, "version", k.Version)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type KeyAttestation.
+func (k *KeyAttestation) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", k, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "certificatePemFile":
+			if val != nil && string(val) != "null" {
+				err = runtime.DecodeByteArray(string(val), &k.CertificatePEMFile, runtime.Base64URLFormat)
+			}
+			delete(rawMsg, key)
+		case "privateKeyAttestation":
+			if val != nil && string(val) != "null" {
+				err = runtime.DecodeByteArray(string(val), &k.PrivateKeyAttestation, runtime.Base64URLFormat)
+			}
+			delete(rawMsg, key)
+		case "publicKeyAttestation":
+			if val != nil && string(val) != "null" {
+				err = runtime.DecodeByteArray(string(val), &k.PublicKeyAttestation, runtime.Base64URLFormat)
+			}
+			delete(rawMsg, key)
+		case "version":
+			err = unpopulate(val, "Version", &k.Version)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", k, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type KeyAttributes.
 func (k KeyAttributes) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
+	populate(objectMap, "attestation", k.Attestation)
 	populateTimeUnix(objectMap, "created", k.Created)
 	populate(objectMap, "enabled", k.Enabled)
 	populateTimeUnix(objectMap, "exp", k.Expires)
@@ -464,6 +516,9 @@ func (k *KeyAttributes) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "attestation":
+			err = unpopulate(val, "Attestation", &k.Attestation)
+			delete(rawMsg, key)
 		case "created":
 			err = unpopulateTimeUnix(val, "Created", &k.Created)
 			delete(rawMsg, key)

--- a/packages/typespec-go/test/local/azkeys/zz_options.go
+++ b/packages/typespec-go/test/local/azkeys/zz_options.go
@@ -34,6 +34,11 @@ type GetDeletedKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
+// GetKeyAttestationOptions contains the optional parameters for the Client.GetKeyAttestation method.
+type GetKeyAttestationOptions struct {
+	// placeholder for future optional parameters
+}
+
 // GetKeyOptions contains the optional parameters for the Client.GetKey method.
 type GetKeyOptions struct {
 	// placeholder for future optional parameters

--- a/packages/typespec-go/test/local/azkeys/zz_responses.go
+++ b/packages/typespec-go/test/local/azkeys/zz_responses.go
@@ -40,6 +40,12 @@ type GetDeletedKeyResponse struct {
 	DeletedKey
 }
 
+// GetKeyAttestationResponse contains the response from method Client.GetKeyAttestation.
+type GetKeyAttestationResponse struct {
+	// A KeyBundle consisting of a WebKey plus its attributes.
+	KeyBundle
+}
+
 // GetKeyResponse contains the response from method Client.GetKey.
 type GetKeyResponse struct {
 	// A KeyBundle consisting of a WebKey plus its attributes.

--- a/packages/typespec-go/test/tsp/KeyVault.Keys/client.tsp
+++ b/packages/typespec-go/test/tsp/KeyVault.Keys/client.tsp
@@ -2,19 +2,389 @@ import "./main.tsp";
 import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
-using TypeSpec.Versioning;
 using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
 
 @versioned(KeyVault.Versions)
 namespace Customizations;
 
+@@clientName(KeyVault, "Key", "java");
 @@clientName(KeyVault, "Client", "go");
+@@clientName(KeyVault, "Key", "rust");
 
 using KeyVault;
 
+// Make optional path parameter required for all languages
+
 /**
- * The full key identifier, attributes, and tags are provided in the response.
- * This operation requires the keys/list permission.
+ * In order to perform this operation, the key must already exist in the Key Vault. Note: The cryptographic material of a key itself cannot be changed. This operation requires the keys/update permission.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
+@summary("The update key operation changes specified attributes of a stored key and can be applied to any key type and key version stored in Azure Key Vault.")
+@route("/keys/{key-name}/{key-version}")
+@patch(#{ implicitOptionality: true })
+op updateKey is KeyVaultOperation<
+  {
+    /**
+     * The name of key to update.
+     */
+    @path("key-name")
+    @clientName("name", "go")
+    keyName: string;
+
+    /**
+     * The version of the key to update.
+     */
+    @path("key-version")
+    @clientName("version", "go")
+    keyVersion: string;
+
+    /**
+     * The parameters of the key to update.
+     */
+    #suppress "deprecated" "Property flattening is supported for legacy scenarios like Key Vault's"
+    @body
+    @flattenProperty
+    parameters: KeyUpdateParameters;
+  },
+  KeyBundle
+>;
+
+/**
+ * The get key operation is applicable to all key types. If the requested key is symmetric, then no key material is released in the response. This operation requires the keys/get permission.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
+@summary("Gets the public part of a stored key.")
+@route("/keys/{key-name}/{key-version}")
+@get
+op getKey is KeyVaultOperation<
+  {
+    /**
+     * The name of the key to get.
+     */
+    @path("key-name")
+    @clientName("name", "go")
+    keyName: string;
+
+    /**
+     * Adding the version parameter retrieves a specific version of a key. This URI fragment is optional. If not specified, the latest version of the key is returned.
+     */
+    @path("key-version")
+    @clientName("version", "go")
+    keyVersion: string;
+  },
+  KeyBundle
+>;
+
+/**
+ * The ENCRYPT operation encrypts an arbitrary sequence of bytes using an encryption key that is stored in Azure Key Vault. Note that the ENCRYPT operation only supports a single block of data, the size of which is dependent on the target key and the encryption algorithm to be used. The ENCRYPT operation is only strictly necessary for symmetric keys stored in Azure Key Vault since protection with an asymmetric key can be performed using public portion of the key. This operation is supported for asymmetric keys as a convenience for callers that have a key-reference but do not have access to the public key material. This operation requires the keys/encrypt permission.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
+#suppress "@azure-tools/typespec-azure-core/no-openapi" "Operation ID is auto-capitalized, which would be breaking"
+@operationId("encrypt")
+@summary("Encrypts an arbitrary sequence of bytes using an encryption key that is stored in a key vault.")
+@route("/keys/{key-name}/{key-version}/encrypt")
+@post
+op encrypt is KeyVaultOperation<
+  {
+    /**
+     * The name of the key.
+     */
+    @path("key-name")
+    @clientName("name", "go")
+    keyName: string;
+
+    /**
+     * The version of the key.
+     */
+    @path("key-version")
+    @clientName("version", "go")
+    keyVersion: string;
+
+    /**
+     * The parameters for the encryption operation.
+     */
+    #suppress "deprecated" "Property flattening is supported for legacy scenarios like Key Vault's"
+    @body
+    @flattenProperty
+    parameters: KeyOperationsParameters;
+  },
+  KeyOperationResult
+>;
+
+/**
+ * The DECRYPT operation decrypts a well-formed block of ciphertext using the target encryption key and specified algorithm. This operation is the reverse of the ENCRYPT operation; only a single block of data may be decrypted, the size of this block is dependent on the target key and the algorithm to be used. The DECRYPT operation applies to asymmetric and symmetric keys stored in Azure Key Vault since it uses the private portion of the key. This operation requires the keys/decrypt permission. Microsoft recommends not to use CBC algorithms for decryption without first ensuring the integrity of the ciphertext using an HMAC, for example. See https://learn.microsoft.com/dotnet/standard/security/vulnerabilities-cbc-mode for more information.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
+#suppress "@azure-tools/typespec-azure-core/no-openapi" "Operation ID is auto-capitalized, which would be breaking"
+@operationId("decrypt")
+@summary("Decrypts a single block of encrypted data.")
+@route("/keys/{key-name}/{key-version}/decrypt")
+@post
+op decrypt is KeyVaultOperation<
+  {
+    /**
+     * The name of the key.
+     */
+    @path("key-name")
+    @clientName("name", "go")
+    keyName: string;
+
+    /**
+     * The version of the key.
+     */
+    @path("key-version")
+    @clientName("version", "go")
+    keyVersion: string;
+
+    /**
+     * The parameters for the decryption operation.
+     */
+    #suppress "deprecated" "Property flattening is supported for legacy scenarios like Key Vault's"
+    @body
+    @flattenProperty
+    parameters: KeyOperationsParameters;
+  },
+  KeyOperationResult
+>;
+
+/**
+ * The SIGN operation is applicable to asymmetric and symmetric keys stored in Azure Key Vault since this operation uses the private portion of the key. This operation requires the keys/sign permission.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
+#suppress "@azure-tools/typespec-azure-core/no-openapi" "Operation ID is auto-capitalized, which would be breaking"
+@operationId("sign")
+@summary("Creates a signature from a digest using the specified key.")
+@route("/keys/{key-name}/{key-version}/sign")
+@post
+op sign is KeyVaultOperation<
+  {
+    /**
+     * The name of the key.
+     */
+    @path("key-name")
+    @clientName("name", "go")
+    keyName: string;
+
+    /**
+     * The version of the key.
+     */
+    @path("key-version")
+    @clientName("version", "go")
+    keyVersion: string;
+
+    /**
+     * The parameters for the signing operation.
+     */
+    #suppress "deprecated" "Property flattening is supported for legacy scenarios like Key Vault's"
+    @body
+    @flattenProperty
+    parameters: KeySignParameters;
+  },
+  KeyOperationResult
+>;
+
+/**
+ * The VERIFY operation is applicable to symmetric keys stored in Azure Key Vault. VERIFY is not strictly necessary for asymmetric keys stored in Azure Key Vault since signature verification can be performed using the public portion of the key but this operation is supported as a convenience for callers that only have a key-reference and not the public portion of the key. This operation requires the keys/verify permission.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
+#suppress "@azure-tools/typespec-azure-core/no-openapi" "Operation ID is auto-capitalized, which would be breaking"
+@operationId("verify")
+@summary("Verifies a signature using a specified key.")
+@route("/keys/{key-name}/{key-version}/verify")
+@post
+op verify is KeyVaultOperation<
+  {
+    /**
+     * The name of the key.
+     */
+    @path("key-name")
+    @clientName("name", "go")
+    keyName: string;
+
+    /**
+     * The version of the key.
+     */
+    @path("key-version")
+    @clientName("version", "go")
+    keyVersion: string;
+
+    /**
+     * The parameters for verify operations.
+     */
+    #suppress "deprecated" "Property flattening is supported for legacy scenarios like Key Vault's"
+    @body
+    @flattenProperty
+    parameters: KeyVerifyParameters;
+  },
+  KeyVerifyResult
+>;
+
+/**
+ * The WRAP operation supports encryption of a symmetric key using a key encryption key that has previously been stored in an Azure Key Vault. The WRAP operation is only strictly necessary for symmetric keys stored in Azure Key Vault since protection with an asymmetric key can be performed using the public portion of the key. This operation is supported for asymmetric keys as a convenience for callers that have a key-reference but do not have access to the public key material. This operation requires the keys/wrapKey permission.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
+#suppress "@azure-tools/typespec-azure-core/no-openapi" "Operation ID is auto-capitalized, which would be breaking"
+@operationId("wrapKey")
+@summary("Wraps a symmetric key using a specified key.")
+@route("/keys/{key-name}/{key-version}/wrapkey")
+@post
+op wrapKey is KeyVaultOperation<
+  {
+    /**
+     * The name of the key.
+     */
+    @path("key-name")
+    @clientName("name", "go")
+    keyName: string;
+
+    /**
+     * The version of the key.
+     */
+    @path("key-version")
+    @clientName("version", "go")
+    keyVersion: string;
+
+    /**
+     * The parameters for wrap operation.
+     */
+    #suppress "deprecated" "Property flattening is supported for legacy scenarios like Key Vault's"
+    @body
+    @flattenProperty
+    parameters: KeyOperationsParameters;
+  },
+  KeyOperationResult
+>;
+
+/**
+ * The UNWRAP operation supports decryption of a symmetric key using the target key encryption key. This operation is the reverse of the WRAP operation. The UNWRAP operation applies to asymmetric and symmetric keys stored in Azure Key Vault since it uses the private portion of the key. This operation requires the keys/unwrapKey permission.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
+#suppress "@azure-tools/typespec-azure-core/no-openapi" "Operation ID is auto-capitalized, which would be breaking"
+@operationId("unwrapKey")
+@summary("Unwraps a symmetric key using the specified key that was initially used for wrapping that key.")
+@route("/keys/{key-name}/{key-version}/unwrapkey")
+@post
+op unwrapKey is KeyVaultOperation<
+  {
+    /**
+     * The name of the key.
+     */
+    @path("key-name")
+    @clientName("name", "go")
+    keyName: string;
+
+    /**
+     * The version of the key.
+     */
+    @path("key-version")
+    @clientName("version", "go")
+    keyVersion: string;
+
+    /**
+     * The parameters for the key operation.
+     */
+    #suppress "deprecated" "Property flattening is supported for legacy scenarios like Key Vault's"
+    @body
+    @flattenProperty
+    parameters: KeyOperationsParameters;
+  },
+  KeyOperationResult
+>;
+
+/**
+ * The release key operation is applicable to all key types. The target key must be marked exportable. This operation requires the keys/release permission.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
+#suppress "@azure-tools/typespec-azure-core/no-openapi" "Operation ID is auto-capitalized, which would be breaking"
+@operationId("release")
+@summary("Releases a key.")
+@route("/keys/{key-name}/{key-version}/release")
+@post
+op release is KeyVaultOperation<
+  {
+    /**
+     * The name of the key to get.
+     */
+    @path("key-name")
+    @clientName("name", "go")
+    keyName: string;
+
+    /**
+     * Adding the version parameter retrieves a specific version of a key.
+     */
+    @path("key-version")
+    @clientName("version", "go")
+    keyVersion: string;
+
+    /**
+     * The parameters for the key release operation.
+     */
+    #suppress "deprecated" "Property flattening is supported for legacy scenarios like Key Vault's"
+    @body
+    @flattenProperty
+    parameters: KeyReleaseParameters;
+  },
+  KeyReleaseResult
+>;
+
+/**
+ * The get key attestation operation returns the key along with its attestation blob. This operation requires the keys/get permission.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
+@Versioning.added(KeyVault.Versions.`v7.6_preview.2`)
+@summary("Gets the public part of a stored key along with its attestation blob.")
+@route("/keys/{key-name}/{key-version}/attestation")
+@get
+op getKeyAttestation is KeyVaultOperation<
+  {
+    /**
+     * The name of the key to retrieve attestation for.
+     */
+    @path("key-name")
+    @clientName("name", "go")
+    keyName: string;
+
+    /**
+     * Adding the version parameter retrieves attestation blob for specific version of a key. This URI fragment is optional. If not specified, the latest version of the key attestation blob is returned.
+     */
+    @path("key-version")
+    @clientName("version", "go")
+    keyVersion: string;
+  },
+  /**
+   * A key bundle containing the key, its attributes and attestation blob.
+   */
+  KeyBundle
+>;
+
+@@override(KeyVault.updateKey, updateKey);
+@@override(KeyVault.getKey, getKey);
+@@override(KeyVault.encrypt, encrypt);
+@@override(KeyVault.decrypt, decrypt);
+@@override(KeyVault.sign, sign);
+@@override(KeyVault.verify, verify);
+@@override(KeyVault.wrapKey, wrapKey);
+@@override(KeyVault.unwrapKey, unwrapKey);
+@@override(KeyVault.release, release);
+@@override(KeyVault.getKeyAttestation, getKeyAttestation);
+
+// Java configuration
+@@clientName(KeyEncryptionAlgorithm, "KeyExportEncryptionAlgorithm", "java");
+@@clientName(KeyReleaseResult, "ReleaseKeyResult", "java");
+@@clientName(JsonWebKeyCurveName.P256, "P_256", "java");
+@@clientName(JsonWebKeyCurveName.P384, "P_384", "java");
+@@clientName(JsonWebKeyCurveName.P521, "P_521", "java");
+@@clientName(JsonWebKeyCurveName.P256_K, "P_256K", "java");
+@@clientName(JsonWebKeyCurveName, "KeyCurveName", "java");
+@@clientName(JsonWebKeyOperation, "KeyOperation", "java");
+@@clientName(JsonWebKeyType, "KeyType", "java");
+
+// Go configuration
+
+/**
+ * The full key identifier, attributes, and tags are provided in the response. This operation requires the keys/list permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name is already established"
@@ -22,25 +392,20 @@ using KeyVault;
 @route("/keys/{key-name}/versions")
 @get
 @list
-op listKeyPropertiesVersions is Azure.Core.Foundations.Operation<
+op listKeyPropertiesVersions is KeyVaultOperation<
   {
     /**
      * The name of the key.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
   },
-  KeyListResult,
-  {},
-  KeyVaultError
+  KeyListResult
 >;
 
-/**s
- * Retrieves a list of the keys in the Key Vault as JSON Web Key structures that
- * contain the public part of a stored key. The LIST operation is applicable to
- * all key types, however only the base key identifier, attributes, and tags are
- * provided in the response. Individual versions of a key are not listed in the
- * response. This operation requires the keys/list permission.
+/**
+ * Retrieves a list of the keys in the Key Vault as JSON Web Key structures that contain the public part of a stored key. The LIST operation is applicable to all key types, however only the base key identifier, attributes, and tags are provided in the response. Individual versions of a key are not listed in the response. This operation requires the keys/list permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name is already established"
@@ -48,20 +413,10 @@ op listKeyPropertiesVersions is Azure.Core.Foundations.Operation<
 @route("/keys")
 @get
 @list
-op listKeyProperties is Azure.Core.Foundations.Operation<
-  {},
-  KeyListResult,
-  {},
-  KeyVaultError
->;
+op listKeyProperties is KeyVaultOperation<{}, KeyListResult>;
 
 /**
- * Retrieves a list of the keys in the Key Vault as JSON Web Key structures that
- * contain the public part of a deleted key. This operation includes
- * deletion-specific information. The Get Deleted Keys operation is applicable for
- * vaults enabled for soft-delete. While the operation can be invoked on any
- * vault, it will return an error if invoked on a non soft-delete enabled vault.
- * This operation requires the keys/list permission.
+ * Retrieves a list of the keys in the Key Vault as JSON Web Key structures that contain the public part of a deleted key. This operation includes deletion-specific information. The Get Deleted Keys operation is applicable for vaults enabled for soft-delete. While the operation can be invoked on any vault, it will return an error if invoked on a non soft-delete enabled vault. This operation requires the keys/list permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name is already established"
@@ -69,59 +424,162 @@ op listKeyProperties is Azure.Core.Foundations.Operation<
 @route("/deletedkeys")
 @get
 @list
-op listDeletedKeyProperties is Azure.Core.Foundations.Operation<
-  {},
-  DeletedKeyListResult,
-  {},
-  KeyVaultError
->;
+op listDeletedKeyProperties is KeyVaultOperation<{}, DeletedKeyListResult>;
 
 @@override(getKeyVersions, listKeyPropertiesVersions, "go");
 @@override(getKeys, listKeyProperties, "go");
 @@override(getDeletedKeys, listDeletedKeyProperties, "go");
+
+@@clientName(getDeletedKeys, "ListDeletedKeyProperties", "go");
+@@clientName(getKeys, "ListKeyProperties", "go");
+@@clientName(getKeyVersions, "ListKeyPropertiesVersions", "go");
+
+// renaming KeyItem to KeyProperties.
+// renaming existing KeyProperties to something else
+// to avoid a naming conflict as it's not part of the public surface area
+@@clientName(KeyProperties, "ShouldNotGenerate", "go");
+@@clientName(KeyItem, "KeyProperties", "go");
 
 @@clientName(KeyCreateParameters, "CreateKeyParameters", "go");
 @@clientName(KeyExportParameters, "ExportKeyParameters", "go");
 @@clientName(KeyImportParameters, "ImportKeyParameters", "go");
 @@clientName(KeyReleaseParameters, "ReleaseParameters", "go");
 @@clientName(KeyRestoreParameters, "RestoreKeyParameters", "go");
-@@clientName(KeySignParameters, "SignParameters", "go"); 
-@@clientName(KeyUpdateParameters, "UpdateKeyParameters", "go");  
-@@clientName(KeyVerifyParameters, "VerifyParameters", "go"); 
-@@clientName(GetRandomBytesRequest, "GetRandomBytesParameters", "go"); 
-@@clientName(getDeletedKeys, "ListDeletedKeyProperties", "go"); 
-@@clientName(getKeys, "ListKeyProperties", "go"); 
-@@clientName(getKeyVersions, "ListKeyPropertiesVersions", "go"); 
-@@clientName(DeletedKeyBundle, "DeletedKey", "go"); 
-@@clientName(KeyProperties, "KeyP", "go"); 
-@@clientName(KeyItem, "KeyProperties", "go"); 
-@@clientName(DeletedKeyItem, "DeletedKeyProperties", "go"); 
-@@clientName(DeletedKeyListResult, "DeletedKeyPropertiesListResult", "go"); 
+@@clientName(KeySignParameters, "SignParameters", "go");
+@@clientName(KeyUpdateParameters, "UpdateKeyParameters", "go");
+@@clientName(KeyVerifyParameters, "VerifyParameters", "go");
+@@clientName(GetRandomBytesRequest, "GetRandomBytesParameters", "go");
+
+@@clientName(DeletedKeyBundle, "DeletedKey", "go");
+@@clientName(DeletedKeyItem, "DeletedKeyProperties", "go");
+@@clientName(DeletedKeyListResult, "DeletedKeyPropertiesListResult", "go");
 @@clientName(KeyListResult, "KeyPropertiesListResult", "go");
-@@clientName(LifetimeActions, "LifetimeAction", "go");  
-@@clientName(LifetimeActionsType, "LifetimeActionType", "go");  
-@@clientName(LifetimeActionsTrigger, "LifetimeActionTrigger", "go");  
-@@clientName(KeyAttributes.hsmPlatform, "HSMPlatform", "go");  
+@@clientName(LifetimeActions, "LifetimeAction", "go");
+@@clientName(LifetimeActionsType, "LifetimeActionType", "go");
+@@clientName(LifetimeActionsTrigger, "LifetimeActionTrigger", "go");
+@@clientName(KeyAttributes.hsmPlatform, "HSMPlatform", "go");
 @@clientName(KeyRestoreParameters.keyBundleBackup, "KeyBackup", "go");
-@@clientName(KeyOperationsParameters, "KeyOperationParameters", "go");  
+@@clientName(KeyOperationsParameters, "KeyOperationParameters", "go");
 
-@@clientName(KeyImportParameters.hsm, "HSM", "go");  
-@@clientName(KeyReleaseParameters.enc, "algorithm", "go");   
-@@clientName(KeyOperationsParameters.aad, "AdditionalAuthenticatedData", "go");  
-@@clientName(KeyOperationsParameters.tag, "AuthenticationTag", "go");  
+@@clientName(KeyImportParameters.hsm, "HSM", "go");
+@@clientName(KeyReleaseParameters.enc, "algorithm", "go");
+@@clientName(KeyOperationsParameters.aad, "AdditionalAuthenticatedData", "go");
+@@clientName(KeyOperationsParameters.tag, "AuthenticationTag", "go");
 
-@@clientName(JsonWebKeyType, "KeyType", "go");  
-@@clientName(JsonWebKeyOperation, "KeyOperation", "go");  
-@@clientName(JsonWebKeyEncryptionAlgorithm, "EncryptionAlgorithm", "go");  
-@@clientName(JsonWebKeyCurveName, "CurveName", "go");  
-@@clientName(JsonWebKeySignatureAlgorithm, "SignatureAlgorithm", "go"); 
+@@clientName(JsonWebKeyType, "KeyType", "go");
+@@clientName(JsonWebKeyOperation, "KeyOperation", "go");
+@@clientName(JsonWebKeyEncryptionAlgorithm, "EncryptionAlgorithm", "go");
+@@clientName(JsonWebKeyCurveName, "CurveName", "go");
+@@clientName(JsonWebKeySignatureAlgorithm, "SignatureAlgorithm", "go");
 
-@@clientName(JsonWebKey.kid, "KID", "go");  
-@@clientName(KeyItem.kid, "KID", "go"); 
-@@clientName(KeyOperationResult.kid, "KID", "go"); 
+@@clientName(JsonWebKey.kid, "KID", "go");
+@@clientName(KeyItem.kid, "KID", "go");
+@@clientName(KeyOperationResult.kid, "KID", "go");
 @@clientName(KeyOperationsParameters.iv, "IV", "go");
-@@clientName(KeyOperationResult.iv, "IV", "go"); 
+@@clientName(KeyOperationResult.iv, "IV", "go");
 
-@@clientName(JsonWebKey.dp, "DP", "go"); 
-@@clientName(JsonWebKey.dq, "DQ", "go"); 
-@@clientName(JsonWebKey.qi, "QI", "go"); 
+@@clientName(JsonWebKey.dp, "DP", "go");
+@@clientName(JsonWebKey.dq, "DQ", "go");
+@@clientName(JsonWebKey.qi, "QI", "go");
+
+@@clientName(KeyAttestation.certificatePemFile, "CertificatePEMFile", "go");
+
+// JS configuration
+@@clientName(JsonWebKeyCurveName.P256_K, "P256K", "javascript");
+@@clientName(JsonWebKeySignatureAlgorithm.RSNULL, "Rsnull", "javascript");
+@@clientName(JsonWebKeySignatureAlgorithm.ES256_K, "ES256K", "javascript");
+@@clientName(JsonWebKeyEncryptionAlgorithm.RSA_OAEP, "RSAOaep", "javascript");
+@@clientName(JsonWebKeyEncryptionAlgorithm.RSA_OAEP256,
+  "RSAOaep256",
+  "javascript"
+);
+@@clientName(JsonWebKeyEncryptionAlgorithm.RSA1_5, "RSA15", "javascript");
+@@clientName(JsonWebKeyEncryptionAlgorithm.A128_GCM, "A128GCM", "javascript");
+@@clientName(JsonWebKeyEncryptionAlgorithm.A192_GCM, "A192GCM", "javascript");
+@@clientName(JsonWebKeyEncryptionAlgorithm.A256_GCM, "A256GCM", "javascript");
+@@clientName(JsonWebKeyEncryptionAlgorithm.A128_KW, "A128KW", "javascript");
+@@clientName(JsonWebKeyEncryptionAlgorithm.A192_KW, "A192KW", "javascript");
+@@clientName(JsonWebKeyEncryptionAlgorithm.A256_KW, "A256KW", "javascript");
+@@clientName(JsonWebKeyEncryptionAlgorithm.A128_CBC, "A128CBC", "javascript");
+@@clientName(JsonWebKeyEncryptionAlgorithm.A192_CBC, "A192CBC", "javascript");
+@@clientName(JsonWebKeyEncryptionAlgorithm.A256_CBC, "A256CBC", "javascript");
+@@clientName(JsonWebKeyEncryptionAlgorithm.A128_CBCPAD,
+  "A128Cbcpad",
+  "javascript"
+);
+@@clientName(JsonWebKeyEncryptionAlgorithm.A192_CBCPAD,
+  "A192Cbcpad",
+  "javascript"
+);
+@@clientName(JsonWebKeyEncryptionAlgorithm.A256_CBCPAD,
+  "A256Cbcpad",
+  "javascript"
+);
+@@clientName(JsonWebKeyEncryptionAlgorithm.CKM_AES_KEY_WRAP,
+  "CkmAesKeyWrap",
+  "javascript"
+);
+@@clientName(JsonWebKeyEncryptionAlgorithm.CKM_AES_KEY_WRAP_PAD,
+  "CkmAesKeyWrapPad",
+  "javascript"
+);
+@@clientName(JsonWebKeyType.EC_HSM, "ECHSM", "javascript");
+@@clientName(JsonWebKeyType.RSA_HSM, "RSAHSM", "javascript");
+@@clientName(JsonWebKeyType.oct_HSM, "OctHSM", "javascript");
+@@clientName(JsonWebKeyType.oct, "Oct", "javascript");
+@@clientName(KeyEncryptionAlgorithm.CKM_RSA_AES_KEY_WRAP,
+  "CkmRsaAesKeyWrap",
+  "javascript"
+);
+@@clientName(KeyEncryptionAlgorithm.RSA_AES_KEY_WRAP_256,
+  "RsaAesKeyWrap256",
+  "javascript"
+);
+@@clientName(KeyEncryptionAlgorithm.RSA_AES_KEY_WRAP_384,
+  "RsaAesKeyWrap384",
+  "javascript"
+);
+
+// Rust configuration
+@@clientName(KeyCreateParameters, "CreateKeyParameters", "rust");
+@@clientName(KeyExportParameters, "ExportKeyParameters", "rust");
+@@clientName(KeyImportParameters, "ImportKeyParameters", "rust");
+@@clientName(KeyReleaseParameters, "ReleaseParameters", "rust");
+@@clientName(KeyRestoreParameters, "RestoreKeyParameters", "rust");
+@@clientName(KeySignParameters, "SignParameters", "rust");
+@@clientName(KeyUpdateParameters, "UpdateKeyPropertiesParameters", "rust");
+@@clientName(KeyVerifyParameters, "VerifyParameters", "rust");
+@@clientName(GetRandomBytesRequest, "GetRandomBytesParameters", "rust");
+@@clientName(getDeletedKeys, "ListDeletedKeyProperties", "rust");
+@@clientName(getKeys, "ListKeyProperties", "rust");
+@@clientName(getKeyVersions, "ListKeyPropertiesVersions", "rust");
+@@clientName(DeletedKeyBundle, "DeletedKey", "rust");
+@@clientName(KeyBundle, "Key", "rust");
+@@clientName(KeyProperties, "OmitKeyProperties", "rust");
+@@clientName(KeyItem, "KeyProperties", "rust");
+@@clientName(DeletedKeyItem, "DeletedKeyProperties", "rust");
+@@clientName(DeletedKeyListResult, "ListDeletedKeyPropertiesResult", "rust");
+@@clientName(KeyListResult, "ListKeyPropertiesResult", "rust");
+@@clientName(LifetimeActions, "LifetimeAction", "rust");
+@@clientName(LifetimeActionsType, "LifetimeActionType", "rust");
+@@clientName(LifetimeActionsTrigger, "LifetimeActionTrigger", "rust");
+@@clientName(KeyRestoreParameters.keyBundleBackup, "KeyBackup", "rust");
+@@clientName(KeyOperationsParameters, "KeyOperationParameters", "rust");
+
+@@clientName(getDeletedKeys, "ListDeletedKeyProperties", "rust");
+@@clientName(getKeys, "ListKeyProperties", "rust");
+@@clientName(getKeyVersions, "ListKeyPropertiesVersions", "rust");
+@@clientName(updateKey, "UpdateKeyProperties", "rust");
+
+@@clientName(KeyReleaseParameters.enc, "algorithm", "rust");
+@@clientName(KeyOperationsParameters.aad,
+  "AdditionalAuthenticatedData",
+  "rust"
+);
+@@clientName(KeyOperationsParameters.tag, "AuthenticationTag", "rust");
+
+@@clientName(JsonWebKeyType, "KeyType", "rust");
+@@clientName(JsonWebKeyOperation, "KeyOperation", "rust");
+@@clientName(JsonWebKeyEncryptionAlgorithm, "EncryptionAlgorithm", "rust");
+@@clientName(JsonWebKeyCurveName, "CurveName", "rust");
+@@clientName(JsonWebKeySignatureAlgorithm, "SignatureAlgorithm", "rust");

--- a/packages/typespec-go/test/tsp/KeyVault.Keys/common.tsp
+++ b/packages/typespec-go/test/tsp/KeyVault.Keys/common.tsp
@@ -1,0 +1,53 @@
+import "@azure-tools/typespec-azure-core";
+import "@typespec/openapi";
+
+using Azure.Core;
+
+alias KeyVaultOperation<
+  TParams extends Reflection.Model,
+  TResponse,
+  Traits extends Reflection.Model = {}
+> = Foundations.Operation<TParams, TResponse, Traits, KeyVaultError>;
+
+/**
+ * The key vault server error.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-nullable" "Intentionally nullable model"
+#suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+union Error {
+  null,
+  #suppress "@azure-tools/typespec-client-generator-core/no-unnamed-types" "Backcompatibility with existing clients"
+  {
+    /**
+     * The error code.
+     */
+    @visibility(Lifecycle.Read)
+    code?: string,
+
+    /**
+     * The error message.
+     */
+    @visibility(Lifecycle.Read)
+    message?: string,
+
+    /**
+     * The key vault server error.
+     */
+    @visibility(Lifecycle.Read)
+    @encodedName("application/json", "innererror")
+    innerError?: Error,
+  },
+}
+
+/**
+ * The key vault error exception.
+ */
+@error
+model KeyVaultError {
+  /**
+   * The key vault server error.
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Intentionally nullable model"
+  @visibility(Lifecycle.Read)
+  error?: Error;
+}

--- a/packages/typespec-go/test/tsp/KeyVault.Keys/main.tsp
+++ b/packages/typespec-go/test/tsp/KeyVault.Keys/main.tsp
@@ -10,8 +10,7 @@ using TypeSpec.Versioning;
 using Azure.Core;
 
 /**
- * The key vault client performs cryptographic key operations and vault operations
- * against the Key Vault service.
+ * The key vault client performs cryptographic key operations and vault operations against the Key Vault service.
  */
 @useAuth(
   OAuth2Auth<[
@@ -22,9 +21,7 @@ using Azure.Core;
     }
   ]>
 )
-@service(#{
-  title: "KeyVaultClient",
-})
+@service(#{ title: "KeyVaultClient" })
 @versioned(Versions)
 @server(
   "{vaultBaseUrl}",
@@ -46,8 +43,20 @@ enum Versions {
   `v7.5`: "7.5",
 
   /**
-   * The 7.6-preview.1 API version.
+   * The 7.6-preview.2 API version.
    */
   @useDependency(Azure.Core.Versions.v1_0_Preview_2)
-  `v7.6_preview.1`: "7.6-preview.1",
+  `v7.6_preview.2`: "7.6-preview.2",
+
+  /**
+   * The 7.6 API version.
+   */
+  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
+  `v7.6`: "7.6",
+
+  /**
+   * The 2025-06-01-preview API version.
+   */
+  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
+  v2025_06_01_preview: "2025-06-01-preview",
 }

--- a/packages/typespec-go/test/tsp/KeyVault.Keys/models.tsp
+++ b/packages/typespec-go/test/tsp/KeyVault.Keys/models.tsp
@@ -11,8 +11,7 @@ using Azure.Core;
 namespace KeyVault;
 
 /**
- * JsonWebKey Key Type (kty), as defined in
- * https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.
+ * JsonWebKey Key Type (kty), as defined in https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.
  */
 union JsonWebKeyType {
   string,
@@ -80,76 +79,45 @@ union JsonWebKeyOperation {
 }
 
 /**
- * Reflects the deletion recovery level currently in effect for certificates in
- * the current vault. If it contains 'Purgeable', the certificate can be
- * permanently deleted by a privileged user; otherwise, only the system can purge
- * the certificate, at the end of the retention interval.
+ * Reflects the deletion recovery level currently in effect for certificates in the current vault. If it contains 'Purgeable', the certificate can be permanently deleted by a privileged user; otherwise, only the system can purge the certificate, at the end of the retention interval.
  */
 union DeletionRecoveryLevel {
   string,
 
   /**
-   * Denotes a vault state in which deletion is an irreversible operation, without
-   * the possibility for recovery. This level corresponds to no protection being
-   * available against a Delete operation; the data is irretrievably lost upon
-   * accepting a Delete operation at the entity level or higher (vault, resource
-   * group, subscription etc.)
+   * Denotes a vault state in which deletion is an irreversible operation, without the possibility for recovery. This level corresponds to no protection being available against a Delete operation; the data is irretrievably lost upon accepting a Delete operation at the entity level or higher (vault, resource group, subscription etc.)
    */
   Purgeable: "Purgeable",
 
   /**
-   * Denotes a vault state in which deletion is recoverable, and which also permits
-   * immediate and permanent deletion (i.e. purge). This level guarantees the
-   * recoverability of the deleted entity during the retention interval (90 days),
-   * unless a Purge operation is requested, or the subscription is cancelled. System
-   * wil permanently delete it after 90 days, if not recovered
+   * Denotes a vault state in which deletion is recoverable, and which also permits immediate and permanent deletion (i.e. purge). This level guarantees the recoverability of the deleted entity during the retention interval (90 days), unless a Purge operation is requested, or the subscription is cancelled. System wil permanently delete it after 90 days, if not recovered
    */
-  Recoverable_Purgeable: "Recoverable+Purgeable",
+  RecoverablePurgeable: "Recoverable+Purgeable",
 
   /**
-   * Denotes a vault state in which deletion is recoverable without the possibility
-   * for immediate and permanent deletion (i.e. purge). This level guarantees the
-   * recoverability of the deleted entity during the retention interval(90 days) and
-   * while the subscription is still available. System wil permanently delete it
-   * after 90 days, if not recovered
+   * Denotes a vault state in which deletion is recoverable without the possibility for immediate and permanent deletion (i.e. purge). This level guarantees the recoverability of the deleted entity during the retention interval(90 days) and while the subscription is still available. System wil permanently delete it after 90 days, if not recovered
    */
   Recoverable: "Recoverable",
 
   /**
-   * Denotes a vault and subscription state in which deletion is recoverable within
-   * retention interval (90 days), immediate and permanent deletion (i.e. purge) is
-   * not permitted, and in which the subscription itself  cannot be permanently
-   * canceled. System wil permanently delete it after 90 days, if not recovered
+   * Denotes a vault and subscription state in which deletion is recoverable within retention interval (90 days), immediate and permanent deletion (i.e. purge) is not permitted, and in which the subscription itself  cannot be permanently canceled. System wil permanently delete it after 90 days, if not recovered
    */
-  Recoverable_ProtectedSubscription: "Recoverable+ProtectedSubscription",
+  RecoverableProtectedSubscription: "Recoverable+ProtectedSubscription",
 
   /**
-   * Denotes a vault state in which deletion is recoverable, and which also permits
-   * immediate and permanent deletion (i.e. purge when 7<= SoftDeleteRetentionInDays
-   * < 90). This level guarantees the recoverability of the deleted entity during
-   * the retention interval, unless a Purge operation is requested, or the
-   * subscription is cancelled.
+   * Denotes a vault state in which deletion is recoverable, and which also permits immediate and permanent deletion (i.e. purge when 7 <= SoftDeleteRetentionInDays < 90). This level guarantees the recoverability of the deleted entity during the retention interval, unless a Purge operation is requested, or the subscription is cancelled.
    */
-  CustomizedRecoverable_Purgeable: "CustomizedRecoverable+Purgeable",
+  CustomizedRecoverablePurgeable: "CustomizedRecoverable+Purgeable",
 
   /**
-   * Denotes a vault state in which deletion is recoverable without the possibility
-   * for immediate and permanent deletion (i.e. purge when 7<=
-   * SoftDeleteRetentionInDays < 90).This level guarantees the recoverability of the
-   * deleted entity during the retention interval and while the subscription is
-   * still available.
+   * Denotes a vault state in which deletion is recoverable without the possibility for immediate and permanent deletion (i.e. purge when 7 <= SoftDeleteRetentionInDays < 90).This level guarantees the recoverability of the deleted entity during the retention interval and while the subscription is still available.
    */
   CustomizedRecoverable: "CustomizedRecoverable",
 
   /**
-   * Denotes a vault and subscription state in which deletion is recoverable,
-   * immediate and permanent deletion (i.e. purge) is not permitted, and in which
-   * the subscription itself cannot be permanently canceled when 7<=
-   * SoftDeleteRetentionInDays < 90. This level guarantees the recoverability of the
-   * deleted entity during the retention interval, and also reflects the fact that
-   * the subscription itself cannot be cancelled.
+   * Denotes a vault and subscription state in which deletion is recoverable, immediate and permanent deletion (i.e. purge) is not permitted, and in which the subscription itself cannot be permanently canceled when 7 <= SoftDeleteRetentionInDays < 90. This level guarantees the recoverability of the deleted entity during the retention interval, and also reflects the fact that the subscription itself cannot be cancelled.
    */
-  CustomizedRecoverable_ProtectedSubscription: "CustomizedRecoverable+ProtectedSubscription",
+  CustomizedRecoverableProtectedSubscription: "CustomizedRecoverable+ProtectedSubscription",
 }
 
 /**
@@ -178,19 +146,16 @@ union JsonWebKeyEncryptionAlgorithm {
   string,
 
   /**
-   * RSAES using Optimal Asymmetric Encryption Padding (OAEP), as described in
-   * https://tools.ietf.org/html/rfc3447, with the default parameters specified by
-   * RFC 3447 in Section A.2.1. Those default parameters are using a hash function
-   * of SHA-1 and a mask generation function of MGF1 with SHA-1.
+   * [Not recommended] RSAES using Optimal Asymmetric Encryption Padding (OAEP), as described in https://tools.ietf.org/html/rfc3447, with the default parameters specified by RFC 3447 in Section A.2.1. Those default parameters are using a hash function of SHA-1 and a mask generation function of MGF1 with SHA-1. Microsoft recommends using RSA_OAEP_256 or stronger algorithms for enhanced security. Microsoft does *not* recommend RSA_OAEP, which is included solely for backwards compatibility. RSA_OAEP utilizes SHA1, which has known collision problems.
    */
   RSA_OAEP: "RSA-OAEP",
 
-  /** RSAES using Optimal Asymmetric Encryption Padding with a hash function of SHA-256
-   * and a mask generation function of MGF1 with SHA-256.
+  /**
+   * RSAES using Optimal Asymmetric Encryption Padding with a hash function of SHA-256 and a mask generation function of MGF1 with SHA-256.
    */
   RSA_OAEP256: "RSA-OAEP-256",
 
-  /** RSAES-PKCS1-V1_5 key encryption, as described in https://tools.ietf.org/html/rfc3447. */
+  /** [Not recommended] RSAES-PKCS1-V1_5 key encryption, as described in https://tools.ietf.org/html/rfc3447. Microsoft recommends using RSA_OAEP_256 or stronger algorithms for enhanced security. Microsoft does *not* recommend RSA_1_5, which is included solely for backwards compatibility. Cryptographic standards no longer consider RSA with the PKCS#1 v1.5 padding scheme secure for encryption. */
   RSA1_5: "RSA1_5",
 
   /** 128-bit AES-GCM. */
@@ -230,56 +195,67 @@ union JsonWebKeyEncryptionAlgorithm {
   A256_CBCPAD: "A256CBCPAD",
 
   /** CKM AES key wrap. */
-  @added(KeyVault.Versions.`v7.6_preview.1`)
+  @added(KeyVault.Versions.`v7.6_preview.2`)
   CKM_AES_KEY_WRAP: "CKM_AES_KEY_WRAP",
 
   /** CKM AES key wrap with padding. */
-  @added(KeyVault.Versions.`v7.6_preview.1`)
+  @added(KeyVault.Versions.`v7.6_preview.2`)
   CKM_AES_KEY_WRAP_PAD: "CKM_AES_KEY_WRAP_PAD",
 }
 
 /**
- * The signing/verification algorithm identifier. For more information on possible
- * algorithm types, see JsonWebKeySignatureAlgorithm.
+ * The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.
  */
 union JsonWebKeySignatureAlgorithm {
   string,
 
   /**
-   * RSASSA-PSS using SHA-256 and MGF1 with SHA-256, as described in
-   * https://tools.ietf.org/html/rfc7518
+   * RSASSA-PSS using SHA-256 and MGF1 with SHA-256, as described in https://tools.ietf.org/html/rfc7518
    */
   PS256: "PS256",
 
   /**
-   * RSASSA-PSS using SHA-384 and MGF1 with SHA-384, as described in
-   * https://tools.ietf.org/html/rfc7518
+   * RSASSA-PSS using SHA-384 and MGF1 with SHA-384, as described in https://tools.ietf.org/html/rfc7518
    */
   PS384: "PS384",
 
   /**
-   * RSASSA-PSS using SHA-512 and MGF1 with SHA-512, as described in
-   * https://tools.ietf.org/html/rfc7518
+   * RSASSA-PSS using SHA-512 and MGF1 with SHA-512, as described in https://tools.ietf.org/html/rfc7518
    */
   PS512: "PS512",
 
   /**
-   * RSASSA-PKCS1-v1_5 using SHA-256, as described in
-   * https://tools.ietf.org/html/rfc7518
+   * RSASSA-PKCS1-v1_5 using SHA-256, as described in https://tools.ietf.org/html/rfc7518
    */
   RS256: "RS256",
 
   /**
-   * RSASSA-PKCS1-v1_5 using SHA-384, as described in
-   * https://tools.ietf.org/html/rfc7518
+   * RSASSA-PKCS1-v1_5 using SHA-384, as described in https://tools.ietf.org/html/rfc7518
    */
   RS384: "RS384",
 
   /**
-   * RSASSA-PKCS1-v1_5 using SHA-512, as described in
-   * https://tools.ietf.org/html/rfc7518
+   * RSASSA-PKCS1-v1_5 using SHA-512, as described in https://tools.ietf.org/html/rfc7518
    */
   RS512: "RS512",
+
+  /**
+   * HMAC using SHA-256, as described in  https://tools.ietf.org/html/rfc7518
+   */
+  @added(KeyVault.Versions.`v7.6_preview.2`)
+  HS256: "HS256",
+
+  /**
+   * HMAC using SHA-384, as described in https://tools.ietf.org/html/rfc7518
+   */
+  @added(KeyVault.Versions.`v7.6_preview.2`)
+  HS384: "HS384",
+
+  /**
+   * HMAC using SHA-512, as described in https://tools.ietf.org/html/rfc7518
+   */
+  @added(KeyVault.Versions.`v7.6_preview.2`)
+  HS512: "HS512",
 
   /**
    * Reserved
@@ -287,26 +263,22 @@ union JsonWebKeySignatureAlgorithm {
   RSNULL: "RSNULL",
 
   /**
-   * ECDSA using P-256 and SHA-256, as described in
-   * https://tools.ietf.org/html/rfc7518.
+   * ECDSA using P-256 and SHA-256, as described in https://tools.ietf.org/html/rfc7518.
    */
   ES256: "ES256",
 
   /**
-   * ECDSA using P-384 and SHA-384, as described in
-   * https://tools.ietf.org/html/rfc7518
+   * ECDSA using P-384 and SHA-384, as described in https://tools.ietf.org/html/rfc7518
    */
   ES384: "ES384",
 
   /**
-   * ECDSA using P-521 and SHA-512, as described in
-   * https://tools.ietf.org/html/rfc7518
+   * ECDSA using P-521 and SHA-512, as described in https://tools.ietf.org/html/rfc7518
    */
   ES512: "ES512",
 
   /**
-   * ECDSA using P-256K and SHA-256, as described in
-   * https://tools.ietf.org/html/rfc7518
+   * ECDSA using P-256K and SHA-256, as described in https://tools.ietf.org/html/rfc7518
    */
   ES256_K: "ES256K",
 }
@@ -330,7 +302,7 @@ union KeyEncryptionAlgorithm {
 /**
  * The type of the action. The value should be compared case-insensitively.
  */
-#suppress "@azure-tools/typespec-azure-core/no-enum" "Intentional enum; orignially modelAsString=false"
+#suppress "@azure-tools/typespec-azure-core/no-enum" "Intentional enum; originally modelAsString=false"
 enum KeyRotationPolicyAction {
   /**
    * Rotate the key based on the key policy.
@@ -365,8 +337,7 @@ model KeyCreateParameters {
   publicExponent?: int32;
 
   /**
-   * Json web key operations. For more information on possible key operations, see
-   * JsonWebKeyOperation.
+   * Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.
    */
   @encodedName("application/json", "key_ops")
   keyOps?: JsonWebKeyOperation[];
@@ -402,24 +373,19 @@ model KeyAttributes {
   ...Attributes;
 
   /**
-   * softDelete data retention days. Value should be >=7 and <=90 when softDelete
-   * enabled, otherwise 0.
+   * softDelete data retention days. Value should be >=7 and <=90 when softDelete enabled, otherwise 0.
    */
   @visibility(Lifecycle.Read)
   recoverableDays?: int32;
 
   /**
-   * Reflects the deletion recovery level currently in effect for keys in the
-   * current vault. If it contains 'Purgeable' the key can be permanently deleted by
-   * a privileged user; otherwise, only the system can purge the key, at the end of
-   * the retention interval.
+   * Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key, at the end of the retention interval.
    */
   @visibility(Lifecycle.Read)
-  recoveryLevel?: string; // DeletionRecoveryLevel, but this should be treated as an opaque string.
+  recoveryLevel?: DeletionRecoveryLevel;
 
   /**
-   * Indicates if the private key can be exported. Release policy must be provided
-   * when creating the first version of an exportable key.
+   * Indicates if the private key can be exported. Release policy must be provided when creating the first version of an exportable key.
    */
   exportable?: boolean;
 
@@ -428,6 +394,42 @@ model KeyAttributes {
    */
   @visibility(Lifecycle.Read)
   hsmPlatform?: string;
+
+  /**
+   * The key or key version attestation information.
+   */
+  @added(KeyVault.Versions.`v7.6_preview.2`)
+  @visibility(Lifecycle.Read)
+  attestation?: KeyAttestation;
+}
+
+/**
+ * The key attestation information.
+ */
+@added(KeyVault.Versions.`v7.6_preview.2`)
+model KeyAttestation {
+  /**
+   * A base64url-encoded string containing certificates in PEM format, used for attestation validation.
+   */
+  @encode("base64url")
+  certificatePemFile?: bytes;
+
+  /**
+   * The attestation blob bytes encoded as base64url string corresponding to a private key.
+   */
+  @encode("base64url")
+  privateKeyAttestation?: bytes;
+
+  /**
+   * The attestation blob bytes encoded as base64url string corresponding to a public key in case of asymmetric key.
+   */
+  @encode("base64url")
+  publicKeyAttestation?: bytes;
+
+  /**
+   * The version of the attestation.
+   */
+  version?: string;
 }
 
 /**
@@ -478,14 +480,12 @@ model KeyReleasePolicy {
   contentType?: string = "application/json; charset=utf-8";
 
   /**
-   * Defines the mutability state of the policy. Once marked immutable, this flag
-   * cannot be reset and the policy cannot be changed under any circumstances.
+   * Defines the mutability state of the policy. Once marked immutable, this flag cannot be reset and the policy cannot be changed under any circumstances.
    */
   immutable?: boolean;
 
   /**
-   * Blob encoding the policy rules under which the key can be released. Blob must
-   * be base64 URL encoded.
+   * Blob encoding the policy rules under which the key can be released. Blob must be base64 URL encoded.
    */
   @encodedName("application/json", "data")
   @encode("base64url")
@@ -512,8 +512,7 @@ model KeyBundle {
   tags?: Record<string>;
 
   /**
-   * True if the key's lifetime is managed by key vault. If this is a key backing a
-   * certificate, then managed will be true.
+   * True if the key's lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.
    */
   @visibility(Lifecycle.Read)
   managed?: boolean;
@@ -535,14 +534,12 @@ model JsonWebKey {
   kid?: string;
 
   /**
-   * JsonWebKey Key Type (kty), as defined in
-   * https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.
+   * JsonWebKey Key Type (kty), as defined in https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.
    */
   kty?: JsonWebKeyType;
 
   /**
-   * Json web key operations. For more information on possible key operations, see
-   * JsonWebKeyOperation.
+   * Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.
    */
   @encodedName("application/json", "key_ops")
   keyOps?: string[];
@@ -627,42 +624,6 @@ model JsonWebKey {
 }
 
 /**
- * The key vault error exception.
- */
-@error
-model KeyVaultError {
-  /**
-   * The key vault server error.
-   */
-  @visibility(Lifecycle.Read)
-  error?: Error;
-}
-
-/**
- * The key vault server error.
- */
-model Error {
-  /**
-   * The error code.
-   */
-  @visibility(Lifecycle.Read)
-  code?: string;
-
-  /**
-   * The error message.
-   */
-  @visibility(Lifecycle.Read)
-  message?: string;
-
-  /**
-   * The key vault server error.
-   */
-  @visibility(Lifecycle.Read)
-  @encodedName("application/json", "innererror")
-  innerError?: Error;
-}
-
-/**
  * The key import parameters.
  */
 model KeyImportParameters {
@@ -726,8 +687,7 @@ model DeletedKeyBundle {
  */
 model KeyUpdateParameters {
   /**
-   * Json web key operations. For more information on possible key operations, see
-   * JsonWebKeyOperation.
+   * Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.
    */
   @encodedName("application/json", "key_ops")
   keyOps?: JsonWebKeyOperation[];
@@ -789,8 +749,7 @@ model KeyItem {
   tags?: Record<string>;
 
   /**
-   * True if the key's lifetime is managed by key vault. If this is a key backing a
-   * certificate, then managed will be true.
+   * True if the key's lifetime is managed by key vault. If this is a key backing a certificate, then managed will be true.
    */
   @visibility(Lifecycle.Read)
   managed?: boolean;
@@ -837,22 +796,19 @@ model KeyOperationsParameters {
   value: bytes;
 
   /**
-   * Cryptographically random, non-repeating initialization vector for symmetric
-   * algorithms.
+   * Cryptographically random, non-repeating initialization vector for symmetric algorithms.
    */
   @encode("base64url")
   iv?: bytes;
 
   /**
-   * Additional data to authenticate but not encrypt/decrypt when using
-   * authenticated crypto algorithms.
+   * Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms.
    */
   @encode("base64url")
   aad?: bytes;
 
   /**
-   * The tag to authenticate when performing decryption with an authenticated
-   * algorithm.
+   * The tag to authenticate when performing decryption with an authenticated algorithm.
    */
   @encode("base64url")
   tag?: bytes;
@@ -877,16 +833,14 @@ model KeyOperationResult {
   result?: bytes;
 
   /**
-   * Cryptographically random, non-repeating initialization vector for symmetric
-   * algorithms.
+   * Cryptographically random, non-repeating initialization vector for symmetric algorithms.
    */
   @visibility(Lifecycle.Read)
   @encode("base64url")
   iv?: bytes;
 
   /**
-   * The tag to authenticate when performing decryption with an authenticated
-   * algorithm.
+   * The tag to authenticate when performing decryption with an authenticated algorithm.
    */
   @visibility(Lifecycle.Read)
   @encodedName("application/json", "tag")
@@ -894,8 +848,7 @@ model KeyOperationResult {
   authenticationTag?: bytes;
 
   /**
-   * Additional data to authenticate but not encrypt/decrypt when using
-   * authenticated crypto algorithms.
+   * Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms.
    */
   @visibility(Lifecycle.Read)
   @encodedName("application/json", "aad")
@@ -908,8 +861,7 @@ model KeyOperationResult {
  */
 model KeySignParameters {
   /**
-   * The signing/verification algorithm identifier. For more information on possible
-   * algorithm types, see JsonWebKeySignatureAlgorithm.
+   * The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.
    */
   @encodedName("application/json", "alg")
   algorithm: JsonWebKeySignatureAlgorithm;
@@ -926,8 +878,7 @@ model KeySignParameters {
  */
 model KeyVerifyParameters {
   /**
-   * The signing/verification algorithm. For more information on possible algorithm
-   * types, see JsonWebKeySignatureAlgorithm.
+   * The signing/verification algorithm. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.
    */
   @encodedName("application/json", "alg")
   algorithm: JsonWebKeySignatureAlgorithm;
@@ -995,8 +946,7 @@ model KeyReleaseResult {
  */
 model DeletedKeyListResult {
   /**
-   * A response message containing a list of deleted keys in the key vault along with a link to the next page of
-   * deleted keys.
+   * A response message containing a list of deleted keys in the key vault along with a link to the next page of deleted keys.
    */
   @pageItems
   @visibility(Lifecycle.Read)
@@ -1011,8 +961,7 @@ model DeletedKeyListResult {
 }
 
 /**
- * The deleted key item containing the deleted key metadata and information about
- * deletion.
+ * The deleted key item containing the deleted key metadata and information about deletion.
  */
 model DeletedKeyItem {
   ...KeyItem;
@@ -1048,10 +997,7 @@ model KeyRotationPolicy {
   id?: string;
 
   /**
-   * Actions that will be performed by Key Vault over the lifetime of a key. For
-   * preview, lifetimeActions can only have two items at maximum: one for rotate,
-   * one for notify. Notification time would be default to 30 days before expiry and
-   * it is not configurable.
+   * Actions that will be performed by Key Vault over the lifetime of a key. For preview, lifetimeActions can only have two items at maximum: one for rotate, one for notify. Notification time would be default to 30 days before expiry and it is not configurable.
    */
   lifetimeActions?: LifetimeActions[];
 
@@ -1062,8 +1008,7 @@ model KeyRotationPolicy {
 }
 
 /**
- * Action and its trigger that will be performed by Key Vault over the lifetime of
- * a key.
+ * Action and its trigger that will be performed by Key Vault over the lifetime of a key.
  */
 model LifetimeActions {
   /**
@@ -1082,14 +1027,12 @@ model LifetimeActions {
  */
 model LifetimeActionsTrigger {
   /**
-   * Time after creation to attempt to rotate. It only applies to rotate. It will be
-   * in ISO 8601 duration format. Example: 90 days : "P90D"
+   * Time after creation to attempt to rotate. It only applies to rotate. It will be in ISO 8601 duration format. Example: 90 days : "P90D"
    */
   timeAfterCreate?: string;
 
   /**
-   * Time before expiry to attempt to rotate or notify. It will be in ISO 8601
-   * duration format. Example: 90 days : "P90D"
+   * Time before expiry to attempt to rotate or notify. It will be in ISO 8601 duration format. Example: 90 days : "P90D"
    */
   timeBeforeExpiry?: string;
 }
@@ -1109,9 +1052,7 @@ model LifetimeActionsType {
  */
 model KeyRotationPolicyAttributes {
   /**
-   * The expiryTime will be applied on the new key version. It should be at least 28
-   * days. It will be in ISO 8601 Format. Examples: 90 days: P90D, 3 months: P3M, 48
-   * hours: PT48H, 1 year and 10 days: P1Y10D
+   * The expiryTime will be applied on the new key version. It should be at least 28 days. It will be in ISO 8601 Format. Examples: 90 days: P90D, 3 months: P3M, 48 hours: PT48H, 1 year and 10 days: P1Y10D
    */
   expiryTime?: string;
 
@@ -1158,8 +1099,7 @@ model RandomBytes {
  */
 model KeyProperties {
   /**
-   * Indicates if the private key can be exported. Release policy must be provided
-   * when creating the first version of an exportable key.
+   * Indicates if the private key can be exported. Release policy must be provided when creating the first version of an exportable key.
    */
   exportable?: boolean;
 
@@ -1194,14 +1134,12 @@ model KeyProperties {
  */
 model KeyExportParameters {
   /**
-   * The export key encryption Json web key. This key MUST be a RSA key that
-   * supports encryption.
+   * The export key encryption Json web key. This key MUST be a RSA key that supports encryption.
    */
   wrappingKey?: JsonWebKey;
 
   /**
-   * The export key encryption key identifier. This key MUST be a RSA key that
-   * supports encryption.
+   * The export key encryption key identifier. This key MUST be a RSA key that supports encryption.
    */
   wrappingKid?: string;
 

--- a/packages/typespec-go/test/tsp/KeyVault.Keys/routes.tsp
+++ b/packages/typespec-go/test/tsp/KeyVault.Keys/routes.tsp
@@ -3,38 +3,29 @@ import "@azure-tools/typespec-client-generator-core";
 import "@typespec/openapi";
 import "@typespec/rest";
 import "./models.tsp";
+import "./common.tsp";
 
-using Azure.Core;
-using Azure.Core.Traits;
 using Azure.ClientGenerator.Core;
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
-using TypeSpec.Rest;
 
 namespace KeyVault;
 
 /**
- * The create key operation can be used to create any key type in Azure Key Vault.
- * If the named key already exists, Azure Key Vault creates a new version of the
- * key. It requires the keys/create permission.
+ * The create key operation can be used to create any key type in Azure Key Vault. If the named key already exists, Azure Key Vault creates a new version of the key. It requires the keys/create permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
-@summary("""
-  Creates a new key, stores it, then returns key parameters and attributes to the
-  client.
-  """)
+@summary("Creates a new key, stores it, then returns key parameters and attributes to the client.")
 @route("/keys/{key-name}/create")
 @post
-op createKey is Azure.Core.Foundations.Operation<
+op createKey is KeyVaultOperation<
   {
     /**
-     * The name for the new key. The system will generate the version name for the new
-     * key. The value you provide may be copied globally for the purpose of running
-     * the service. The value provided should not include personally identifiable or
-     * sensitive information.
+     * The name for the new key. The system will generate the version name for the new key. The value you provide may be copied globally for the purpose of running the service. The value provided should not include personally identifiable or sensitive information.
      */
     @pattern("^[0-9a-zA-Z-]+$")
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
 
     /**
@@ -45,59 +36,45 @@ op createKey is Azure.Core.Foundations.Operation<
     @flattenProperty
     parameters: KeyCreateParameters;
   },
-  KeyBundle,
-  {},
-  KeyVaultError
+  KeyBundle
 >;
 
 /**
- * The operation will rotate the key based on the key policy. It requires the
- * keys/rotate permission.
+ * The operation will rotate the key based on the key policy. It requires the keys/rotate permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
-@summary("""
-  Creates a new key version, stores it, then returns key parameters, attributes
-  and policy to the client.
-  """)
+@summary("Creates a new key version, stores it, then returns key parameters, attributes and policy to the client.")
 @route("/keys/{key-name}/rotate")
 @post
-op rotateKey is Azure.Core.Foundations.Operation<
+op rotateKey is KeyVaultOperation<
   {
     /**
-     * The name of key to be rotated. The system will generate a new version in the
-     * specified key.
+     * The name of key to be rotated. The system will generate a new version in the specified key.
      */
     @pattern("^[0-9a-zA-Z-]+$")
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
   },
-  KeyBundle,
-  {},
-  KeyVaultError
+  KeyBundle
 >;
 
 /**
- * The import key operation may be used to import any key type into an Azure Key
- * Vault. If the named key already exists, Azure Key Vault creates a new version
- * of the key. This operation requires the keys/import permission.
+ * The import key operation may be used to import any key type into an Azure Key Vault. If the named key already exists, Azure Key Vault creates a new version of the key. This operation requires the keys/import permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name is already established"
-@summary("""
-  Imports an externally created key, stores it, and returns key parameters and
-  attributes to the client.
-  """)
+@summary("Imports an externally created key, stores it, and returns key parameters and attributes to the client.")
 @route("/keys/{key-name}")
 @put
-op importKey is Azure.Core.Foundations.Operation<
+op importKey is KeyVaultOperation<
   {
     /**
-     * Name for the imported key. The value you provide may be copied globally for the
-     * purpose of running the service. The value provided should not include
-     * personally identifiable or sensitive information.
+     * Name for the imported key. The value you provide may be copied globally for the purpose of running the service. The value provided should not include personally identifiable or sensitive information.
      */
     @pattern("^[0-9a-zA-Z-]+$")
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
 
     /**
@@ -108,59 +85,51 @@ op importKey is Azure.Core.Foundations.Operation<
     @flattenProperty
     parameters: KeyImportParameters;
   },
-  KeyBundle,
-  {},
-  KeyVaultError
+  KeyBundle
 >;
 
 /**
- * The delete key operation cannot be used to remove individual versions of a key.
- * This operation removes the cryptographic material associated with the key,
- * which means the key is not usable for Sign/Verify, Wrap/Unwrap or
- * Encrypt/Decrypt operations. This operation requires the keys/delete permission.
+ * The delete key operation cannot be used to remove individual versions of a key. This operation removes the cryptographic material associated with the key, which means the key is not usable for Sign/Verify, Wrap/Unwrap or Encrypt/Decrypt operations. This operation requires the keys/delete permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 @summary("Deletes a key of any type from storage in Azure Key Vault.")
 @route("/keys/{key-name}")
 @delete
-op deleteKey is Azure.Core.Foundations.Operation<
+op deleteKey is KeyVaultOperation<
   {
     /**
      * The name of the key to delete.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
   },
-  DeletedKeyBundle,
-  {},
-  KeyVaultError
+  DeletedKeyBundle
 >;
 
 /**
- * In order to perform this operation, the key must already exist in the Key
- * Vault. Note: The cryptographic material of a key itself cannot be changed. This
- * operation requires the keys/update permission.
+ * In order to perform this operation, the key must already exist in the Key Vault. Note: The cryptographic material of a key itself cannot be changed. This operation requires the keys/update permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
-@summary("""
-  The update key operation changes specified attributes of a stored key and can
-  be applied to any key type and key version stored in Azure Key Vault.
-  """)
+#suppress "@azure-tools/typespec-autorest/unsupported-optional-path-param" "Intentionally optional"
+@summary("The update key operation changes specified attributes of a stored key and can be applied to any key type and key version stored in Azure Key Vault.")
 @route("/keys/{key-name}/{key-version}")
-@patch
-op updateKey is Azure.Core.Foundations.Operation<
+@patch(#{ implicitOptionality: true })
+op updateKey is KeyVaultOperation<
   {
     /**
      * The name of key to update.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
 
     /**
      * The version of the key to update.
      */
     @path("key-version")
-    keyVersion: string;
+    @clientName("version", "go")
+    keyVersion?: string;
 
     /**
      * The parameters of the key to update.
@@ -170,44 +139,38 @@ op updateKey is Azure.Core.Foundations.Operation<
     @flattenProperty
     parameters: KeyUpdateParameters;
   },
-  KeyBundle,
-  {},
-  KeyVaultError
+  KeyBundle
 >;
 
 /**
- * The get key operation is applicable to all key types. If the requested key is
- * symmetric, then no key material is released in the response. This operation
- * requires the keys/get permission.
+ * The get key operation is applicable to all key types. If the requested key is symmetric, then no key material is released in the response. This operation requires the keys/get permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
+#suppress "@azure-tools/typespec-autorest/unsupported-optional-path-param" "Intentionally optional"
 @summary("Gets the public part of a stored key.")
 @route("/keys/{key-name}/{key-version}")
 @get
-op getKey is Azure.Core.Foundations.Operation<
+op getKey is KeyVaultOperation<
   {
     /**
      * The name of the key to get.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
 
     /**
-     * Adding the version parameter retrieves a specific version of a key. This URI
-     * fragment is optional. If not specified, the latest version of the key is
-     * returned.
+     * Adding the version parameter retrieves a specific version of a key. This URI fragment is optional. If not specified, the latest version of the key is returned.
      */
     @path("key-version")
-    keyVersion: string;
+    @clientName("version", "go")
+    keyVersion?: string;
   },
-  KeyBundle,
-  {},
-  KeyVaultError
+  KeyBundle
 >;
 
 /**
- * The full key identifier, attributes, and tags are provided in the response.
- * This operation requires the keys/list permission.
+ * The full key identifier, attributes, and tags are provided in the response. This operation requires the keys/list permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name is already established"
@@ -215,34 +178,28 @@ op getKey is Azure.Core.Foundations.Operation<
 @route("/keys/{key-name}/versions")
 @get
 @list
-op getKeyVersions is Azure.Core.Foundations.Operation<
+op getKeyVersions is KeyVaultOperation<
   {
     /**
      * The name of the key.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
 
     /**
-     * Maximum number of results to return in a page. If not specified the service
-     * will return up to 25 results.
+     * Maximum number of results to return in a page. If not specified the service will return up to 25 results.
      */
     @maxValue(25)
     @minValue(1)
     @query("maxresults")
     maxresults?: int32;
   },
-  KeyListResult,
-  {},
-  KeyVaultError
+  KeyListResult
 >;
 
 /**
- * Retrieves a list of the keys in the Key Vault as JSON Web Key structures that
- * contain the public part of a stored key. The LIST operation is applicable to
- * all key types, however only the base key identifier, attributes, and tags are
- * provided in the response. Individual versions of a key are not listed in the
- * response. This operation requires the keys/list permission.
+ * Retrieves a list of the keys in the Key Vault as JSON Web Key structures that contain the public part of a stored key. The LIST operation is applicable to all key types, however only the base key identifier, attributes, and tags are provided in the response. Individual versions of a key are not listed in the response. This operation requires the keys/list permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name is already established"
@@ -250,73 +207,46 @@ op getKeyVersions is Azure.Core.Foundations.Operation<
 @route("/keys")
 @get
 @list
-op getKeys is Azure.Core.Foundations.Operation<
+op getKeys is KeyVaultOperation<
   {
     /**
-     * Maximum number of results to return in a page. If not specified the service
-     * will return up to 25 results.
+     * Maximum number of results to return in a page. If not specified the service will return up to 25 results.
      */
     @maxValue(25)
     @minValue(1)
     @query("maxresults")
     maxresults?: int32;
   },
-  KeyListResult,
-  {},
-  KeyVaultError
+  KeyListResult
 >;
 
 /**
- * The Key Backup operation exports a key from Azure Key Vault in a protected
- * form. Note that this operation does NOT return key material in a form that can
- * be used outside the Azure Key Vault system, the returned key material is either
- * protected to a Azure Key Vault HSM or to Azure Key Vault itself. The intent of
- * this operation is to allow a client to GENERATE a key in one Azure Key Vault
- * instance, BACKUP the key, and then RESTORE it into another Azure Key Vault
- * instance. The BACKUP operation may be used to export, in protected form, any
- * key type from Azure Key Vault. Individual versions of a key cannot be backed
- * up. BACKUP / RESTORE can be performed within geographical boundaries only;
- * meaning that a BACKUP from one geographical area cannot be restored to another
- * geographical area. For example, a backup from the US geographical area cannot
- * be restored in an EU geographical area. This operation requires the key/backup
- * permission.
+ * The Key Backup operation exports a key from Azure Key Vault in a protected form. Note that this operation does NOT return key material in a form that can be used outside the Azure Key Vault system, the returned key material is either protected to a Azure Key Vault HSM or to Azure Key Vault itself. The intent of this operation is to allow a client to GENERATE a key in one Azure Key Vault instance, BACKUP the key, and then RESTORE it into another Azure Key Vault instance. The BACKUP operation may be used to export, in protected form, any key type from Azure Key Vault. Individual versions of a key cannot be backed up. BACKUP / RESTORE can be performed within geographical boundaries only; meaning that a BACKUP from one geographical area cannot be restored to another geographical area. For example, a backup from the US geographical area cannot be restored in an EU geographical area. This operation requires the key/backup permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 @summary("Requests that a backup of the specified key be downloaded to the client.")
 @route("/keys/{key-name}/backup")
 @post
-op backupKey is Azure.Core.Foundations.Operation<
+op backupKey is KeyVaultOperation<
   {
     /**
      * The name of the key.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
   },
-  BackupKeyResult,
-  {},
-  KeyVaultError
+  BackupKeyResult
 >;
 
 /**
- * Imports a previously backed up key into Azure Key Vault, restoring the key, its
- * key identifier, attributes and access control policies. The RESTORE operation
- * may be used to import a previously backed up key. Individual versions of a key
- * cannot be restored. The key is restored in its entirety with the same key name
- * as it had when it was backed up. If the key name is not available in the target
- * Key Vault, the RESTORE operation will be rejected. While the key name is
- * retained during restore, the final key identifier will change if the key is
- * restored to a different vault. Restore will restore all versions and preserve
- * version identifiers. The RESTORE operation is subject to security constraints:
- * The target Key Vault must be owned by the same Microsoft Azure Subscription as
- * the source Key Vault The user must have RESTORE permission in the target Key
- * Vault. This operation requires the keys/restore permission.
+ * Imports a previously backed up key into Azure Key Vault, restoring the key, its key identifier, attributes and access control policies. The RESTORE operation may be used to import a previously backed up key. Individual versions of a key cannot be restored. The key is restored in its entirety with the same key name as it had when it was backed up. If the key name is not available in the target Key Vault, the RESTORE operation will be rejected. While the key name is retained during restore, the final key identifier will change if the key is restored to a different vault. Restore will restore all versions and preserve version identifiers. The RESTORE operation is subject to security constraints: The target Key Vault must be owned by the same Microsoft Azure Subscription as the source Key Vault The user must have RESTORE permission in the target Key Vault. This operation requires the keys/restore permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 @summary("Restores a backed up key to a vault.")
 @route("/keys/restore")
 @post
-op restoreKey is Azure.Core.Foundations.Operation<
+op restoreKey is KeyVaultOperation<
   {
     /** The parameters to restore the key. */
     #suppress "deprecated" "Property flattening is supported for legacy scenarios like Key Vault's"
@@ -324,44 +254,34 @@ op restoreKey is Azure.Core.Foundations.Operation<
     @flattenProperty
     parameters: KeyRestoreParameters;
   },
-  KeyBundle,
-  {},
-  KeyVaultError
+  KeyBundle
 >;
 
 /**
- * The ENCRYPT operation encrypts an arbitrary sequence of bytes using an
- * encryption key that is stored in Azure Key Vault. Note that the ENCRYPT
- * operation only supports a single block of data, the size of which is dependent
- * on the target key and the encryption algorithm to be used. The ENCRYPT
- * operation is only strictly necessary for symmetric keys stored in Azure Key
- * Vault since protection with an asymmetric key can be performed using public
- * portion of the key. This operation is supported for asymmetric keys as a
- * convenience for callers that have a key-reference but do not have access to the
- * public key material. This operation requires the keys/encrypt permission.
+ * The ENCRYPT operation encrypts an arbitrary sequence of bytes using an encryption key that is stored in Azure Key Vault. Note that the ENCRYPT operation only supports a single block of data, the size of which is dependent on the target key and the encryption algorithm to be used. The ENCRYPT operation is only strictly necessary for symmetric keys stored in Azure Key Vault since protection with an asymmetric key can be performed using public portion of the key. This operation is supported for asymmetric keys as a convenience for callers that have a key-reference but do not have access to the public key material. This operation requires the keys/encrypt permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/no-openapi" "Operation ID is auto-capitalized, which would be breaking"
+#suppress "@azure-tools/typespec-autorest/unsupported-optional-path-param" "Intentionally optional"
 @operationId("encrypt")
-@summary("""
-  Encrypts an arbitrary sequence of bytes using an encryption key that is stored
-  in a key vault.
-  """)
+@summary("Encrypts an arbitrary sequence of bytes using an encryption key that is stored in a key vault.")
 @route("/keys/{key-name}/{key-version}/encrypt")
 @post
-op encrypt is Azure.Core.Foundations.Operation<
+op encrypt is KeyVaultOperation<
   {
     /**
      * The name of the key.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
 
     /**
      * The version of the key.
      */
     @path("key-version")
-    keyVersion: string;
+    @clientName("version", "go")
+    keyVersion?: string;
 
     /**
      * The parameters for the encryption operation.
@@ -371,43 +291,34 @@ op encrypt is Azure.Core.Foundations.Operation<
     @flattenProperty
     parameters: KeyOperationsParameters;
   },
-  KeyOperationResult,
-  {},
-  KeyVaultError
+  KeyOperationResult
 >;
 
 /**
- * The DECRYPT operation decrypts a well-formed block of ciphertext using the
- * target encryption key and specified algorithm. This operation is the reverse of
- * the ENCRYPT operation; only a single block of data may be decrypted, the size
- * of this block is dependent on the target key and the algorithm to be used. The
- * DECRYPT operation applies to asymmetric and symmetric keys stored in Azure Key
- * Vault since it uses the private portion of the key. This operation requires the
- * keys/decrypt permission. Microsoft recommends not to use CBC algorithms for
- * decryption without first ensuring the integrity of the ciphertext using an
- * HMAC, for example. See
- * https://docs.microsoft.com/dotnet/standard/security/vulnerabilities-cbc-mode
- * for more information.
+ * The DECRYPT operation decrypts a well-formed block of ciphertext using the target encryption key and specified algorithm. This operation is the reverse of the ENCRYPT operation; only a single block of data may be decrypted, the size of this block is dependent on the target key and the algorithm to be used. The DECRYPT operation applies to asymmetric and symmetric keys stored in Azure Key Vault since it uses the private portion of the key. This operation requires the keys/decrypt permission. Microsoft recommends not to use CBC algorithms for decryption without first ensuring the integrity of the ciphertext using an HMAC, for example. See https://learn.microsoft.com/dotnet/standard/security/vulnerabilities-cbc-mode for more information.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/no-openapi" "Operation ID is auto-capitalized, which would be breaking"
+#suppress "@azure-tools/typespec-autorest/unsupported-optional-path-param" "Intentionally optional"
 @operationId("decrypt")
 @summary("Decrypts a single block of encrypted data.")
 @route("/keys/{key-name}/{key-version}/decrypt")
 @post
-op decrypt is Azure.Core.Foundations.Operation<
+op decrypt is KeyVaultOperation<
   {
     /**
      * The name of the key.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
 
     /**
      * The version of the key.
      */
     @path("key-version")
-    keyVersion: string;
+    @clientName("version", "go")
+    keyVersion?: string;
 
     /**
      * The parameters for the decryption operation.
@@ -417,35 +328,34 @@ op decrypt is Azure.Core.Foundations.Operation<
     @flattenProperty
     parameters: KeyOperationsParameters;
   },
-  KeyOperationResult,
-  {},
-  KeyVaultError
+  KeyOperationResult
 >;
 
 /**
- * The SIGN operation is applicable to asymmetric and symmetric keys stored in
- * Azure Key Vault since this operation uses the private portion of the key. This
- * operation requires the keys/sign permission.
+ * The SIGN operation is applicable to asymmetric and symmetric keys stored in Azure Key Vault since this operation uses the private portion of the key. This operation requires the keys/sign permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/no-openapi" "Operation ID is auto-capitalized, which would be breaking"
+#suppress "@azure-tools/typespec-autorest/unsupported-optional-path-param" "Intentionally optional"
 @operationId("sign")
 @summary("Creates a signature from a digest using the specified key.")
 @route("/keys/{key-name}/{key-version}/sign")
 @post
-op sign is Azure.Core.Foundations.Operation<
+op sign is KeyVaultOperation<
   {
     /**
      * The name of the key.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
 
     /**
      * The version of the key.
      */
     @path("key-version")
-    keyVersion: string;
+    @clientName("version", "go")
+    keyVersion?: string;
 
     /**
      * The parameters for the signing operation.
@@ -455,38 +365,34 @@ op sign is Azure.Core.Foundations.Operation<
     @flattenProperty
     parameters: KeySignParameters;
   },
-  KeyOperationResult,
-  {},
-  KeyVaultError
+  KeyOperationResult
 >;
 
 /**
- * The VERIFY operation is applicable to symmetric keys stored in Azure Key Vault.
- * VERIFY is not strictly necessary for asymmetric keys stored in Azure Key Vault
- * since signature verification can be performed using the public portion of the
- * key but this operation is supported as a convenience for callers that only have
- * a key-reference and not the public portion of the key. This operation requires
- * the keys/verify permission.
+ * The VERIFY operation is applicable to symmetric keys stored in Azure Key Vault. VERIFY is not strictly necessary for asymmetric keys stored in Azure Key Vault since signature verification can be performed using the public portion of the key but this operation is supported as a convenience for callers that only have a key-reference and not the public portion of the key. This operation requires the keys/verify permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/no-openapi" "Operation ID is auto-capitalized, which would be breaking"
+#suppress "@azure-tools/typespec-autorest/unsupported-optional-path-param" "Intentionally optional"
 @operationId("verify")
 @summary("Verifies a signature using a specified key.")
 @route("/keys/{key-name}/{key-version}/verify")
 @post
-op verify is Azure.Core.Foundations.Operation<
+op verify is KeyVaultOperation<
   {
     /**
      * The name of the key.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
 
     /**
      * The version of the key.
      */
     @path("key-version")
-    keyVersion: string;
+    @clientName("version", "go")
+    keyVersion?: string;
 
     /**
      * The parameters for verify operations.
@@ -496,39 +402,34 @@ op verify is Azure.Core.Foundations.Operation<
     @flattenProperty
     parameters: KeyVerifyParameters;
   },
-  KeyVerifyResult,
-  {},
-  KeyVaultError
+  KeyVerifyResult
 >;
 
 /**
- * The WRAP operation supports encryption of a symmetric key using a key
- * encryption key that has previously been stored in an Azure Key Vault. The WRAP
- * operation is only strictly necessary for symmetric keys stored in Azure Key
- * Vault since protection with an asymmetric key can be performed using the public
- * portion of the key. This operation is supported for asymmetric keys as a
- * convenience for callers that have a key-reference but do not have access to the
- * public key material. This operation requires the keys/wrapKey permission.
+ * The WRAP operation supports encryption of a symmetric key using a key encryption key that has previously been stored in an Azure Key Vault. The WRAP operation is only strictly necessary for symmetric keys stored in Azure Key Vault since protection with an asymmetric key can be performed using the public portion of the key. This operation is supported for asymmetric keys as a convenience for callers that have a key-reference but do not have access to the public key material. This operation requires the keys/wrapKey permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/no-openapi" "Operation ID is auto-capitalized, which would be breaking"
+#suppress "@azure-tools/typespec-autorest/unsupported-optional-path-param" "Intentionally optional"
 @operationId("wrapKey")
 @summary("Wraps a symmetric key using a specified key.")
 @route("/keys/{key-name}/{key-version}/wrapkey")
 @post
-op wrapKey is Azure.Core.Foundations.Operation<
+op wrapKey is KeyVaultOperation<
   {
     /**
      * The name of the key.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
 
     /**
      * The version of the key.
      */
     @path("key-version")
-    keyVersion: string;
+    @clientName("version", "go")
+    keyVersion?: string;
 
     /**
      * The parameters for wrap operation.
@@ -538,40 +439,34 @@ op wrapKey is Azure.Core.Foundations.Operation<
     @flattenProperty
     parameters: KeyOperationsParameters;
   },
-  KeyOperationResult,
-  {},
-  KeyVaultError
+  KeyOperationResult
 >;
 
 /**
- * The UNWRAP operation supports decryption of a symmetric key using the target
- * key encryption key. This operation is the reverse of the WRAP operation. The
- * UNWRAP operation applies to asymmetric and symmetric keys stored in Azure Key
- * Vault since it uses the private portion of the key. This operation requires the
- * keys/unwrapKey permission.
+ * The UNWRAP operation supports decryption of a symmetric key using the target key encryption key. This operation is the reverse of the WRAP operation. The UNWRAP operation applies to asymmetric and symmetric keys stored in Azure Key Vault since it uses the private portion of the key. This operation requires the keys/unwrapKey permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/no-openapi" "Operation ID is auto-capitalized, which would be breaking"
+#suppress "@azure-tools/typespec-autorest/unsupported-optional-path-param" "Intentionally optional"
 @operationId("unwrapKey")
-@summary("""
-  Unwraps a symmetric key using the specified key that was initially used for
-  wrapping that key.
-  """)
+@summary("Unwraps a symmetric key using the specified key that was initially used for wrapping that key.")
 @route("/keys/{key-name}/{key-version}/unwrapkey")
 @post
-op unwrapKey is Azure.Core.Foundations.Operation<
+op unwrapKey is KeyVaultOperation<
   {
     /**
      * The name of the key.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
 
     /**
      * The version of the key.
      */
     @path("key-version")
-    keyVersion: string;
+    @clientName("version", "go")
+    keyVersion?: string;
 
     /**
      * The parameters for the key operation.
@@ -581,34 +476,34 @@ op unwrapKey is Azure.Core.Foundations.Operation<
     @flattenProperty
     parameters: KeyOperationsParameters;
   },
-  KeyOperationResult,
-  {},
-  KeyVaultError
+  KeyOperationResult
 >;
 
 /**
- * The release key operation is applicable to all key types. The target key must
- * be marked exportable. This operation requires the keys/release permission.
+ * The release key operation is applicable to all key types. The target key must be marked exportable. This operation requires the keys/release permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/no-openapi" "Operation ID is auto-capitalized, which would be breaking"
+#suppress "@azure-tools/typespec-autorest/unsupported-optional-path-param" "Intentionally optional"
 @operationId("release")
 @summary("Releases a key.")
 @route("/keys/{key-name}/{key-version}/release")
 @post
-op release is Azure.Core.Foundations.Operation<
+op release is KeyVaultOperation<
   {
     /**
      * The name of the key to get.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
 
     /**
      * Adding the version parameter retrieves a specific version of a key.
      */
     @path("key-version")
-    keyVersion: string;
+    @clientName("version", "go")
+    keyVersion?: string;
 
     /**
      * The parameters for the key release operation.
@@ -618,18 +513,11 @@ op release is Azure.Core.Foundations.Operation<
     @flattenProperty
     parameters: KeyReleaseParameters;
   },
-  KeyReleaseResult,
-  {},
-  KeyVaultError
+  KeyReleaseResult
 >;
 
 /**
- * Retrieves a list of the keys in the Key Vault as JSON Web Key structures that
- * contain the public part of a deleted key. This operation includes
- * deletion-specific information. The Get Deleted Keys operation is applicable for
- * vaults enabled for soft-delete. While the operation can be invoked on any
- * vault, it will return an error if invoked on a non soft-delete enabled vault.
- * This operation requires the keys/list permission.
+ * Retrieves a list of the keys in the Key Vault as JSON Web Key structures that contain the public part of a deleted key. This operation includes deletion-specific information. The Get Deleted Keys operation is applicable for vaults enabled for soft-delete. While the operation can be invoked on any vault, it will return an error if invoked on a non soft-delete enabled vault. This operation requires the keys/list permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name is already established"
@@ -637,129 +525,111 @@ op release is Azure.Core.Foundations.Operation<
 @route("/deletedkeys")
 @get
 @list
-op getDeletedKeys is Azure.Core.Foundations.Operation<
+op getDeletedKeys is KeyVaultOperation<
   {
     /**
-     * Maximum number of results to return in a page. If not specified the service
-     * will return up to 25 results.
+     * Maximum number of results to return in a page. If not specified the service will return up to 25 results.
      */
     @maxValue(25)
     @minValue(1)
     @query("maxresults")
     maxresults?: int32;
   },
-  DeletedKeyListResult,
-  {},
-  KeyVaultError
+  DeletedKeyListResult
 >;
 
 /**
- * The Get Deleted Key operation is applicable for soft-delete enabled vaults.
- * While the operation can be invoked on any vault, it will return an error if
- * invoked on a non soft-delete enabled vault. This operation requires the
- * keys/get permission.
+ * The Get Deleted Key operation is applicable for soft-delete enabled vaults. While the operation can be invoked on any vault, it will return an error if invoked on a non soft-delete enabled vault. This operation requires the keys/get permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 @summary("Gets the public part of a deleted key.")
 @route("/deletedkeys/{key-name}")
 @get
-op getDeletedKey is Azure.Core.Foundations.Operation<
+op getDeletedKey is KeyVaultOperation<
   {
     /**
      * The name of the key.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
   },
-  DeletedKeyBundle,
-  {},
-  KeyVaultError
+  DeletedKeyBundle
 >;
 
 /**
- * The Purge Deleted Key operation is applicable for soft-delete enabled vaults.
- * While the operation can be invoked on any vault, it will return an error if
- * invoked on a non soft-delete enabled vault. This operation requires the
- * keys/purge permission.
+ * The Purge Deleted Key operation is applicable for soft-delete enabled vaults. While the operation can be invoked on any vault, it will return an error if invoked on a non soft-delete enabled vault. This operation requires the keys/purge permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name is already established"
 @summary("Permanently deletes the specified key.")
 @route("/deletedkeys/{key-name}")
 @delete
-op purgeDeletedKey is Azure.Core.Foundations.Operation<
+op purgeDeletedKey is KeyVaultOperation<
   {
     /**
      * The name of the key
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
   },
-  void,
-  {},
-  KeyVaultError
+  void
 >;
 
 /**
- * The Recover Deleted Key operation is applicable for deleted keys in soft-delete
- * enabled vaults. It recovers the deleted key back to its latest version under
- * /keys. An attempt to recover an non-deleted key will return an error. Consider
- * this the inverse of the delete operation on soft-delete enabled vaults. This
- * operation requires the keys/recover permission.
+ * The Recover Deleted Key operation is applicable for deleted keys in soft-delete enabled vaults. It recovers the deleted key back to its latest version under /keys. An attempt to recover an non-deleted key will return an error. Consider this the inverse of the delete operation on soft-delete enabled vaults. This operation requires the keys/recover permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 @summary("Recovers the deleted key to its latest version.")
 @route("/deletedkeys/{key-name}/recover")
 @post
-op recoverDeletedKey is Azure.Core.Foundations.Operation<
+op recoverDeletedKey is KeyVaultOperation<
   {
     /**
      * The name of the deleted key.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
   },
-  KeyBundle,
-  {},
-  KeyVaultError
+  KeyBundle
 >;
 
 /**
- * The GetKeyRotationPolicy operation returns the specified key policy resources
- * in the specified key vault. This operation requires the keys/get permission.
+ * The GetKeyRotationPolicy operation returns the specified key policy resources in the specified key vault. This operation requires the keys/get permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 @summary("Lists the policy for a key.")
 @route("/keys/{key-name}/rotationpolicy")
 @get
-op getKeyRotationPolicy is Azure.Core.Foundations.Operation<
+op getKeyRotationPolicy is KeyVaultOperation<
   {
     /**
      * The name of the key in a given key vault.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
   },
-  KeyRotationPolicy,
-  {},
-  KeyVaultError
+  KeyRotationPolicy
 >;
 
 /**
- * Set specified members in the key policy. Leave others as undefined. This
- * operation requires the keys/update permission.
+ * Set specified members in the key policy. Leave others as undefined. This operation requires the keys/update permission.
  */
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
 #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Operation name is already established"
 @summary("Updates the rotation policy for a key.")
 @route("/keys/{key-name}/rotationpolicy")
 @put
-op updateKeyRotationPolicy is Azure.Core.Foundations.Operation<
+op updateKeyRotationPolicy is KeyVaultOperation<
   {
     /**
      * The name of the key in the given vault.
      */
     @path("key-name")
+    @clientName("name", "go")
     keyName: string;
 
     /**
@@ -768,9 +638,7 @@ op updateKeyRotationPolicy is Azure.Core.Foundations.Operation<
     @body
     keyRotationPolicy: KeyRotationPolicy;
   },
-  KeyRotationPolicy,
-  {},
-  KeyVaultError
+  KeyRotationPolicy
 >;
 
 /**
@@ -780,7 +648,7 @@ op updateKeyRotationPolicy is Azure.Core.Foundations.Operation<
 @summary("Get the requested number of bytes containing random values.")
 @route("/rng")
 @post
-op getRandomBytes is Azure.Core.Foundations.Operation<
+op getRandomBytes is KeyVaultOperation<
   {
     /** The request object to get random bytes. */
     #suppress "deprecated" "Property flattening is supported for legacy scenarios like Key Vault's"
@@ -788,7 +656,36 @@ op getRandomBytes is Azure.Core.Foundations.Operation<
     @flattenProperty
     parameters: GetRandomBytesRequest;
   },
-  RandomBytes,
-  {},
-  KeyVaultError
+  RandomBytes
+>;
+
+/**
+ * The get key attestation operation returns the key along with its attestation blob. This operation requires the keys/get permission.
+ */
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Foundations.Operation is necessary for Key Vault"
+#suppress "@azure-tools/typespec-autorest/unsupported-optional-path-param" "Intentionally optional"
+@Versioning.added(KeyVault.Versions.`v7.6_preview.2`)
+@summary("Gets the public part of a stored key along with its attestation blob.")
+@route("/keys/{key-name}/{key-version}/attestation")
+@get
+op getKeyAttestation is KeyVaultOperation<
+  {
+    /**
+     * The name of the key to retrieve attestation for.
+     */
+    @path("key-name")
+    @clientName("name", "go")
+    keyName: string;
+
+    /**
+     * Adding the version parameter retrieves attestation blob for specific version of a key. This URI fragment is optional. If not specified, the latest version of the key attestation blob is returned.
+     */
+    @path("key-version")
+    @clientName("version", "go")
+    keyVersion?: string;
+  },
+  /**
+   * A key bundle containing the key, its attributes and attestation blob.
+   */
+  KeyBundle
 >;


### PR DESCRIPTION
Only use values from operation param data that aren't captured in the
method param data (e.g. header/path/query param type etc).
Updated KV tsp to the latest version and regenerated.