### PR TITLE
Refactor method types in code model

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/adapter.ts
+++ b/packages/autorest.go/src/m4togocodemodel/adapter.ts
@@ -56,7 +56,7 @@ export async function m4ToGoCodeModel(host: AutorestExtensionHost) {
 
     for (const client of values(codeModel.clients)) {
       for (const method of client.methods) {
-        codeModel.responseEnvelopes.push(method.responseEnvelope);
+        codeModel.responseEnvelopes.push(method.returns);
         for (const param of values(method.parameters)) {
           if (param.group) {
             if (!paramGroups.has(param.group.groupName)) {

--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -57,7 +57,7 @@ export function adaptClients(m4CodeModel: m4.CodeModel, codeModel: go.CodeModel)
           method.nextPageMethod = nextPageMethod;
         }
       } else {
-        method = new go.Method(op.language.go!.name, client, httpPath, httpMethod, getStatusCodes(op), naming);
+        method = new go.SyncMethod(op.language.go!.name, client, httpPath, httpMethod, getStatusCodes(op), naming);
       }
 
       populateMethod(op, method, m4CodeModel, codeModel);
@@ -110,7 +110,7 @@ function populateMethod(op: m4.Operation, method: go.MethodType | go.NextPageMet
     }
 
     method.optionalParamsGroup = optionalParamsGroup;
-    method.responseEnvelope = adaptResponseEnvelope(m4CodeModel, codeModel, op, method);
+    method.returns = adaptResponseEnvelope(m4CodeModel, codeModel, op, method);
   }
 
   adaptMethodParameters(op, method);

--- a/packages/codegen.go/src/example.ts
+++ b/packages/codegen.go/src/example.ts
@@ -172,7 +172,7 @@ export async function generateExamples(codeModel: go.CodeModel): Promise<Array<E
           if (method.kind === 'lroPageableMethod') {
             resultName = 'res';
           }
-          const itemType = ((method as go.PageableMethod).responseEnvelope.result as go.ModelResult).modelType.fields.find(f => f.type.kind === 'slice')!;
+          const itemType = ((method as go.PageableMethod).returns.result as go.ModelResult).modelType.fields.find(f => f.type.kind === 'slice')!;
           exampleText += `\tfor ${resultName}.More() {\n`;
           exampleText += `\t\tpage, err := ${resultName}.NextPage(ctx)\n`;
           exampleText += `\t\tif err != nil {\n`;
@@ -192,7 +192,7 @@ export async function generateExamples(codeModel: go.CodeModel): Promise<Array<E
           exampleText += `\t}\n`;
         } else if (checkResponse) {
           // if has fieldName, then the result is not a model type
-          const fieldName = (method.responseEnvelope as any).fieldName;
+          const fieldName = (method.returns as any).fieldName;
           exampleText += `\t// You could use response here. We use blank identifier for just demo purposes.\n`;
           exampleText += `\t_ = res\n`;
 

--- a/packages/codegen.go/src/helpers.ts
+++ b/packages/codegen.go/src/helpers.ts
@@ -394,7 +394,7 @@ export function formatLiteralValue(value: go.Literal, withCast: boolean): string
 
 // returns true if at least one of the responses has a schema
 export function hasSchemaResponse(method: go.MethodType): boolean {
-  switch (method.responseEnvelope.result?.kind) {
+  switch (method.returns.result?.kind) {
     case 'anyResult':
     case 'modelResult':
     case 'monomorphicResult':
@@ -407,7 +407,7 @@ export function hasSchemaResponse(method: go.MethodType): boolean {
 
 // returns the name of the response field within the response envelope
 export function getResultFieldName(method: go.MethodType): string {
-  const result = method.responseEnvelope.result;
+  const result = method.returns.result;
   if (!result) {
     throw new CodegenError('InternalError', `missing result for method ${method.name}`);
   }
@@ -765,7 +765,7 @@ export function getSerDeFormat(model: go.Model | go.PolymorphicModel, codeModel:
         recursiveWalkModelFields(param.type, param.bodyFormat);
       }
 
-      const resultType = method.responseEnvelope.result;
+      const resultType = method.returns.result;
       switch (resultType?.kind) {
         case 'anyResult':
           if (resultType.format === 'JSON' || resultType.format === 'XML') {

--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -141,13 +141,13 @@ export async function generateOperations(codeModel: go.CodeModel): Promise<Array
       // it must be done before the imports are written out
       if (go.isLROMethod(method)) {
         // generate Begin method
-        opText += generateLROBeginMethod(client, method, imports, codeModel.options.injectSpans, codeModel.options.generateFakes);
+        opText += generateLROBeginMethod(method, imports, codeModel.options.injectSpans, codeModel.options.generateFakes);
       }
-      opText += generateOperation(client, method, imports, codeModel.options.injectSpans, codeModel.options.generateFakes);
-      opText += createProtocolRequest(azureARM, client, method, imports);
+      opText += generateOperation(method, imports, codeModel.options.injectSpans, codeModel.options.generateFakes);
+      opText += createProtocolRequest(azureARM, method, imports);
       if (method.kind !== 'lroMethod') {
         // LRO responses are handled elsewhere, with the exception of pageable LROs
-        opText += createProtocolResponse(client, method, imports);
+        opText += createProtocolResponse(method, imports);
       }
       if ((method.kind === 'lroPageableMethod' || method.kind === 'pageableMethod') && method.nextPageMethod && !nextPageMethods.includes(method.nextPageMethod)) {
         // track the next page methods to generate as multiple operations can use the same next page operation
@@ -156,7 +156,7 @@ export async function generateOperations(codeModel: go.CodeModel): Promise<Array
     }
 
     for (const method of nextPageMethods) {
-      opText += createProtocolRequest(azureARM, client, method, imports);
+      opText += createProtocolRequest(azureARM, method, imports);
     }
 
     // stitch it all together
@@ -483,7 +483,7 @@ function formatHeaderResponseValue(headerResp: go.HeaderScalarResponse | go.Head
 }
 
 function getZeroReturnValue(method: go.MethodType, apiType: 'api' | 'op' | 'handler'): string {
-  let returnType = `${method.responseEnvelope.name}{}`;
+  let returnType = `${method.returns.name}{}`;
   if (go.isLROMethod(method)) {
     if (apiType === 'api' || apiType === 'op') {
       // the api returns a *Poller[T]
@@ -507,10 +507,10 @@ function generateNilChecks(path: string, prefix: string = 'page'): string {
   return checks.join(' && ');
 }
 
-function emitPagerDefinition(client: go.Client, method: go.LROPageableMethod | go.PageableMethod, imports: ImportManager, injectSpans: boolean, generateFakes: boolean): string {
+function emitPagerDefinition(method: go.LROPageableMethod | go.PageableMethod, imports: ImportManager, injectSpans: boolean, generateFakes: boolean): string {
   imports.add('context');
-  let text = `runtime.NewPager(runtime.PagingHandler[${method.responseEnvelope.name}]{\n`;
-  text += `\t\tMore: func(page ${method.responseEnvelope.name}) bool {\n`;
+  let text = `runtime.NewPager(runtime.PagingHandler[${method.returns.name}]{\n`;
+  text += `\t\tMore: func(page ${method.returns.name}) bool {\n`;
   // there is no advancer for single-page pagers
   if (method.nextLinkName) {
     const nilChecks = generateNilChecks(method.nextLinkName);
@@ -520,10 +520,10 @@ function emitPagerDefinition(client: go.Client, method: go.LROPageableMethod | g
     text += '\t\t\treturn false\n';
     text += '\t\t},\n';
   }
-  text += `\t\tFetcher: func(ctx context.Context, page *${method.responseEnvelope.name}) (${method.responseEnvelope.name}, error) {\n`;
+  text += `\t\tFetcher: func(ctx context.Context, page *${method.returns.name}) (${method.returns.name}, error) {\n`;
   const reqParams = helpers.getCreateRequestParameters(method);
   if (generateFakes) {
-    text += `\t\tctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "${client.name}.${fixUpMethodName(method)}")\n`;
+    text += `\t\tctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "${method.receiver.type.name}.${fixUpMethodName(method)}")\n`;
   }
   if (method.nextLinkName) {
     let nextLinkVar: string;
@@ -556,21 +556,21 @@ function emitPagerDefinition(client: go.Client, method: go.LROPageableMethod | g
     } else {
       text += 'nil)\n';
     }
-    text += `\t\t\tif err != nil {\n\t\t\t\treturn ${method.responseEnvelope.name}{}, err\n\t\t\t}\n`;
+    text += `\t\t\tif err != nil {\n\t\t\t\treturn ${method.returns.name}{}, err\n\t\t\t}\n`;
     text += `\t\t\treturn client.${method.naming.responseMethod}(resp)\n`;
     text += '\t\t\t},\n';
   } else {
     // this is the singular page case, no fetcher helper required
     text += `\t\t\treq, err := client.${method.naming.requestMethod}(${reqParams})\n`;
     text += '\t\t\tif err != nil {\n';
-    text += `\t\t\t\treturn ${method.responseEnvelope.name}{}, err\n`;
+    text += `\t\t\t\treturn ${method.returns.name}{}, err\n`;
     text += '\t\t\t}\n';
     text += '\t\t\tresp, err := client.internal.Pipeline().Do(req)\n';
     text += '\t\t\tif err != nil {\n';
-    text += `\t\t\t\treturn ${method.responseEnvelope.name}{}, err\n`;
+    text += `\t\t\t\treturn ${method.returns.name}{}, err\n`;
     text += '\t\t\t}\n';
     text += '\t\t\tif !runtime.HasStatusCode(resp, http.StatusOK) {\n';
-    text += `\t\t\t\treturn ${method.responseEnvelope.name}{}, runtime.NewResponseError(resp)\n`;
+    text += `\t\t\t\treturn ${method.returns.name}{}, runtime.NewResponseError(resp)\n`;
     text += '\t\t\t}\n';
     text += `\t\t\treturn client.${method.naming.responseMethod}(resp)\n`;
     text += '\t\t},\n';
@@ -590,7 +590,7 @@ function genApiVersionDoc(apiVersions: Array<string>): string {
 }
 
 function genRespErrorDoc(method: go.MethodType): string {
-  if (!(method.responseEnvelope.result?.kind === 'headAsBooleanResult') && !go.isPageableMethod(method)) {
+  if (!(method.returns.result?.kind === 'headAsBooleanResult') && !go.isPageableMethod(method)) {
     // when head-as-boolean is enabled, no error is returned for 4xx status codes.
     // pager constructors don't return an error
     return '// If the operation fails it returns an *azcore.ResponseError type.\n';
@@ -598,7 +598,17 @@ function genRespErrorDoc(method: go.MethodType): string {
   return '';
 }
 
-function generateOperation(client: go.Client, method: go.MethodType, imports: ImportManager, injectSpans: boolean, generateFakes: boolean): string {
+/**
+ * returns the receiver definition for a client
+ * 
+ * @param receiver the receiver for which to emit the definition
+ * @returns the receiver definition
+ */
+function getClientReceiverDefinition(receiver: go.Receiver<go.Client>): string {
+  return `(${receiver.name} ${receiver.byValue ? '' : '*'}${receiver.type.name})`;
+}
+
+function generateOperation(method: go.MethodType, imports: ImportManager, injectSpans: boolean, generateFakes: boolean): string {
   const params = getAPIParametersSig(method, imports);
   const returns = generateReturnsInfo(method, 'op');
   let methodName = method.name;
@@ -625,16 +635,16 @@ function generateOperation(client: go.Client, method: go.MethodType, imports: Im
       text += helpers.formatCommentAsBulletItem(param.name, param.docs);
     }
   }
-  text += `func (client *${client.name}) ${methodName}(${params}) (${returns.join(', ')}) {\n`;
+  text += `func ${getClientReceiverDefinition(method.receiver)} ${methodName}(${params}) (${returns.join(', ')}) {\n`;
   const reqParams = helpers.getCreateRequestParameters(method);
   if (method.kind === 'pageableMethod') {
     text += '\treturn ';
-    text += emitPagerDefinition(client, method, imports, injectSpans, generateFakes);
+    text += emitPagerDefinition(method, imports, injectSpans, generateFakes);
     text += '}\n\n';
     return text;
   }
   text += '\tvar err error\n';
-  let operationName = `"${client.name}.${fixUpMethodName(method)}"`;
+  let operationName = `"${method.receiver.type.name}.${fixUpMethodName(method)}"`;
   if (generateFakes && injectSpans) {
     text += `\tconst operationName = ${operationName}\n`;
     operationName = 'operationName';
@@ -660,8 +670,8 @@ function generateOperation(client: go.Client, method: go.MethodType, imports: Im
   text += `\t\treturn ${zeroResp}, err\n`;
   text += '\t}\n';
   // HAB with headers response is handled in protocol responder
-  if (method.responseEnvelope.result?.kind === 'headAsBooleanResult' && method.responseEnvelope.headers.length === 0) {
-    text += `\treturn ${method.responseEnvelope.name}{${method.responseEnvelope.result.fieldName}: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil\n`;
+  if (method.returns.result?.kind === 'headAsBooleanResult' && method.returns.headers.length === 0) {
+    text += `\treturn ${method.returns.name}{${method.returns.result.fieldName}: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil\n`;
   } else {
     if (go.isLROMethod(method)) {
       text += '\treturn httpResp, nil\n';
@@ -669,17 +679,17 @@ function generateOperation(client: go.Client, method: go.MethodType, imports: Im
       // also cheating here as at present the only param to the responder is an http.Response
       text += `\tresp, err := client.${method.naming.responseMethod}(httpResp)\n`;
       text += '\treturn resp, err\n';
-    } else if (method.responseEnvelope.result?.kind === 'binaryResult') {
-      text += `\treturn ${method.responseEnvelope.name}{${method.responseEnvelope.result.fieldName}: httpResp.Body}, nil\n`;
+    } else if (method.returns.result?.kind === 'binaryResult') {
+      text += `\treturn ${method.returns.name}{${method.returns.result.fieldName}: httpResp.Body}, nil\n`;
     } else {
-      text += `\treturn ${method.responseEnvelope.name}{}, nil\n`;
+      text += `\treturn ${method.returns.name}{}, nil\n`;
     }
   }
   text += '}\n\n';
   return text;
 }
 
-function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.MethodType | go.NextPageMethod, imports: ImportManager): string {
+function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.NextPageMethod, imports: ImportManager): string {
   let name = method.name;
   if (method.kind !== 'nextPageMethod') {
     name = method.naming.requestMethod;
@@ -694,10 +704,10 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
 
   const returns = ['*policy.Request', 'error'];
   let text = `${comment(name, '// ')} creates the ${method.name} request.\n`;
-  text += `func (client *${client.name}) ${name}(${helpers.getCreateRequestParametersSig(method)}) (${returns.join(', ')}) {\n`;
+  text += `func ${getClientReceiverDefinition(method.receiver)} ${name}(${helpers.getCreateRequestParametersSig(method)}) (${returns.join(', ')}) {\n`;
 
   const hostParams = new Array<go.URIParameter>();
-  for (const parameter of client.parameters) {
+  for (const parameter of method.receiver.type.parameters) {
     if (parameter.kind === 'uriParam') {
       hostParams.push(parameter);
     }
@@ -706,10 +716,10 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
   let hostParam: string;
   if (azureARM) {
     hostParam = 'client.internal.Endpoint()';
-  } else if (client.templatedHost) {
+  } else if (method.receiver.type.templatedHost) {
     imports.add('strings');
     // we have a templated host
-    text += `\thost := "${client.templatedHost}"\n`;
+    text += `\thost := "${method.receiver.type.templatedHost}"\n`;
     // get all the host params on the client
     for (const hostParam of hostParams) {
       text += `\thost = strings.ReplaceAll(host, "{${hostParam.uriPathSegment}}", ${helpers.formatValue(`client.${hostParam.name}`, hostParam.type, imports)})\n`;
@@ -725,7 +735,7 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
     // simple parameterized host case
     hostParam = 'client.' + hostParams[0].name;
   } else {
-    throw new CodegenError('InternalError', `no host or endpoint defined for method ${client.name}.${method.name}`);
+    throw new CodegenError('InternalError', `no host or endpoint defined for method ${method.receiver.type.name}.${method.name}`);
   }
 
   const methodParamGroups = helpers.getMethodParamGroups(method);
@@ -879,7 +889,7 @@ function createProtocolRequest(azureARM: boolean, client: go.Client, method: go.
     text += '\treq.Raw().URL.RawQuery = strings.Join(unencodedParams, "&")\n';
   }
 
-  if (method.kind !== 'nextPageMethod' && method.responseEnvelope.result?.kind === 'binaryResult') {
+  if (method.kind !== 'nextPageMethod' && method.returns.result?.kind === 'binaryResult') {
     // skip auto-body downloading for binary stream responses
     text += '\truntime.SkipBodyDownload(req)\n';
   }
@@ -1170,7 +1180,7 @@ function isArrayOfDateTimeForMarshalling(paramType: go.WireType): { format: go.T
 // returns true if the method requires a response handler.
 // this is used to unmarshal the response body, parse response headers, or both.
 function needsResponseHandler(method: go.MethodType): boolean {
-  return helpers.hasSchemaResponse(method) || method.responseEnvelope.headers.length > 0;
+  return helpers.hasSchemaResponse(method) || method.returns.headers.length > 0;
 }
 
 function generateResponseUnmarshaller(method: go.MethodType, type: go.WireType, format: go.ResultFormat, unmarshalTarget: string): string {
@@ -1234,36 +1244,36 @@ function generateResponseUnmarshaller(method: go.MethodType, type: go.WireType, 
     unmarshallerText += `\t${unmarshalTarget} = &txt\n`;
   } else {
     // the remaining formats should have been handled elsewhere
-    throw new CodegenError('InternalError', `unhandled format ${format} for operation ${method.client.name}.${method.name}`);
+    throw new CodegenError('InternalError', `unhandled format ${format} for operation ${method.receiver.type.name}.${method.name}`);
   }
   return unmarshallerText;
 }
 
-function createProtocolResponse(client: go.Client, method: go.Method | go.LROPageableMethod | go.PageableMethod, imports: ImportManager): string {
+function createProtocolResponse(method: go.SyncMethod | go.LROPageableMethod | go.PageableMethod, imports: ImportManager): string {
   if (!needsResponseHandler(method)) {
     return '';
   }
   const name = method.naming.responseMethod;
   let text = `${comment(name, '// ')} handles the ${method.name} response.\n`;
-  text += `func (client *${client.name}) ${name}(resp *http.Response) (${generateReturnsInfo(method, 'handler').join(', ')}) {\n`;
+  text += `func ${getClientReceiverDefinition(method.receiver)} ${name}(resp *http.Response) (${generateReturnsInfo(method, 'handler').join(', ')}) {\n`;
 
   const addHeaders = function (headers: Array<go.HeaderScalarResponse | go.HeaderMapResponse>) {
     for (const header of values(headers)) {
-      text += formatHeaderResponseValue(header, imports, 'result', `${method.responseEnvelope.name}{}`);
+      text += formatHeaderResponseValue(header, imports, 'result', `${method.returns.name}{}`);
     }
   };
 
-  const result = method.responseEnvelope.result;
+  const result = method.returns.result;
   if (!result) {
     // only headers
-    text += `\tresult := ${method.responseEnvelope.name}{}\n`;
-    addHeaders(method.responseEnvelope.headers);
+    text += `\tresult := ${method.returns.name}{}\n`;
+    addHeaders(method.returns.headers);
   } else {
     switch (result.kind) {
       case 'anyResult':
         imports.add('fmt');
-        text += `\tresult := ${method.responseEnvelope.name}{}\n`;
-        addHeaders(method.responseEnvelope.headers);
+        text += `\tresult := ${method.returns.name}{}\n`;
+        addHeaders(method.returns.headers);
         text += '\tswitch resp.StatusCode {\n';
         for (const statusCode of method.httpStatusCodes) {
           text += `\tcase ${helpers.formatStatusCodes([statusCode])}:\n`;
@@ -1281,21 +1291,21 @@ function createProtocolResponse(client: go.Client, method: go.Method | go.LROPag
         text += '\t}\n';
         break;
       case 'binaryResult':
-        text += `\tresult := ${method.responseEnvelope.name}{${result.fieldName}: resp.Body}\n`;
-        addHeaders(method.responseEnvelope.headers);
+        text += `\tresult := ${method.returns.name}{${result.fieldName}: resp.Body}\n`;
+        addHeaders(method.returns.headers);
         break;
       case 'headAsBooleanResult':
-        text += `\tresult := ${method.responseEnvelope.name}{${result.fieldName}: resp.StatusCode >= 200 && resp.StatusCode < 300}\n`;
-        addHeaders(method.responseEnvelope.headers);
+        text += `\tresult := ${method.returns.name}{${result.fieldName}: resp.StatusCode >= 200 && resp.StatusCode < 300}\n`;
+        addHeaders(method.returns.headers);
         break;
       case 'modelResult':
-        text += `\tresult := ${method.responseEnvelope.name}{}\n`;
-        addHeaders(method.responseEnvelope.headers);
+        text += `\tresult := ${method.returns.name}{}\n`;
+        addHeaders(method.returns.headers);
         text += generateResponseUnmarshaller(method, result.modelType, result.format, `result.${helpers.getResultFieldName(method)}`);
         break;
       case 'monomorphicResult':
-        text += `\tresult := ${method.responseEnvelope.name}{}\n`;
-        addHeaders(method.responseEnvelope.headers);
+        text += `\tresult := ${method.returns.name}{}\n`;
+        addHeaders(method.returns.headers);
         let target = `result.${helpers.getResultFieldName(method)}`;
         // when unmarshalling a wrapped XML array, unmarshal into the response envelope
         if (result.format === 'XML' && result.monomorphicType.kind === 'slice') {
@@ -1304,8 +1314,8 @@ function createProtocolResponse(client: go.Client, method: go.Method | go.LROPag
         text += generateResponseUnmarshaller(method, result.monomorphicType, result.format, target);
         break;
       case 'polymorphicResult':
-        text += `\tresult := ${method.responseEnvelope.name}{}\n`;
-        addHeaders(method.responseEnvelope.headers);
+        text += `\tresult := ${method.returns.name}{}\n`;
+        addHeaders(method.returns.headers);
         text += generateResponseUnmarshaller(method, result.interface, result.format, 'result');
         break;
       default:
@@ -1363,7 +1373,7 @@ function getAPIParametersSig(method: go.MethodType, imports: ImportManager, pkgN
 //    op - for the operation
 // handler - for the response handler
 function generateReturnsInfo(method: go.MethodType, apiType: 'api' | 'op' | 'handler'): Array<string> {
-  let returnType = method.responseEnvelope.name;
+  let returnType = method.returns.name;
   switch (method.kind) {
     case 'lroMethod':
     case 'lroPageableMethod':
@@ -1398,7 +1408,7 @@ function generateReturnsInfo(method: go.MethodType, apiType: 'api' | 'op' | 'han
   return [returnType, 'error'];
 }
 
-function generateLROBeginMethod(client: go.Client, method: go.LROMethod | go.LROPageableMethod, imports: ImportManager, injectSpans: boolean, generateFakes: boolean): string {
+function generateLROBeginMethod(method: go.LROMethod | go.LROPageableMethod, imports: ImportManager, injectSpans: boolean, generateFakes: boolean): string {
   const params = getAPIParametersSig(method, imports);
   const returns = generateReturnsInfo(method, 'api');
   imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime');
@@ -1413,15 +1423,15 @@ function generateLROBeginMethod(client: go.Client, method: go.LROMethod | go.LRO
   for (const param of values(methodParams)) {
     text += helpers.formatCommentAsBulletItem(param.name, param.docs);
   }
-  text += `func (client *${client.name}) ${fixUpMethodName(method)}(${params}) (${returns.join(', ')}) {\n`;
+  text += `func ${getClientReceiverDefinition(method.receiver)} ${fixUpMethodName(method)}(${params}) (${returns.join(', ')}) {\n`;
   let pollerType = 'nil';
-  let pollerTypeParam = `[${method.responseEnvelope.name}]`;
+  let pollerTypeParam = `[${method.returns.name}]`;
   if (method.kind === 'lroPageableMethod') {
     // for paged LROs, we construct a pager and pass it to the LRO ctor.
     pollerTypeParam = `[*runtime.Pager${pollerTypeParam}]`;
     pollerType = '&pager';
     text += '\tpager := ';
-    text += emitPagerDefinition(client, method, imports, injectSpans, generateFakes);
+    text += emitPagerDefinition(method, imports, injectSpans, generateFakes);
   }
 
   text += '\tif options == nil || options.ResumeToken == "" {\n';

--- a/packages/codemodel.go/src/index.ts
+++ b/packages/codemodel.go/src/index.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 export * from './client.js';
+//export * from './method.js';
 export * from './package.js';
 export * from './param.js';
 export * from './result.js';

--- a/packages/codemodel.go/src/method.ts
+++ b/packages/codemodel.go/src/method.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as type from './type.js';
+
+/** a Go method */
+export interface Method<TReceiver, TReturns> {
+  /** the name of the method */
+  name: string;
+
+  /** any docs for the method */
+  docs: type.Docs;
+
+  /** contains info about the receiver */
+  receiver: Receiver<TReceiver>;
+
+  /** the parameters passed to the method. can be empty */
+  parameters: Array<Parameter>;
+
+  /** the method's return type */
+  returns?: TReturns;
+}
+
+/** a Go function or method parameter */
+export interface Parameter {
+  /** the name of the parameter */
+  name: string;
+
+  /** any docs for the parameter */
+  docs: type.Docs;
+
+  /** the parameter's type */
+  type: type.Type;
+
+  /** indicates if the param is pointer-to-type or not */
+  byValue: boolean;
+}
+
+/** a method's receiver parameter */
+export interface Receiver<T> {
+  /** the receiver var name */
+  name: string;
+
+  /** the receiver param's type */
+  type: T;
+
+  /** indicates if the receiver is pointer-to-type or not */
+  byValue: boolean;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+export class Method<TReceiver, TReturns> implements Method<TReceiver, TReturns> {
+  constructor(name: string, receiver: Receiver<TReceiver>) {
+    this.name = name;
+    this.receiver = receiver;
+    this.parameters = new Array<Parameter>();
+    this.docs = {};
+  }
+}
+
+export class Parameter implements Parameter {
+  constructor(name: string, type: type.Type, byValue: boolean) {
+    this.name = name;
+    this.type = type;
+    this.byValue = byValue;
+    this.docs = {};
+  }
+}
+
+export class Receiver<T> implements Receiver<T> {
+  constructor(name: string, type: T, byValue: boolean) {
+    this.name = name;
+    this.type = type;
+    this.byValue = byValue;
+  }
+}

--- a/packages/codemodel.go/src/param.ts
+++ b/packages/codemodel.go/src/param.ts
@@ -3,6 +3,7 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
+import * as method from './method.js';
 import * as type from './type.js';
 
 /** indicates the wire format for request bodies */
@@ -407,30 +408,7 @@ export function isLiteralParameter(param: MethodParameter | Parameter): boolean 
 // base types
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-interface ParameterBase {
-  /** the name of the parameter */
-  name: string;
-
-  /** any docs for the parameter */
-  docs: type.Docs;
-
-  /** the parameter's type */
-  type: type.Type;
-
-  /** indicates if the parameter is passed by value or by pointer */
-  byValue: boolean;
-}
-
-class ParameterBase implements ParameterBase {
-  constructor(name: string, type: type.Type, byValue: boolean) {
-    this.name = name;
-    this.type = type;
-    this.byValue = byValue;
-    this.docs = {};
-  }
-}
-
-interface HttpParameterBase extends ParameterBase {
+interface HttpParameterBase extends method.Parameter {
   /**
    * the parameter's type.
    * NOTE: if the type is a LiteralValue the style will either be literal or flag
@@ -447,7 +425,7 @@ interface HttpParameterBase extends ParameterBase {
   location: ParameterLocation;
 }
 
-class HttpParameterBase extends ParameterBase implements HttpParameterBase {
+class HttpParameterBase extends method.Parameter implements HttpParameterBase {
   constructor(name: string, type: type.WireType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
     super(name, type, byValue);
     this.style = style;


### PR DESCRIPTION
Added definition for vanilla Go methods and their parts (parameters and receivers).  The HTTP methods and parameters were updated to extend these types.  As a result, the client field was renamed to receiver and the responseEnvelope file was renamed to returns.
Renamed synchronous operation method to SyncMethod so it doesn't clash with the vanilla Method type.
Removed Client parameter from some codegen methods as it's not required (the method type contains this info).
Consolidated emitting a method's receiver signature to a shared helper.