### PR TITLE
Fixes for empty path param check

### DIFF
--- a/packages/autorest.go/CHANGELOG.md
+++ b/packages/autorest.go/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 4.0.0-preview.75 (unreleased)
+
+### Bugs Fixed
+
+* Emit empty path param check for path collection parameters.
+
 ## 4.0.0-preview.74 (2025-09-05)
 
 ### Breaking Changes

--- a/packages/autorest.go/package.json
+++ b/packages/autorest.go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/go",
-  "version": "4.0.0-preview.74",
+  "version": "4.0.0-preview.75",
   "description": "AutoRest Go Generator",
   "main": "dist/autorest.go/src/main.js",
   "type": "module",

--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -388,8 +388,12 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.MethodP
         adaptedParam = new go.PathCollectionParameter(param.language.go!.name, param.language.go!.serializedName, !skipURLEncoding(param),
           pathType, collectionFormat, style, param.language.go!.byValue, location);
       } else {
-        adaptedParam = new go.PathScalarParameter(param.language.go!.name, param.language.go!.serializedName, !skipURLEncoding(param),
+        const skipUrlEncoding = skipURLEncoding(param);
+        adaptedParam = new go.PathScalarParameter(param.language.go!.name, param.language.go!.serializedName, !skipUrlEncoding,
           adaptPathScalarParameterType(param.schema), style, param.language.go!.byValue, location);
+        // this is a legacy hack to work around the fact that
+        // swagger doesn't allow path params to be empty.
+        adaptedParam.omitEmptyStringCheck = skipUrlEncoding && (adaptedParam.type.kind === 'string' || (adaptedParam.type.kind === 'constant' && adaptedParam.type.type === 'string'));
       }
       break;
     }

--- a/packages/autorest.go/test/autorest/urlgroup/zz_paths_client.go
+++ b/packages/autorest.go/test/autorest/urlgroup/zz_paths_client.go
@@ -55,7 +55,11 @@ func (client *PathsClient) ArrayCSVInPath(ctx context.Context, arrayPath []strin
 // arrayCSVInPathCreateRequest creates the ArrayCSVInPath request.
 func (client *PathsClient) arrayCSVInPathCreateRequest(ctx context.Context, arrayPath []string, _ *PathsClientArrayCSVInPathOptions) (*policy.Request, error) {
 	urlPath := "/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}"
-	urlPath = strings.ReplaceAll(urlPath, "{arrayPath}", url.PathEscape(strings.Join(arrayPath, ",")))
+	arrayPathParam := strings.Join(arrayPath, ",")
+	if len(arrayPathParam) == 0 {
+		return nil, errors.New("parameter arrayPath cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{arrayPath}", url.PathEscape(arrayPathParam))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err

--- a/packages/codemodel.go/src/param.ts
+++ b/packages/codemodel.go/src/param.ts
@@ -217,6 +217,12 @@ export interface PathScalarParameter extends HttpParameterBase {
    * the default value is false.
    */
   isApiVersion: boolean;
+
+  /**
+   * this is ONLY for compat with autorest.
+   * the default value is false.
+   */
+  omitEmptyStringCheck: boolean;
 }
 
 /** defines the possible types for a PathScalarParameter */
@@ -548,6 +554,7 @@ export class PathScalarParameter extends HttpParameterBase implements PathScalar
     this.pathSegment = pathSegment;
     this.isEncoded = isEncoded;
     this.isApiVersion = false;
+    this.omitEmptyStringCheck = false;
   }
 }
 

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.8.3 (unreleased)
 
+### Bugs Fixed
+
+* Fixed missing empty path param check for unencoded path params.
+* Emit empty path param check for path collection parameters.
+
 ### Features Added
 
 * Clean up all generated Go files before emitting any new files.

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_extensionsresources_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_extensionsresources_client.go
@@ -91,6 +91,9 @@ func (client *ExtensionsResourcesClient) createOrUpdate(ctx context.Context, res
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *ExtensionsResourcesClient) createOrUpdateCreateRequest(ctx context.Context, resourceURI string, extensionsResourceName string, resource ExtensionsResource, _ *ExtensionsResourcesClientBeginCreateOrUpdateOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Azure.ResourceManager.Resources/extensionsResources/{extensionsResourceName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if extensionsResourceName == "" {
 		return nil, errors.New("parameter extensionsResourceName cannot be empty")
@@ -143,6 +146,9 @@ func (client *ExtensionsResourcesClient) Delete(ctx context.Context, resourceURI
 // deleteCreateRequest creates the Delete request.
 func (client *ExtensionsResourcesClient) deleteCreateRequest(ctx context.Context, resourceURI string, extensionsResourceName string, _ *ExtensionsResourcesClientDeleteOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Azure.ResourceManager.Resources/extensionsResources/{extensionsResourceName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if extensionsResourceName == "" {
 		return nil, errors.New("parameter extensionsResourceName cannot be empty")
@@ -190,6 +196,9 @@ func (client *ExtensionsResourcesClient) Get(ctx context.Context, resourceURI st
 // getCreateRequest creates the Get request.
 func (client *ExtensionsResourcesClient) getCreateRequest(ctx context.Context, resourceURI string, extensionsResourceName string, _ *ExtensionsResourcesClientGetOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Azure.ResourceManager.Resources/extensionsResources/{extensionsResourceName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if extensionsResourceName == "" {
 		return nil, errors.New("parameter extensionsResourceName cannot be empty")
@@ -247,6 +256,9 @@ func (client *ExtensionsResourcesClient) NewListByScopePager(resourceURI string,
 // listByScopeCreateRequest creates the ListByScope request.
 func (client *ExtensionsResourcesClient) listByScopeCreateRequest(ctx context.Context, resourceURI string, _ *ExtensionsResourcesClientListByScopeOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Azure.ResourceManager.Resources/extensionsResources"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
@@ -302,6 +314,9 @@ func (client *ExtensionsResourcesClient) Update(ctx context.Context, resourceURI
 // updateCreateRequest creates the Update request.
 func (client *ExtensionsResourcesClient) updateCreateRequest(ctx context.Context, resourceURI string, extensionsResourceName string, properties ExtensionsResource, _ *ExtensionsResourcesClientUpdateOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Azure.ResourceManager.Resources/extensionsResources/{extensionsResourceName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if extensionsResourceName == "" {
 		return nil, errors.New("parameter extensionsResourceName cannot be empty")

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_bgppeers_client.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_bgppeers_client.go
@@ -91,6 +91,9 @@ func (client *BgpPeersClient) createOrUpdate(ctx context.Context, resourceURI st
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *BgpPeersClient) createOrUpdateCreateRequest(ctx context.Context, resourceURI string, bgpPeerName string, resource BgpPeer, _ *BgpPeersClientBeginCreateOrUpdateOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/bgpPeers/{bgpPeerName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if bgpPeerName == "" {
 		return nil, errors.New("parameter bgpPeerName cannot be empty")
@@ -142,6 +145,9 @@ func (client *BgpPeersClient) Delete(ctx context.Context, resourceURI string, bg
 // deleteCreateRequest creates the Delete request.
 func (client *BgpPeersClient) deleteCreateRequest(ctx context.Context, resourceURI string, bgpPeerName string, _ *BgpPeersClientDeleteOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/bgpPeers/{bgpPeerName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if bgpPeerName == "" {
 		return nil, errors.New("parameter bgpPeerName cannot be empty")
@@ -189,6 +195,9 @@ func (client *BgpPeersClient) Get(ctx context.Context, resourceURI string, bgpPe
 // getCreateRequest creates the Get request.
 func (client *BgpPeersClient) getCreateRequest(ctx context.Context, resourceURI string, bgpPeerName string, _ *BgpPeersClientGetOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/bgpPeers/{bgpPeerName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if bgpPeerName == "" {
 		return nil, errors.New("parameter bgpPeerName cannot be empty")
@@ -245,6 +254,9 @@ func (client *BgpPeersClient) NewListPager(resourceURI string, options *BgpPeers
 // listCreateRequest creates the List request.
 func (client *BgpPeersClient) listCreateRequest(ctx context.Context, resourceURI string, _ *BgpPeersClientListOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/bgpPeers"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_loadbalancers_client.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_loadbalancers_client.go
@@ -91,6 +91,9 @@ func (client *LoadBalancersClient) createOrUpdate(ctx context.Context, resourceU
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *LoadBalancersClient) createOrUpdateCreateRequest(ctx context.Context, resourceURI string, loadBalancerName string, resource LoadBalancer, _ *LoadBalancersClientBeginCreateOrUpdateOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/loadBalancers/{loadBalancerName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if loadBalancerName == "" {
 		return nil, errors.New("parameter loadBalancerName cannot be empty")
@@ -142,6 +145,9 @@ func (client *LoadBalancersClient) Delete(ctx context.Context, resourceURI strin
 // deleteCreateRequest creates the Delete request.
 func (client *LoadBalancersClient) deleteCreateRequest(ctx context.Context, resourceURI string, loadBalancerName string, _ *LoadBalancersClientDeleteOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/loadBalancers/{loadBalancerName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if loadBalancerName == "" {
 		return nil, errors.New("parameter loadBalancerName cannot be empty")
@@ -189,6 +195,9 @@ func (client *LoadBalancersClient) Get(ctx context.Context, resourceURI string, 
 // getCreateRequest creates the Get request.
 func (client *LoadBalancersClient) getCreateRequest(ctx context.Context, resourceURI string, loadBalancerName string, _ *LoadBalancersClientGetOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/loadBalancers/{loadBalancerName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if loadBalancerName == "" {
 		return nil, errors.New("parameter loadBalancerName cannot be empty")
@@ -245,6 +254,9 @@ func (client *LoadBalancersClient) NewListPager(resourceURI string, options *Loa
 // listCreateRequest creates the List request.
 func (client *LoadBalancersClient) listCreateRequest(ctx context.Context, resourceURI string, _ *LoadBalancersClientListOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/loadBalancers"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_services_client.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_services_client.go
@@ -69,6 +69,9 @@ func (client *ServicesClient) CreateOrUpdate(ctx context.Context, resourceURI st
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *ServicesClient) createOrUpdateCreateRequest(ctx context.Context, resourceURI string, serviceName string, resource ServiceResource, _ *ServicesClientCreateOrUpdateOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/services/{serviceName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if serviceName == "" {
 		return nil, errors.New("parameter serviceName cannot be empty")
@@ -129,6 +132,9 @@ func (client *ServicesClient) Delete(ctx context.Context, resourceURI string, se
 // deleteCreateRequest creates the Delete request.
 func (client *ServicesClient) deleteCreateRequest(ctx context.Context, resourceURI string, serviceName string, _ *ServicesClientDeleteOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/services/{serviceName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if serviceName == "" {
 		return nil, errors.New("parameter serviceName cannot be empty")
@@ -176,6 +182,9 @@ func (client *ServicesClient) Get(ctx context.Context, resourceURI string, servi
 // getCreateRequest creates the Get request.
 func (client *ServicesClient) getCreateRequest(ctx context.Context, resourceURI string, serviceName string, _ *ServicesClientGetOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/services/{serviceName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if serviceName == "" {
 		return nil, errors.New("parameter serviceName cannot be empty")
@@ -232,6 +241,9 @@ func (client *ServicesClient) NewListPager(resourceURI string, options *Services
 // listCreateRequest creates the List request.
 func (client *ServicesClient) listCreateRequest(ctx context.Context, resourceURI string, _ *ServicesClientListOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/services"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_storageclass_client.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_storageclass_client.go
@@ -91,6 +91,9 @@ func (client *StorageClassClient) createOrUpdate(ctx context.Context, resourceUR
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *StorageClassClient) createOrUpdateCreateRequest(ctx context.Context, resourceURI string, storageClassName string, resource StorageClassResource, _ *StorageClassClientBeginCreateOrUpdateOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/storageClasses/{storageClassName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if storageClassName == "" {
 		return nil, errors.New("parameter storageClassName cannot be empty")
@@ -164,6 +167,9 @@ func (client *StorageClassClient) deleteOperation(ctx context.Context, resourceU
 // deleteCreateRequest creates the Delete request.
 func (client *StorageClassClient) deleteCreateRequest(ctx context.Context, resourceURI string, storageClassName string, _ *StorageClassClientBeginDeleteOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/storageClasses/{storageClassName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if storageClassName == "" {
 		return nil, errors.New("parameter storageClassName cannot be empty")
@@ -211,6 +217,9 @@ func (client *StorageClassClient) Get(ctx context.Context, resourceURI string, s
 // getCreateRequest creates the Get request.
 func (client *StorageClassClient) getCreateRequest(ctx context.Context, resourceURI string, storageClassName string, _ *StorageClassClientGetOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/storageClasses/{storageClassName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if storageClassName == "" {
 		return nil, errors.New("parameter storageClassName cannot be empty")
@@ -267,6 +276,9 @@ func (client *StorageClassClient) NewListPager(resourceURI string, options *Stor
 // listCreateRequest creates the List request.
 func (client *StorageClassClient) listCreateRequest(ctx context.Context, resourceURI string, _ *StorageClassClientListOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/storageClasses"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
@@ -342,6 +354,9 @@ func (client *StorageClassClient) update(ctx context.Context, resourceURI string
 // updateCreateRequest creates the Update request.
 func (client *StorageClassClient) updateCreateRequest(ctx context.Context, resourceURI string, storageClassName string, properties StorageClassResourceUpdate, _ *StorageClassClientBeginUpdateOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.KubernetesRuntime/storageClasses/{storageClassName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if storageClassName == "" {
 		return nil, errors.New("parameter storageClassName cannot be empty")

--- a/packages/typespec-go/test/local/armloadtestservice/zz_loadtestmappings_client.go
+++ b/packages/typespec-go/test/local/armloadtestservice/zz_loadtestmappings_client.go
@@ -70,6 +70,9 @@ func (client *LoadTestMappingsClient) CreateOrUpdate(ctx context.Context, resour
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *LoadTestMappingsClient) createOrUpdateCreateRequest(ctx context.Context, resourceURI string, loadTestMappingName string, resource LoadTestMappingResource, _ *LoadTestMappingsClientCreateOrUpdateOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.LoadTestService/loadTestMappings/{loadTestMappingName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if loadTestMappingName == "" {
 		return nil, errors.New("parameter loadTestMappingName cannot be empty")
@@ -130,6 +133,9 @@ func (client *LoadTestMappingsClient) Delete(ctx context.Context, resourceURI st
 // deleteCreateRequest creates the Delete request.
 func (client *LoadTestMappingsClient) deleteCreateRequest(ctx context.Context, resourceURI string, loadTestMappingName string, _ *LoadTestMappingsClientDeleteOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.LoadTestService/loadTestMappings/{loadTestMappingName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if loadTestMappingName == "" {
 		return nil, errors.New("parameter loadTestMappingName cannot be empty")
@@ -177,6 +183,9 @@ func (client *LoadTestMappingsClient) Get(ctx context.Context, resourceURI strin
 // getCreateRequest creates the Get request.
 func (client *LoadTestMappingsClient) getCreateRequest(ctx context.Context, resourceURI string, loadTestMappingName string, _ *LoadTestMappingsClientGetOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.LoadTestService/loadTestMappings/{loadTestMappingName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if loadTestMappingName == "" {
 		return nil, errors.New("parameter loadTestMappingName cannot be empty")
@@ -234,6 +243,9 @@ func (client *LoadTestMappingsClient) NewListPager(resourceURI string, options *
 // listCreateRequest creates the List request.
 func (client *LoadTestMappingsClient) listCreateRequest(ctx context.Context, resourceURI string, _ *LoadTestMappingsClientListOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.LoadTestService/loadTestMappings"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
@@ -288,6 +300,9 @@ func (client *LoadTestMappingsClient) Update(ctx context.Context, resourceURI st
 // updateCreateRequest creates the Update request.
 func (client *LoadTestMappingsClient) updateCreateRequest(ctx context.Context, resourceURI string, loadTestMappingName string, properties LoadTestMappingResourceUpdate, _ *LoadTestMappingsClientUpdateOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.LoadTestService/loadTestMappings/{loadTestMappingName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if loadTestMappingName == "" {
 		return nil, errors.New("parameter loadTestMappingName cannot be empty")

--- a/packages/typespec-go/test/local/armloadtestservice/zz_loadtestprofilemappings_client.go
+++ b/packages/typespec-go/test/local/armloadtestservice/zz_loadtestprofilemappings_client.go
@@ -70,6 +70,9 @@ func (client *LoadTestProfileMappingsClient) CreateOrUpdate(ctx context.Context,
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *LoadTestProfileMappingsClient) createOrUpdateCreateRequest(ctx context.Context, resourceURI string, loadTestProfileMappingName string, resource LoadTestProfileMappingResource, _ *LoadTestProfileMappingsClientCreateOrUpdateOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.LoadTestService/loadTestProfileMappings/{loadTestProfileMappingName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if loadTestProfileMappingName == "" {
 		return nil, errors.New("parameter loadTestProfileMappingName cannot be empty")
@@ -131,6 +134,9 @@ func (client *LoadTestProfileMappingsClient) Delete(ctx context.Context, resourc
 // deleteCreateRequest creates the Delete request.
 func (client *LoadTestProfileMappingsClient) deleteCreateRequest(ctx context.Context, resourceURI string, loadTestProfileMappingName string, _ *LoadTestProfileMappingsClientDeleteOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.LoadTestService/loadTestProfileMappings/{loadTestProfileMappingName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if loadTestProfileMappingName == "" {
 		return nil, errors.New("parameter loadTestProfileMappingName cannot be empty")
@@ -179,6 +185,9 @@ func (client *LoadTestProfileMappingsClient) Get(ctx context.Context, resourceUR
 // getCreateRequest creates the Get request.
 func (client *LoadTestProfileMappingsClient) getCreateRequest(ctx context.Context, resourceURI string, loadTestProfileMappingName string, _ *LoadTestProfileMappingsClientGetOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.LoadTestService/loadTestProfileMappings/{loadTestProfileMappingName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if loadTestProfileMappingName == "" {
 		return nil, errors.New("parameter loadTestProfileMappingName cannot be empty")
@@ -236,6 +245,9 @@ func (client *LoadTestProfileMappingsClient) NewListPager(resourceURI string, op
 // listCreateRequest creates the List request.
 func (client *LoadTestProfileMappingsClient) listCreateRequest(ctx context.Context, resourceURI string, _ *LoadTestProfileMappingsClientListOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.LoadTestService/loadTestProfileMappings"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
@@ -291,6 +303,9 @@ func (client *LoadTestProfileMappingsClient) Update(ctx context.Context, resourc
 // updateCreateRequest creates the Update request.
 func (client *LoadTestProfileMappingsClient) updateCreateRequest(ctx context.Context, resourceURI string, loadTestProfileMappingName string, properties LoadTestProfileMappingResourceUpdate, _ *LoadTestProfileMappingsClientUpdateOptions) (*policy.Request, error) {
 	urlPath := "/{resourceUri}/providers/Microsoft.LoadTestService/loadTestProfileMappings/{loadTestProfileMappingName}"
+	if resourceURI == "" {
+		return nil, errors.New("parameter resourceURI cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceUri}", resourceURI)
 	if loadTestProfileMappingName == "" {
 		return nil, errors.New("parameter loadTestProfileMappingName cannot be empty")


### PR DESCRIPTION
Always emit the empty path param check for unencoded path params with an underlying type of string when the source is tsp.
Added missing empty path param check for path collection params.

Fixes https://github.com/Azure/autorest.go/issues/1593