### PR TITLE
remove `@useDependency` for core and arm lib

### DIFF
--- a/packages/typespec-go/test/tsp/ApiCenter.Management/main.tsp
+++ b/packages/typespec-go/test/tsp/ApiCenter.Management/main.tsp
@@ -31,13 +31,9 @@ namespace Microsoft.ApiCenter;
 @doc("The available API versions.")
 enum Versions {
   /** The initial service version */
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   v2024_03_01: "2024-03-01",
 
   @doc("Azure API Center 2024-03-15-preview")
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   v2024_03_15_preview: "2024-03-15-preview",
 }
 

--- a/packages/typespec-go/test/tsp/AzureLargeInstance.Management/main.tsp
+++ b/packages/typespec-go/test/tsp/AzureLargeInstance.Management/main.tsp
@@ -25,17 +25,11 @@ namespace Microsoft.AzureLargeInstance;
 @doc("Azure Large Instance api versions.")
 enum Versions {
   @doc("Azure Large Instance api version 2023-07-20-preview.")
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   v2023_07_20_preview: "2023-07-20-preview",
 
   @doc("Azure Large Instance api version 2024-04-10.")
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   v2024_04_10: "2024-04-10",
 
   @doc("Azure Large Instance api version 2024-08-01-preview.")
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   v2024_08_01_preview: "2024-08-01-preview",
 }

--- a/packages/typespec-go/test/tsp/BillingBenefits.Management/main.tsp
+++ b/packages/typespec-go/test/tsp/BillingBenefits.Management/main.tsp
@@ -42,8 +42,6 @@ enum Versions {
   /**
    * The 2024-11-01-preview API version.
    */
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   v2024_11_01_preview: "2024-11-01-preview",
 }
 

--- a/packages/typespec-go/test/tsp/CodeSigning.Management/main.tsp
+++ b/packages/typespec-go/test/tsp/CodeSigning.Management/main.tsp
@@ -25,8 +25,6 @@ namespace Microsoft.CodeSigning;
 @doc("The available API versions.")
 enum Versions {
   @doc("The 2024-02-05-preview API version.")
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   v2024_02_05_preview: "2024-02-05-preview",
 
   v2024_09_30_preview: "2024-09-30-preview",

--- a/packages/typespec-go/test/tsp/Community.Management/main.tsp
+++ b/packages/typespec-go/test/tsp/Community.Management/main.tsp
@@ -19,7 +19,6 @@ namespace Microsoft.Community;
 /** Api versions */
 enum Versions {
   /** 2023-11-01 api version */
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
   `2023-11-01`,
 }
 

--- a/packages/typespec-go/test/tsp/ComputeSchedule.Management/main.tsp
+++ b/packages/typespec-go/test/tsp/ComputeSchedule.Management/main.tsp
@@ -20,20 +20,14 @@ namespace Microsoft.ComputeSchedule;
 /** ComputeSchedule API versions */
 enum Versions {
   /** 2024-08-15-preview version */
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
   `2024-08-15-preview`,
 
   /** 2024-10-01 version */
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
   `2024-10-01`,
 
   /** 2025-05-01 version */
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
   `2025-05-01`,
 }

--- a/packages/typespec-go/test/tsp/DatabaseWatcher.Management/watcher.tsp
+++ b/packages/typespec-go/test/tsp/DatabaseWatcher.Management/watcher.tsp
@@ -28,14 +28,10 @@ interface Operations extends Azure.ResourceManager.Operations {}
 @doc("Versions info.")
 enum Versions {
   @doc("The 2023-09-01-preview version.")
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   v2023_09_01_preview: "2023-09-01-preview",
 
   @doc("The 2024-07-17-preview version.")
   @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   v2024_07_19_preview: "2024-07-19-preview",
 }
 @doc("The DatabaseWatcherProviderHub resource.")

--- a/packages/typespec-go/test/tsp/HardwareSecurityModules.Management/main.tsp
+++ b/packages/typespec-go/test/tsp/HardwareSecurityModules.Management/main.tsp
@@ -39,8 +39,6 @@ enum Versions {
   /**
    * The 2024-06-30-preview API version.
    */
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   v2024_06_30_preview: "2024-06-30-preview",
 }
 

--- a/packages/typespec-go/test/tsp/Healthbot.Management/main.tsp
+++ b/packages/typespec-go/test/tsp/Healthbot.Management/main.tsp
@@ -39,8 +39,6 @@ enum Versions {
   /**
    * The 2024-02-01 API version.
    */
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   v2024_02_01: "2024-02-01",
 }
 

--- a/packages/typespec-go/test/tsp/KeyVault.Keys/main.tsp
+++ b/packages/typespec-go/test/tsp/KeyVault.Keys/main.tsp
@@ -39,24 +39,20 @@ enum Versions {
   /**
    * The 7.5 API version.
    */
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   `v7.5`: "7.5",
 
   /**
    * The 7.6-preview.2 API version.
    */
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   `v7.6_preview.2`: "7.6-preview.2",
 
   /**
    * The 7.6 API version.
    */
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   `v7.6`: "7.6",
 
   /**
    * The 2025-06-01-preview API version.
    */
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   v2025_06_01_preview: "2025-06-01-preview",
 }

--- a/packages/typespec-go/test/tsp/KubernetesRuntime.Management/common.tsp
+++ b/packages/typespec-go/test/tsp/KubernetesRuntime.Management/common.tsp
@@ -19,8 +19,6 @@ namespace Microsoft.KubernetesRuntime;
 
 @doc("Versions of KubernetesRuntime service")
 enum Versions {
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   @doc("2023-10-01-preview")
   v2023_10_01_preview: "2023-10-01-preview",
 

--- a/packages/typespec-go/test/tsp/LoadTestService.Management/client.tsp
+++ b/packages/typespec-go/test/tsp/LoadTestService.Management/client.tsp
@@ -8,7 +8,6 @@ using Microsoft.LoadTestService;
 using Azure.ResourceManager;
 
 @useDependency(Microsoft.LoadTestService.APIVersions.v2022_12_01)
-@useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
 namespace Customizations;
 
 @@clientName(LoadTests.updateLoadtest::parameters.properties,

--- a/packages/typespec-go/test/tsp/LoadTestService.Management/main.tsp
+++ b/packages/typespec-go/test/tsp/LoadTestService.Management/main.tsp
@@ -23,8 +23,6 @@ namespace Microsoft.LoadTestService;
 @doc("The Loadtest service resource manager version.")
 enum APIVersions {
   @doc("The 2022-12-01 version of the Azure Load Testing Resource manager API.")
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   v2022_12_01: "2022-12-01",
 
   @doc("The 2023-12-01-preview version of the Azure Load Testing Resource manager API.")

--- a/packages/typespec-go/test/tsp/Microsoft.DevOpsInfrastructure/main.tsp
+++ b/packages/typespec-go/test/tsp/Microsoft.DevOpsInfrastructure/main.tsp
@@ -22,8 +22,6 @@ namespace Microsoft.DevOpsInfrastructure;
 /** Api versions */
 enum Versions {
   /** 2024-04-04-preview preview version */
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   `2024-04-04-preview`,
 }
 

--- a/packages/typespec-go/test/tsp/MongoCluster.Management/main.tsp
+++ b/packages/typespec-go/test/tsp/MongoCluster.Management/main.tsp
@@ -26,17 +26,11 @@ namespace Microsoft.DocumentDB;
 /** The available API versions. */
 enum Versions {
   /** Azure Cosmos DB for Mongo vCore clusters api version 2024-03-01-preview. */
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   v2024_03_01_preview: "2024-03-01-preview",
 
   /** Azure Cosmos DB for Mongo vCore clusters api version 2024-06-01-preview. */
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   v2024_06_01_preview: "2024-06-01-preview",
 
   /** Azure Cosmos DB for Mongo vCore clusters api version 2024-07-01. */
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   v2024_07_01: "2024-07-01",
 }

--- a/packages/typespec-go/test/tsp/Oracle.Database.Management/versions.tsp
+++ b/packages/typespec-go/test/tsp/Oracle.Database.Management/versions.tsp
@@ -4,8 +4,6 @@ namespace Oracle.Database;
 
 @doc("Versions for API")
 enum Versions {
-  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
   @doc("2024-06-01-preview")
   v20240601_preview: "2024-06-01-preview",
 }

--- a/packages/typespec-go/test/tsp/Random.Management/main.tsp
+++ b/packages/typespec-go/test/tsp/Random.Management/main.tsp
@@ -22,8 +22,6 @@ namespace Microsoft.Random;
 @doc("The available API versions.")
 enum Versions {
   /** The initial service version */
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   v2024_03_01: "2024-03-01",
 }
 

--- a/packages/typespec-go/test/tsp/Test.Management/main.tsp
+++ b/packages/typespec-go/test/tsp/Test.Management/main.tsp
@@ -23,7 +23,5 @@ namespace Microsoft.Test;
 @doc("The available API versions.")
 enum Versions {
   @doc("The 2025-01-01 API version.")
-  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
-  @useDependency(Azure.Core.Versions.v1_0_Preview_1)
   v2025_01_01: "2025-01-01",
 }


### PR DESCRIPTION
It is a breaking change of core and arm lib to remove the [versioning](https://github.com/Azure/typespec-azure/pull/3268), this PR remove them from the local test and restore the nightly.