### PR TITLE
Consolidate parameter type definition emitting logic

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -356,7 +356,7 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.MethodP
           if (bodyType.kind !== 'slice') {
             throw new Error(`unexpected type ${go.getTypeDeclaration(bodyType)} for FormBodyCollectionParameter ${param.language.go!.name}`);
           }
-          adaptedParam = new go.FormBodyCollectionParameter(param.language.go!.name, param.language.go!.serializedName, bodyType, collectionFormat, style,byValue);
+          adaptedParam = new go.FormBodyCollectionParameter(param.language.go!.name, param.language.go!.serializedName, bodyType, collectionFormat, style, byValue);
         } else {
           adaptedParam = new go.FormBodyScalarParameter(param.language.go!.name, param.language.go!.serializedName, bodyType, style, byValue);
         }

--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -330,6 +330,10 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.MethodP
 
   const style = adaptParameterStyle(param);
 
+  // unfortunately param.language.go!.byValue isn't always populated.
+  // since we can't trust it, we calculate the value instead.
+  const byValue = helpers.isTypePassedByValue(param.schema) ? true : (go.isRequiredParameter(style) || (location === 'client' && go.isClientSideDefault(style)));
+
   switch (param.protocol.http?.in) {
     case 'body': {
       if (!op.requests![0].protocol.http!.mediaTypes) {
@@ -352,15 +356,15 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.MethodP
           if (bodyType.kind !== 'slice') {
             throw new Error(`unexpected type ${go.getTypeDeclaration(bodyType)} for FormBodyCollectionParameter ${param.language.go!.name}`);
           }
-          adaptedParam = new go.FormBodyCollectionParameter(param.language.go!.name, param.language.go!.serializedName, bodyType, collectionFormat, style, param.language.go!.byValue);
+          adaptedParam = new go.FormBodyCollectionParameter(param.language.go!.name, param.language.go!.serializedName, bodyType, collectionFormat, style,byValue);
         } else {
-          adaptedParam = new go.FormBodyScalarParameter(param.language.go!.name, param.language.go!.serializedName, bodyType, style, param.language.go!.byValue);
+          adaptedParam = new go.FormBodyScalarParameter(param.language.go!.name, param.language.go!.serializedName, bodyType, style, byValue);
         }
       } else if (op.requests![0].protocol.http!.knownMediaType === KnownMediaType.Multipart) {
-        adaptedParam = new go.MultipartFormBodyParameter(param.language.go!.name, bodyType, style, param.language.go!.byValue);
+        adaptedParam = new go.MultipartFormBodyParameter(param.language.go!.name, bodyType, style, byValue);
       } else {
         const format = adaptBodyFormat(op.requests![0].protocol);
-        adaptedParam = new go.BodyParameter(param.language.go!.name, format, contentType, bodyType, style, param.language.go!.byValue);
+        adaptedParam = new go.BodyParameter(param.language.go!.name, format, contentType, bodyType, style, byValue);
         adaptedParam.xml = adaptXMLInfo(param.schema);
       }
 
@@ -373,18 +377,16 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.MethodP
         if (headerType.kind !== 'map') {
           throw new Error(`unexpected type ${go.getTypeDeclaration(headerType)} for HeaderMapParameter ${param.language.go!.name}`);
         }
-        adaptedParam = new go.HeaderMapParameter(param.language.go!.name, param.schema.language.go!.headerCollectionPrefix, headerType, style,
-          param.language.go!.byValue, location);
+        adaptedParam = new go.HeaderMapParameter(param.language.go!.name, param.schema.language.go!.headerCollectionPrefix, headerType, style, byValue, location);
       } else if (collectionFormat) {
         const headerType = adaptWireType(param.schema, true);
         if (headerType.kind !== 'slice') {
           throw new Error(`unexpected type ${go.getTypeDeclaration(headerType)} for HeaderCollectionParameter ${param.language.go!.name}`);
         }
-        adaptedParam = new go.HeaderCollectionParameter(param.language.go!.name, param.language.go!.serializedName, headerType, collectionFormat, style,
-          param.language.go!.byValue, location);
+        adaptedParam = new go.HeaderCollectionParameter(param.language.go!.name, param.language.go!.serializedName, headerType, collectionFormat, style, byValue, location);
       } else {
         adaptedParam = new go.HeaderScalarParameter(param.language.go!.name, param.language.go!.serializedName, adaptHeaderScalarType(param.schema, true),
-          style, param.language.go!.byValue, location);
+          style, byValue, location);
       }
       break;
     }
@@ -396,11 +398,11 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.MethodP
           throw new Error(`unexpected type ${go.getTypeDeclaration(pathType)} for PathCollectionParameter ${param.language.go!.name}`);
         }
         adaptedParam = new go.PathCollectionParameter(param.language.go!.name, param.language.go!.serializedName, !skipURLEncoding(param),
-          pathType, collectionFormat, style, param.language.go!.byValue, location);
+          pathType, collectionFormat, style, byValue, location);
       } else {
         const skipUrlEncoding = skipURLEncoding(param);
         adaptedParam = new go.PathScalarParameter(param.language.go!.name, param.language.go!.serializedName, !skipUrlEncoding,
-          adaptPathScalarParameterType(param.schema), style, param.language.go!.byValue, location);
+          adaptPathScalarParameterType(param.schema), style, byValue, location);
         // this is a legacy hack to work around the fact that
         // swagger doesn't allow path params to be empty.
         adaptedParam.omitEmptyStringCheck = skipUrlEncoding && (adaptedParam.type.kind === 'string' || (adaptedParam.type.kind === 'constant' && adaptedParam.type.type === 'string'));
@@ -415,16 +417,16 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.MethodP
           throw new Error(`unexpected type ${go.getTypeDeclaration(queryType)} for QueryCollectionParameter ${param.language.go!.name}`);
         }
         adaptedParam = new go.QueryCollectionParameter(param.language.go!.name, param.language.go!.serializedName, !skipURLEncoding(param),
-          queryType, collectionFormat, style, param.language.go!.byValue, location);
+          queryType, collectionFormat, style, byValue, location);
       } else {
         adaptedParam = new go.QueryScalarParameter(param.language.go!.name, param.language.go!.serializedName, !skipURLEncoding(param),
-          adaptQueryScalarParameterType(param.schema), style, param.language.go!.byValue, location);
+          adaptQueryScalarParameterType(param.schema), style, byValue, location);
       }
       break;
     }
     case 'uri':
       adaptedParam = new go.URIParameter(param.language.go!.name, param.language.go!.serializedName, adaptURIPrameterType(param.schema),
-        style, param.language.go!.byValue, adaptParameterlocation(param));
+        style, byValue, adaptParameterlocation(param));
       break;
     default: {
       if (param.protocol.http?.in) {

--- a/packages/codegen.go/src/example.ts
+++ b/packages/codegen.go/src/example.ts
@@ -96,7 +96,7 @@ export async function generateExamples(codeModel: go.CodeModel): Promise<Array<E
               clientFactoryParamsExample.push({ parameter: clientParam, value: generateFakeExample(clientParam.type, clientParam.name) });
             }
           }
-          exampleText += `\tclientFactory, err := ${codeModel.packageName}.NewClientFactory(${clientFactoryParamsExample.map(p => getExampleValue(codeModel, p.value, '\t', imports, helpers.parameterByValue(p.parameter)).slice(1)).join(', ')}${clientFactoryParams.length > 0 ? ', ' : ''}cred, nil)\n`;
+          exampleText += `\tclientFactory, err := ${codeModel.packageName}.NewClientFactory(${clientFactoryParamsExample.map(p => getExampleValue(codeModel, p.value, '\t', imports, p.parameter.byValue).slice(1)).join(', ')}${clientFactoryParams.length > 0 ? ', ' : ''}cred, nil)\n`;
           exampleText += `\tif err != nil {\n`;
           exampleText += `\t\tlog.Fatalf("failed to create client: %v", err)\n`;
           exampleText += `\t}\n`;
@@ -108,11 +108,11 @@ export async function generateExamples(codeModel: go.CodeModel): Promise<Array<E
             }
           }
           if (clientPrivateParameters.length > 0) {
-            clientRef += `${clientPrivateParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, helpers.parameterByValue(p.parameter)).slice(1)).join(', ')}`;
+            clientRef += `${clientPrivateParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, p.parameter.byValue).slice(1)).join(', ')}`;
           }
           clientRef += `)`;
         } else {
-          exampleText += `\tclient, err := ${codeModel.packageName}.${client.constructors[0]?.name}(${clientParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, helpers.parameterByValue(p.parameter)).slice(1)).join(', ')}, cred, nil)\n`;
+          exampleText += `\tclient, err := ${codeModel.packageName}.${client.constructors[0]?.name}(${clientParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, p.parameter.byValue).slice(1)).join(', ')}, cred, nil)\n`;
           exampleText += `\tif err != nil {\n`;
           exampleText += `\t\tlog.Fatalf("failed to create client: %v", err)\n`;
           exampleText += `\t}\n`;
@@ -136,14 +136,14 @@ export async function generateExamples(codeModel: go.CodeModel): Promise<Array<E
         let methodOptionalParametersText = 'nil';
         if (methodOptionalParameters.length > 0) {
           methodOptionalParametersText = `&${codeModel.packageName}.${method.optionalParamsGroup.groupName}{\n`;
-          methodOptionalParametersText += methodOptionalParameters.map(p => `${capitalize(p.parameter.name)}: ${getExampleValue(codeModel, p.value, '\t', imports, helpers.parameterByValue(p.parameter)).slice(1)}`).join(',\n');
+          methodOptionalParametersText += methodOptionalParameters.map(p => `${capitalize(p.parameter.name)}: ${getExampleValue(codeModel, p.value, '\t', imports, p.parameter.byValue).slice(1)}`).join(',\n');
           methodOptionalParametersText += `}`;
         }
 
         switch (method.kind) {
           case 'lroMethod':
           case 'lroPageableMethod':
-            exampleText += `\tpoller, err := ${clientRef}.${fixUpMethodName(method)}(ctx, ${methodParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, helpers.parameterByValue(p.parameter)).slice(1)).join(', ')}${methodParameters.length > 0 ? ', ' : ''}${methodOptionalParametersText.split('\n').join('\n\t')})\n`;
+            exampleText += `\tpoller, err := ${clientRef}.${fixUpMethodName(method)}(ctx, ${methodParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, p.parameter.byValue).slice(1)).join(', ')}${methodParameters.length > 0 ? ', ' : ''}${methodOptionalParametersText.split('\n').join('\n\t')})\n`;
             exampleText += `\tif err != nil {\n`;
             exampleText += `\t\tlog.Fatalf("failed to finish the request: %v", err)\n`;
             exampleText += `\t}\n`;
@@ -154,13 +154,13 @@ export async function generateExamples(codeModel: go.CodeModel): Promise<Array<E
             exampleText += `\t}\n`;
             break;
           case 'method':
-            exampleText += `\t${checkResponse ? 'res' : '_'}, err ${checkResponse ? ':=' : '='} ${clientRef}.${fixUpMethodName(method)}(ctx, ${methodParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, helpers.parameterByValue(p.parameter)).slice(1)).join(', ')}${methodParameters.length > 0 ? ', ' : ''}${methodOptionalParametersText.split('\n').join('\n\t')})\n`;
+            exampleText += `\t${checkResponse ? 'res' : '_'}, err ${checkResponse ? ':=' : '='} ${clientRef}.${fixUpMethodName(method)}(ctx, ${methodParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, p.parameter.byValue).slice(1)).join(', ')}${methodParameters.length > 0 ? ', ' : ''}${methodOptionalParametersText.split('\n').join('\n\t')})\n`;
             exampleText += `\tif err != nil {\n`;
             exampleText += `\t\tlog.Fatalf("failed to finish the request: %v", err)\n`;
             exampleText += `\t}\n`;
             break;
           case 'pageableMethod':
-            exampleText += `\tpager := ${clientRef}.${fixUpMethodName(method)}(${methodParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, helpers.parameterByValue(p.parameter)).slice(1)).join(', ')}${methodParameters.length > 0 ? ', ' : ''}${methodOptionalParametersText.split('\n').join('\n\t')})\n`;
+            exampleText += `\tpager := ${clientRef}.${fixUpMethodName(method)}(${methodParameters.map(p => getExampleValue(codeModel, p.value, '\t', imports, p.parameter.byValue).slice(1)).join(', ')}${methodParameters.length > 0 ? ', ' : ''}${methodOptionalParametersText.split('\n').join('\n\t')})\n`;
             break;
           default:
             method satisfies never;

--- a/packages/codegen.go/src/helpers.ts
+++ b/packages/codegen.go/src/helpers.ts
@@ -53,7 +53,13 @@ export function sortAscending(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
-// returns the type name with possible * prefix
+/**
+ * returns the parameter's type definition with a possible '*' prefix
+ * 
+ * @param param the parameter for which to emit the type definition
+ * @param pkgName optional package name in which the type resides
+ * @returns the parameter type definition text
+ */
 export function formatParameterTypeName(param: go.ClientOptionsParameter | go.ClientParameter | go.ParameterGroup, pkgName?: string): string {
   let typeName: string;
   switch (param.kind) {
@@ -71,16 +77,11 @@ export function formatParameterTypeName(param: go.ClientOptionsParameter | go.Cl
       break;
     default:
       typeName = go.getTypeDeclaration(param.type, pkgName);
-      if (parameterByValue(param)) {
-        // client parameters with default values aren't emitted as pointer-to-type
+      if (param.byValue) {
         return typeName;
       }
   }
   return `*${typeName}`;
-}
-
-export function parameterByValue(param: go.ClientParameter): boolean {
-  return go.isRequiredParameter(param.style) || (param.location === 'client' && go.isClientSideDefault(param.style))
 }
 
 // sorts parameters by their required state, ordering required before optional


### PR DESCRIPTION
Use a param's byValue field instead of calculating it in some cases. This makes the param type definition emitting logic consistent with other cases (struct fields, etc).
Set the correct value for byValue in the Autorest emitter; its absence is likely why this code was bifurcated.