### PR TITLE
regen based on original api-version

### DIFF
--- a/eng/scripts/sdk_regenerate.py
+++ b/eng/scripts/sdk_regenerate.py
@@ -126,7 +126,7 @@ def get_api_version(package_folder: Path, sdk_root: str) -> Optional[str]:
     return api_version
 
 def regenerate_sdk(use_latest_spec: bool, service_filter: str, sdk_root: str) -> Dict[str, List[str]]:
-    result = {"succeed_to_regenerate": [], "fail_to_regenerate": [], "time_to_regenerate": str(datetime.now())}
+    result = {"succeed_to_regenerate": [], "fail_to_regenerate": [], "not_found_api_version": [], "time_to_regenerate": str(datetime.now())}
     # get all tsp-location.yaml
     commit_id = get_latest_commit_id()
     sdk_resourcemanager_path = Path(sdk_root) / "sdk" / "resourcemanager"


### PR DESCRIPTION
Make sure every service regenerated based on its original api-version

- step1: extract api-version from _metadata.json
- step2: if not found apiVersion, extract api-version from generated client files

## Test
Use armconnectedcache as a test case, its original apiVersion is 2023-05-01-preview. The apiVersion in the latest spec commit is 2024-11-30-preview.  https://github.com/Azure/azure-rest-api-specs/blob/main/specification/connectedcache/ConnectedCache.Management/main.tsp

Currently, regen pipeline correctly use the 2023-05-01-preview apiVersion to generate SDK
- pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5323591&view=logs&j=c28f120c-e125-5ec5-8d4c-ba1a4d871fcc&t=60c22148-f7d7-52be-4bcb-ebd1725b4e5a
- regen PR: https://github.com/Azure/azure-sdk-for-go/pull/25222/files