### PR TITLE
Refactor handling of tsp endpoint template args

### DIFF
--- a/packages/codegen.go/src/cloudConfig.ts
+++ b/packages/codegen.go/src/cloudConfig.ts
@@ -22,7 +22,10 @@ export function generateCloudConfig(codeModel: go.CodeModel): string {
   // check if this SDK uses token auth
   let tokenCred: go.TokenAuthentication | undefined;
   for (const client of codeModel.clients) {
-    for (const constructor of client.constructors) {
+    if (client.instance?.kind !== 'constructable') {
+      continue;
+    }
+    for (const constructor of client.instance.constructors) {
       if (constructor.authentication.kind === 'token') {
         tokenCred = constructor.authentication;
         break;

--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -49,8 +49,8 @@ export async function generateOperations(codeModel: go.CodeModel): Promise<Array
 
     let clientText = helpers.formatDocComment(client.docs);
     clientText += '// Don\'t use this type directly, use ';
-    if (client.constructors.length === 1) {
-      clientText += `${client.constructors[0].name}() instead.\n`;
+    if (client.instance?.kind === 'constructable' && client.instance.constructors.length === 1) {
+      clientText += `${client.instance.constructors[0].name}() instead.\n`;
     } else if (client.parent) {
       // find the accessor method
       let accessorMethod: string | undefined;
@@ -173,17 +173,19 @@ export async function generateOperations(codeModel: go.CodeModel): Promise<Array
  * @returns the client constructor code or the empty string
  */
 function generateConstructors(client: go.Client, imports: ImportManager): string {
-  if (client.constructors.length === 0) {
+  if (client.instance?.kind !== 'constructable') {
     return '';
   }
 
+  const clientOptions = client.instance.options;
+
   let ctorText = '';
 
-  if (client.options.kind === 'clientOptions') {
+  if (clientOptions.kind === 'clientOptions') {
     // for non-ARM, the options type will always be a parameter group
-    ctorText += `// ${client.options.name} contains the optional values for creating a [${client.name}].\n`;
-    ctorText += `type ${client.options.name} struct {\n\tazcore.ClientOptions\n`;
-    for (const param of client.options.params) {
+    ctorText += `// ${clientOptions.name} contains the optional values for creating a [${client.name}].\n`;
+    ctorText += `type ${clientOptions.name} struct {\n\tazcore.ClientOptions\n`;
+    for (const param of clientOptions.params) {
       if (go.isAPIVersionParameter(param)) {
         // we use azcore.ClientOptions.APIVersion
         continue;
@@ -200,12 +202,18 @@ function generateConstructors(client: go.Client, imports: ImportManager): string
     ctorText += '}\n\n';
   }
 
-  for (const constructor of client.constructors) {
+  for (const constructor of client.instance.constructors) {
     const ctorParams = new Array<string>();
     const paramDocs = new Array<string>();
 
-    constructor.parameters.sort(helpers.sortParametersByRequired);
-    for (const ctorParam of constructor.parameters) {
+    // ctor params can also be present in the supplemental endpoint parameters
+    const consolidatedCtorParams = new Array<go.ClientParameter>(...constructor.parameters);
+    if (client.instance.endpoint) {
+      consolidatedCtorParams.push(...client.instance.endpoint.parameters);
+    }
+
+    consolidatedCtorParams.sort(helpers.sortParametersByRequired);
+    for (const ctorParam of consolidatedCtorParams) {
       if (!go.isRequiredParameter(ctorParam.style)) {
         // param is part of the options group
         continue;
@@ -223,7 +231,7 @@ function generateConstructors(client: go.Client, imports: ImportManager): string
       let apiVersionConfig = '';
       // check if there's an api version parameter
       let apiVersionParam: go.HeaderScalarParameter | go.PathScalarParameter | go.QueryScalarParameter | go.URIParameter | undefined;
-      for (const param of client.parameters) {
+      for (const param of consolidatedCtorParams) {
         switch (param.kind) {
           case 'headerScalarParam':
           case 'pathScalarParam':
@@ -285,22 +293,22 @@ function generateConstructors(client: go.Client, imports: ImportManager): string
     let prolog: string;
     switch (constructor.authentication.kind) {
       case 'none':
-        if (client.options.kind !== 'clientOptions') {
-          throw new CodegenError('InternalError', `unexpected client options kind ${client.options.kind}`);
+        if (clientOptions.kind !== 'clientOptions') {
+          throw new CodegenError('InternalError', `unexpected client options kind ${clientOptions.kind}`);
         }
-        prolog = emitProlog(client.options.name, false);
+        prolog = emitProlog(clientOptions.name, false);
         break;
       case 'token':
         imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore');
         ctorParams.push('credential azcore.TokenCredential');
         paramDocs.push(helpers.formatCommentAsBulletItem('credential', { summary: 'used to authorize requests. Usually a credential from azidentity.' }));
-        switch (client.options.kind) {
+        switch (clientOptions.kind) {
           case 'clientOptions': {
             imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/policy');
             const tokenPolicyOpts = '&policy.BearerTokenOptions{\n\t\t\tInsecureAllowCredentialWithHTTP: options.InsecureAllowCredentialWithHTTP,\n\t\t}';
             // we assume a single scope. this is enforced when adapting the data from tcgc
             const tokenPolicy = `\n\t\tPerCall: []policy.Policy{\n\t\truntime.NewBearerTokenPolicy(credential, []string{c.Audience + "${helpers.splitScope(constructor.authentication.scopes[0]).scope}"}, ${tokenPolicyOpts}),\n\t\t},\n`;
-            prolog = emitProlog(client.options.name, true, tokenPolicy);
+            prolog = emitProlog(clientOptions.name, true, tokenPolicy);
             break;
           }
           case 'parameter':
@@ -313,8 +321,8 @@ function generateConstructors(client: go.Client, imports: ImportManager): string
     }
 
     // add client options last
-    ctorParams.push(`options ${helpers.formatParameterTypeName(client.options)}`);
-    paramDocs.push(helpers.formatCommentAsBulletItem('options', client.options.docs));
+    ctorParams.push(`options ${helpers.formatParameterTypeName(clientOptions)}`);
+    paramDocs.push(helpers.formatCommentAsBulletItem('options', clientOptions.docs));
 
     ctorText += `// ${constructor.name} creates a new instance of ${client.name} with the specified values.\n`;
     for (const doc of paramDocs) {
@@ -327,26 +335,45 @@ function generateConstructors(client: go.Client, imports: ImportManager): string
     ctorText += '\t\treturn nil, err\n';
     ctorText += '\t}\n';
 
-    // handle any client-side defaults
-    if (client.options.kind === 'clientOptions') {
-      for (const param of client.options.params) {
-        if (go.isClientSideDefault(param.style)) {
-          let name: string;
-          if (go.isAPIVersionParameter(param)) {
-            name = 'APIVersion';
-          } else {
-            name = ensureNameCase(param.name);
-          }
-          ctorText += `\t${param.name} := ${helpers.formatLiteralValue(param.style.defaultValue, false)}\n`;
-          ctorText += `\tif options.${name} != ${helpers.zeroValue(param)} {\n\t\t${param.name} = ${helpers.star(param.byValue)}options.${name}\n\t}\n`;
+    const emitClientSideDefault = function(param: go.ClientParameter): void {
+      if (go.isClientSideDefault(param.style)) {
+        let name: string;
+        if (go.isAPIVersionParameter(param)) {
+          name = 'APIVersion';
+        } else {
+          name = ensureNameCase(param.name);
         }
+        ctorText += `\t${param.name} := ${helpers.formatLiteralValue(param.style.defaultValue, false)}\n`;
+        ctorText += `\tif options.${name} != ${helpers.zeroValue(param)} {\n\t\t${param.name} = ${helpers.star(param.byValue)}options.${name}\n\t}\n`;
       }
+    };
+
+    // handle any client-side defaults
+    if (clientOptions.kind === 'clientOptions') {
+      for (const param of clientOptions.params) {
+        emitClientSideDefault(param);
+      }
+    }
+
+    // construct the supplemental path and join it to the endpoint
+    if (client.instance.endpoint) {
+      for (const param of client.instance.endpoint.parameters) {
+        emitClientSideDefault(param);
+      }
+      imports.add('strings');
+      ctorText += `\thost := "${client.instance.endpoint.path}"\n`;
+      for (const param of client.instance.endpoint.parameters) {
+        ctorText += `\thost = strings.ReplaceAll(host, "{${param.uriPathSegment}}", ${helpers.formatValue(param.name, param.type, imports)})\n`;
+      }
+      // the endpoint param is always the first ctor param
+      const endpointParam = client.instance.constructors[0].parameters[0];
+      ctorText += `\t${endpointParam.name} = runtime.JoinPaths(${endpointParam.name}, host)\n`;
     }
 
     // construct client literal
     let clientVar = 'client';
     // ensure clientVar doesn't collide with any params
-    for (const param of client.parameters) {
+    for (const param of consolidatedCtorParams) {
       if (param.name === clientVar) {
         clientVar = ensureNameCase(client.name, true);
         break;
@@ -354,6 +381,9 @@ function generateConstructors(client: go.Client, imports: ImportManager): string
     }
 
     ctorText += `\t${clientVar} := &${client.name}{\n`;
+    // NOTE: we don't enumerate consolidatedCtorParams here
+    // as any supplemental endpoint params are ephemeral and
+    // consumed during client construction.
     for (const parameter of values(client.parameters)) {
       if (go.isLiteralParameter(parameter.style)) {
         continue;
@@ -700,10 +730,10 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
   let hostParam: string;
   if (azureARM) {
     hostParam = 'client.internal.Endpoint()';
-  } else if (method.receiver.type.templatedHost) {
+  } else if (method.receiver.type.instance?.kind === 'templatedHost') {
     imports.add('strings');
     // we have a templated host
-    text += `\thost := "${method.receiver.type.templatedHost}"\n`;
+    text += `\thost := "${method.receiver.type.instance.path}"\n`;
     // get all the host params on the client
     for (const hostParam of hostParams) {
       text += `\thost = strings.ReplaceAll(host, "{${hostParam.uriPathSegment}}", ${helpers.formatValue(`client.${hostParam.name}`, hostParam.type, imports)})\n`;

--- a/packages/codemodel.go/src/package.ts
+++ b/packages/codemodel.go/src/package.ts
@@ -155,7 +155,9 @@ export class CodeModel implements CodeModel {
   
     this.clients.sort((a: client.Client, b: client.Client) => { return sortAscending(a.name, b.name); });
     for (const client of this.clients) {
-      client.constructors.sort((a: client.Constructor, b: client.Constructor) => sortAscending(a.name, b.name));
+      if (client.instance?.kind === 'constructable') {
+        client.instance.constructors.sort((a: client.Constructor, b: client.Constructor) => sortAscending(a.name, b.name));
+      }
       client.methods.sort((a: client.MethodType, b: client.MethodType) => { return sortAscending(a.name, b.name); });
       client.clientAccessors.sort((a: client.ClientAccessor, b: client.ClientAccessor) => { return sortAscending(a.name, b.name); });
       for (const method of client.methods) {

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Other Changes
 
 * Updated to the latest tsp toolset.
+* Moved handling of templated endpoints to client constructors.
 
 ## 0.8.2 (2025-09-10)
 

--- a/packages/typespec-go/test/azure-http-specs/client/structure/clientopgroup/zz_first_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/clientopgroup/zz_first_client.go
@@ -18,7 +18,6 @@ import (
 type FirstClient struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // FirstClientOptions contains the optional values for creating a [FirstClient].
@@ -38,9 +37,11 @@ func NewFirstClientWithNoCredential(endpoint string, client ClientType, options 
 	if err != nil {
 		return nil, err
 	}
+	host := "client/structure/{client}"
+	host = strings.ReplaceAll(host, "{client}", string(client))
+	endpoint = runtime.JoinPaths(endpoint, host)
 	firstClient := &FirstClient{
 		endpoint: endpoint,
-		client:   client,
 		internal: cl,
 	}
 	return firstClient, nil
@@ -51,7 +52,6 @@ func (client *FirstClient) NewFirstGroup3Client() *FirstGroup3Client {
 	return &FirstGroup3Client{
 		internal: client.internal,
 		endpoint: client.endpoint,
-		client:   client.client,
 	}
 }
 
@@ -60,7 +60,6 @@ func (client *FirstClient) NewFirstGroup4Client() *FirstGroup4Client {
 	return &FirstGroup4Client{
 		internal: client.internal,
 		endpoint: client.endpoint,
-		client:   client.client,
 	}
 }
 
@@ -90,11 +89,8 @@ func (client *FirstClient) One(ctx context.Context, options *FirstClientOneOptio
 
 // oneCreateRequest creates the One request.
 func (client *FirstClient) oneCreateRequest(ctx context.Context, _ *FirstClientOneOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/one"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/clientopgroup/zz_firstgroup3_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/clientopgroup/zz_firstgroup3_client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
-	"strings"
 )
 
 // FirstGroup3Client contains the methods for the FirstGroup3 group.
@@ -18,7 +17,6 @@ import (
 type FirstGroup3Client struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // Three -
@@ -47,11 +45,8 @@ func (client *FirstGroup3Client) Three(ctx context.Context, options *FirstGroup3
 
 // threeCreateRequest creates the Three request.
 func (client *FirstGroup3Client) threeCreateRequest(ctx context.Context, _ *FirstGroup3ClientThreeOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/three"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -84,11 +79,8 @@ func (client *FirstGroup3Client) Two(ctx context.Context, options *FirstGroup3Cl
 
 // twoCreateRequest creates the Two request.
 func (client *FirstGroup3Client) twoCreateRequest(ctx context.Context, _ *FirstGroup3ClientTwoOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/two"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/clientopgroup/zz_firstgroup4_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/clientopgroup/zz_firstgroup4_client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
-	"strings"
 )
 
 // FirstGroup4Client contains the methods for the FirstGroup4 group.
@@ -18,7 +17,6 @@ import (
 type FirstGroup4Client struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // Four -
@@ -47,11 +45,8 @@ func (client *FirstGroup4Client) Four(ctx context.Context, options *FirstGroup4C
 
 // fourCreateRequest creates the Four request.
 func (client *FirstGroup4Client) fourCreateRequest(ctx context.Context, _ *FirstGroup4ClientFourOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/four"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/clientopgroup/zz_second_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/clientopgroup/zz_second_client.go
@@ -18,7 +18,6 @@ import (
 type SecondClient struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // SecondClientOptions contains the optional values for creating a [SecondClient].
@@ -38,9 +37,11 @@ func NewSecondClientWithNoCredential(endpoint string, client ClientType, options
 	if err != nil {
 		return nil, err
 	}
+	host := "client/structure/{client}"
+	host = strings.ReplaceAll(host, "{client}", string(client))
+	endpoint = runtime.JoinPaths(endpoint, host)
 	secondClient := &SecondClient{
 		endpoint: endpoint,
-		client:   client,
 		internal: cl,
 	}
 	return secondClient, nil
@@ -51,7 +52,6 @@ func (client *SecondClient) NewSecondGroup5Client() *SecondGroup5Client {
 	return &SecondGroup5Client{
 		internal: client.internal,
 		endpoint: client.endpoint,
-		client:   client.client,
 	}
 }
 
@@ -81,11 +81,8 @@ func (client *SecondClient) Five(ctx context.Context, options *SecondClientFiveO
 
 // fiveCreateRequest creates the Five request.
 func (client *SecondClient) fiveCreateRequest(ctx context.Context, _ *SecondClientFiveOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/five"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/clientopgroup/zz_secondgroup5_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/clientopgroup/zz_secondgroup5_client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
-	"strings"
 )
 
 // SecondGroup5Client contains the methods for the SecondGroup5 group.
@@ -18,7 +17,6 @@ import (
 type SecondGroup5Client struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // Six -
@@ -47,11 +45,8 @@ func (client *SecondGroup5Client) Six(ctx context.Context, options *SecondGroup5
 
 // sixCreateRequest creates the Six request.
 func (client *SecondGroup5Client) sixCreateRequest(ctx context.Context, _ *SecondGroup5ClientSixOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/six"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_service_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_service_client.go
@@ -25,7 +25,6 @@ import (
 type ServiceClient struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // ServiceClientOptions contains the optional values for creating a [ServiceClient].
@@ -45,9 +44,11 @@ func NewServiceClientWithNoCredential(endpoint string, client ClientType, option
 	if err != nil {
 		return nil, err
 	}
+	host := "client/structure/{client}"
+	host = strings.ReplaceAll(host, "{client}", string(client))
+	endpoint = runtime.JoinPaths(endpoint, host)
 	serviceClient := &ServiceClient{
 		endpoint: endpoint,
-		client:   client,
 		internal: cl,
 	}
 	return serviceClient, nil
@@ -58,7 +59,6 @@ func (client *ServiceClient) NewServiceBarClient() *ServiceBarClient {
 	return &ServiceBarClient{
 		internal: client.internal,
 		endpoint: client.endpoint,
-		client:   client.client,
 	}
 }
 
@@ -67,7 +67,6 @@ func (client *ServiceClient) NewServiceBazClient() *ServiceBazClient {
 	return &ServiceBazClient{
 		internal: client.internal,
 		endpoint: client.endpoint,
-		client:   client.client,
 	}
 }
 
@@ -76,7 +75,6 @@ func (client *ServiceClient) NewServiceFooClient() *ServiceFooClient {
 	return &ServiceFooClient{
 		internal: client.internal,
 		endpoint: client.endpoint,
-		client:   client.client,
 	}
 }
 
@@ -85,7 +83,6 @@ func (client *ServiceClient) NewServiceQuxClient() *ServiceQuxClient {
 	return &ServiceQuxClient{
 		internal: client.internal,
 		endpoint: client.endpoint,
-		client:   client.client,
 	}
 }
 
@@ -115,11 +112,8 @@ func (client *ServiceClient) One(ctx context.Context, options *ServiceClientOneO
 
 // oneCreateRequest creates the One request.
 func (client *ServiceClient) oneCreateRequest(ctx context.Context, _ *ServiceClientOneOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/one"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -152,11 +146,8 @@ func (client *ServiceClient) Two(ctx context.Context, options *ServiceClientTwoO
 
 // twoCreateRequest creates the Two request.
 func (client *ServiceClient) twoCreateRequest(ctx context.Context, _ *ServiceClientTwoOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/two"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_servicebar_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_servicebar_client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
-	"strings"
 )
 
 // ServiceBarClient contains the methods for the ServiceBar group.
@@ -18,7 +17,6 @@ import (
 type ServiceBarClient struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // Five -
@@ -47,11 +45,8 @@ func (client *ServiceBarClient) Five(ctx context.Context, options *ServiceBarCli
 
 // fiveCreateRequest creates the Five request.
 func (client *ServiceBarClient) fiveCreateRequest(ctx context.Context, _ *ServiceBarClientFiveOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/five"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -84,11 +79,8 @@ func (client *ServiceBarClient) Six(ctx context.Context, options *ServiceBarClie
 
 // sixCreateRequest creates the Six request.
 func (client *ServiceBarClient) sixCreateRequest(ctx context.Context, _ *ServiceBarClientSixOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/six"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_servicebaz_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_servicebaz_client.go
@@ -11,7 +11,6 @@ import "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 type ServiceBazClient struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // NewServiceBazFooClient creates a new instance of [ServiceBazFooClient].
@@ -19,6 +18,5 @@ func (client *ServiceBazClient) NewServiceBazFooClient() *ServiceBazFooClient {
 	return &ServiceBazFooClient{
 		internal: client.internal,
 		endpoint: client.endpoint,
-		client:   client.client,
 	}
 }

--- a/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_servicebazfoo_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_servicebazfoo_client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
-	"strings"
 )
 
 // ServiceBazFooClient contains the methods for the ServiceBazFoo group.
@@ -18,7 +17,6 @@ import (
 type ServiceBazFooClient struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // Seven -
@@ -47,11 +45,8 @@ func (client *ServiceBazFooClient) Seven(ctx context.Context, options *ServiceBa
 
 // sevenCreateRequest creates the Seven request.
 func (client *ServiceBazFooClient) sevenCreateRequest(ctx context.Context, _ *ServiceBazFooClientSevenOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/seven"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_servicefoo_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_servicefoo_client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
-	"strings"
 )
 
 // ServiceFooClient contains the methods for the ServiceFoo group.
@@ -18,7 +17,6 @@ import (
 type ServiceFooClient struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // Four -
@@ -47,11 +45,8 @@ func (client *ServiceFooClient) Four(ctx context.Context, options *ServiceFooCli
 
 // fourCreateRequest creates the Four request.
 func (client *ServiceFooClient) fourCreateRequest(ctx context.Context, _ *ServiceFooClientFourOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/four"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -84,11 +79,8 @@ func (client *ServiceFooClient) Three(ctx context.Context, options *ServiceFooCl
 
 // threeCreateRequest creates the Three request.
 func (client *ServiceFooClient) threeCreateRequest(ctx context.Context, _ *ServiceFooClientThreeOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/three"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_servicequx_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_servicequx_client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
-	"strings"
 )
 
 // ServiceQuxClient contains the methods for the ServiceQux group.
@@ -18,7 +17,6 @@ import (
 type ServiceQuxClient struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // NewServiceQuxBarClient creates a new instance of [ServiceQuxBarClient].
@@ -26,7 +24,6 @@ func (client *ServiceQuxClient) NewServiceQuxBarClient() *ServiceQuxBarClient {
 	return &ServiceQuxBarClient{
 		internal: client.internal,
 		endpoint: client.endpoint,
-		client:   client.client,
 	}
 }
 
@@ -56,11 +53,8 @@ func (client *ServiceQuxClient) Eight(ctx context.Context, options *ServiceQuxCl
 
 // eightCreateRequest creates the Eight request.
 func (client *ServiceQuxClient) eightCreateRequest(ctx context.Context, _ *ServiceQuxClientEightOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/eight"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_servicequxbar_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_servicequxbar_client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
-	"strings"
 )
 
 // ServiceQuxBarClient contains the methods for the ServiceQuxBar group.
@@ -18,7 +17,6 @@ import (
 type ServiceQuxBarClient struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // Nine -
@@ -47,11 +45,8 @@ func (client *ServiceQuxBarClient) Nine(ctx context.Context, options *ServiceQux
 
 // nineCreateRequest creates the Nine request.
 func (client *ServiceQuxBarClient) nineCreateRequest(ctx context.Context, _ *ServiceQuxBarClientNineOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/nine"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/multiclientgroup/zz_clienta_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/multiclientgroup/zz_clienta_client.go
@@ -18,7 +18,6 @@ import (
 type ClientAClient struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // ClientAClientOptions contains the optional values for creating a [ClientAClient].
@@ -38,9 +37,11 @@ func NewClientAClientWithNoCredential(endpoint string, client ClientType, option
 	if err != nil {
 		return nil, err
 	}
+	host := "client/structure/{client}"
+	host = strings.ReplaceAll(host, "{client}", string(client))
+	endpoint = runtime.JoinPaths(endpoint, host)
 	clientAClient := &ClientAClient{
 		endpoint: endpoint,
-		client:   client,
 		internal: cl,
 	}
 	return clientAClient, nil
@@ -72,11 +73,8 @@ func (client *ClientAClient) RenamedFive(ctx context.Context, options *ClientACl
 
 // renamedFiveCreateRequest creates the RenamedFive request.
 func (client *ClientAClient) renamedFiveCreateRequest(ctx context.Context, _ *ClientAClientRenamedFiveOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/five"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -109,11 +107,8 @@ func (client *ClientAClient) RenamedOne(ctx context.Context, options *ClientACli
 
 // renamedOneCreateRequest creates the RenamedOne request.
 func (client *ClientAClient) renamedOneCreateRequest(ctx context.Context, _ *ClientAClientRenamedOneOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/one"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -146,11 +141,8 @@ func (client *ClientAClient) RenamedThree(ctx context.Context, options *ClientAC
 
 // renamedThreeCreateRequest creates the RenamedThree request.
 func (client *ClientAClient) renamedThreeCreateRequest(ctx context.Context, _ *ClientAClientRenamedThreeOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/three"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/multiclientgroup/zz_clientb_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/multiclientgroup/zz_clientb_client.go
@@ -18,7 +18,6 @@ import (
 type ClientBClient struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // ClientBClientOptions contains the optional values for creating a [ClientBClient].
@@ -38,9 +37,11 @@ func NewClientBClientWithNoCredential(endpoint string, client ClientType, option
 	if err != nil {
 		return nil, err
 	}
+	host := "client/structure/{client}"
+	host = strings.ReplaceAll(host, "{client}", string(client))
+	endpoint = runtime.JoinPaths(endpoint, host)
 	clientBClient := &ClientBClient{
 		endpoint: endpoint,
-		client:   client,
 		internal: cl,
 	}
 	return clientBClient, nil
@@ -72,11 +73,8 @@ func (client *ClientBClient) RenamedFour(ctx context.Context, options *ClientBCl
 
 // renamedFourCreateRequest creates the RenamedFour request.
 func (client *ClientBClient) renamedFourCreateRequest(ctx context.Context, _ *ClientBClientRenamedFourOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/four"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -109,11 +107,8 @@ func (client *ClientBClient) RenamedSix(ctx context.Context, options *ClientBCli
 
 // renamedSixCreateRequest creates the RenamedSix request.
 func (client *ClientBClient) renamedSixCreateRequest(ctx context.Context, _ *ClientBClientRenamedSixOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/six"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -146,11 +141,8 @@ func (client *ClientBClient) RenamedTwo(ctx context.Context, options *ClientBCli
 
 // renamedTwoCreateRequest creates the RenamedTwo request.
 func (client *ClientBClient) renamedTwoCreateRequest(ctx context.Context, _ *ClientBClientRenamedTwoOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/two"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/renamedopgroup/zz_renamedoperation_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/renamedopgroup/zz_renamedoperation_client.go
@@ -18,7 +18,6 @@ import (
 type RenamedOperationClient struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // RenamedOperationClientOptions contains the optional values for creating a [RenamedOperationClient].
@@ -38,9 +37,11 @@ func NewRenamedOperationClientWithNoCredential(endpoint string, client ClientTyp
 	if err != nil {
 		return nil, err
 	}
+	host := "client/structure/{client}"
+	host = strings.ReplaceAll(host, "{client}", string(client))
+	endpoint = runtime.JoinPaths(endpoint, host)
 	renamedOperationClient := &RenamedOperationClient{
 		endpoint: endpoint,
-		client:   client,
 		internal: cl,
 	}
 	return renamedOperationClient, nil
@@ -51,7 +52,6 @@ func (client *RenamedOperationClient) NewRenamedOperationGroupClient() *RenamedO
 	return &RenamedOperationGroupClient{
 		internal: client.internal,
 		endpoint: client.endpoint,
-		client:   client.client,
 	}
 }
 
@@ -82,11 +82,8 @@ func (client *RenamedOperationClient) RenamedFive(ctx context.Context, options *
 
 // renamedFiveCreateRequest creates the RenamedFive request.
 func (client *RenamedOperationClient) renamedFiveCreateRequest(ctx context.Context, _ *RenamedOperationClientRenamedFiveOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/five"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -120,11 +117,8 @@ func (client *RenamedOperationClient) RenamedOne(ctx context.Context, options *R
 
 // renamedOneCreateRequest creates the RenamedOne request.
 func (client *RenamedOperationClient) renamedOneCreateRequest(ctx context.Context, _ *RenamedOperationClientRenamedOneOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/one"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -158,11 +152,8 @@ func (client *RenamedOperationClient) RenamedThree(ctx context.Context, options 
 
 // renamedThreeCreateRequest creates the RenamedThree request.
 func (client *RenamedOperationClient) renamedThreeCreateRequest(ctx context.Context, _ *RenamedOperationClientRenamedThreeOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/three"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/renamedopgroup/zz_renamedoperationgroup_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/renamedopgroup/zz_renamedoperationgroup_client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
-	"strings"
 )
 
 // RenamedOperationGroupClient contains the methods for the RenamedOperationGroup group.
@@ -18,7 +17,6 @@ import (
 type RenamedOperationGroupClient struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // RenamedFour -
@@ -48,11 +46,8 @@ func (client *RenamedOperationGroupClient) RenamedFour(ctx context.Context, opti
 
 // renamedFourCreateRequest creates the RenamedFour request.
 func (client *RenamedOperationGroupClient) renamedFourCreateRequest(ctx context.Context, _ *RenamedOperationGroupClientRenamedFourOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/four"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -86,11 +81,8 @@ func (client *RenamedOperationGroupClient) RenamedSix(ctx context.Context, optio
 
 // renamedSixCreateRequest creates the RenamedSix request.
 func (client *RenamedOperationGroupClient) renamedSixCreateRequest(ctx context.Context, _ *RenamedOperationGroupClientRenamedSixOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/six"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -124,11 +116,8 @@ func (client *RenamedOperationGroupClient) RenamedTwo(ctx context.Context, optio
 
 // renamedTwoCreateRequest creates the RenamedTwo request.
 func (client *RenamedOperationGroupClient) renamedTwoCreateRequest(ctx context.Context, _ *RenamedOperationGroupClientRenamedTwoOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/two"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/twoopgroup/zz_twooperationgroup_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/twoopgroup/zz_twooperationgroup_client.go
@@ -7,6 +7,7 @@ package twoopgroup
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"strings"
 )
 
 // TwoOperationGroupClient contains the methods for the TwoOperationGroup group.
@@ -14,7 +15,6 @@ import (
 type TwoOperationGroupClient struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // TwoOperationGroupClientOptions contains the optional values for creating a [TwoOperationGroupClient].
@@ -34,9 +34,11 @@ func NewTwoOperationGroupClientWithNoCredential(endpoint string, client ClientTy
 	if err != nil {
 		return nil, err
 	}
+	host := "client/structure/{client}"
+	host = strings.ReplaceAll(host, "{client}", string(client))
+	endpoint = runtime.JoinPaths(endpoint, host)
 	twoOperationGroupClient := &TwoOperationGroupClient{
 		endpoint: endpoint,
-		client:   client,
 		internal: cl,
 	}
 	return twoOperationGroupClient, nil
@@ -47,7 +49,6 @@ func (client *TwoOperationGroupClient) NewTwoOperationGroupGroup1Client() *TwoOp
 	return &TwoOperationGroupGroup1Client{
 		internal: client.internal,
 		endpoint: client.endpoint,
-		client:   client.client,
 	}
 }
 
@@ -56,6 +57,5 @@ func (client *TwoOperationGroupClient) NewTwoOperationGroupGroup2Client() *TwoOp
 	return &TwoOperationGroupGroup2Client{
 		internal: client.internal,
 		endpoint: client.endpoint,
-		client:   client.client,
 	}
 }

--- a/packages/typespec-go/test/azure-http-specs/client/structure/twoopgroup/zz_twooperationgroupgroup1_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/twoopgroup/zz_twooperationgroupgroup1_client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
-	"strings"
 )
 
 // TwoOperationGroupGroup1Client contains the methods for the TwoOperationGroupGroup1 group.
@@ -18,7 +17,6 @@ import (
 type TwoOperationGroupGroup1Client struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // Four -
@@ -48,11 +46,8 @@ func (client *TwoOperationGroupGroup1Client) Four(ctx context.Context, options *
 
 // fourCreateRequest creates the Four request.
 func (client *TwoOperationGroupGroup1Client) fourCreateRequest(ctx context.Context, _ *TwoOperationGroupGroup1ClientFourOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/four"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -86,11 +81,8 @@ func (client *TwoOperationGroupGroup1Client) One(ctx context.Context, options *T
 
 // oneCreateRequest creates the One request.
 func (client *TwoOperationGroupGroup1Client) oneCreateRequest(ctx context.Context, _ *TwoOperationGroupGroup1ClientOneOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/one"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -124,11 +116,8 @@ func (client *TwoOperationGroupGroup1Client) Three(ctx context.Context, options 
 
 // threeCreateRequest creates the Three request.
 func (client *TwoOperationGroupGroup1Client) threeCreateRequest(ctx context.Context, _ *TwoOperationGroupGroup1ClientThreeOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/three"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/twoopgroup/zz_twooperationgroupgroup2_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/twoopgroup/zz_twooperationgroupgroup2_client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
-	"strings"
 )
 
 // TwoOperationGroupGroup2Client contains the methods for the TwoOperationGroupGroup2 group.
@@ -18,7 +17,6 @@ import (
 type TwoOperationGroupGroup2Client struct {
 	internal *azcore.Client
 	endpoint string
-	client   ClientType
 }
 
 // Five -
@@ -48,11 +46,8 @@ func (client *TwoOperationGroupGroup2Client) Five(ctx context.Context, options *
 
 // fiveCreateRequest creates the Five request.
 func (client *TwoOperationGroupGroup2Client) fiveCreateRequest(ctx context.Context, _ *TwoOperationGroupGroup2ClientFiveOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/five"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -86,11 +81,8 @@ func (client *TwoOperationGroupGroup2Client) Six(ctx context.Context, options *T
 
 // sixCreateRequest creates the Six request.
 func (client *TwoOperationGroupGroup2Client) sixCreateRequest(ctx context.Context, _ *TwoOperationGroupGroup2ClientSixOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/six"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -124,11 +116,8 @@ func (client *TwoOperationGroupGroup2Client) Two(ctx context.Context, options *T
 
 // twoCreateRequest creates the Two request.
 func (client *TwoOperationGroupGroup2Client) twoCreateRequest(ctx context.Context, _ *TwoOperationGroupGroup2ClientTwoOptions) (*policy.Request, error) {
-	host := "{endpoint}/client/structure/{client}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{client}", string(client.client))
 	urlPath := "/two"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/resiliency/srvdrivennewgroup/zz_resiliencyservicedriven_client.go
+++ b/packages/typespec-go/test/azure-http-specs/resiliency/srvdrivennewgroup/zz_resiliencyservicedriven_client.go
@@ -27,10 +27,8 @@ import (
 // - A client generated from the second service spec can call the second deployment of a service with api version v2
 // Don't use this type directly, use NewResiliencyServiceDrivenClientWithNoCredential() instead.
 type ResiliencyServiceDrivenClient struct {
-	internal                 *azcore.Client
-	endpoint                 string
-	serviceDeploymentVersion string
-	apiVersion               string
+	internal *azcore.Client
+	endpoint string
 }
 
 // ResiliencyServiceDrivenClientOptions contains the optional values for creating a [ResiliencyServiceDrivenClient].
@@ -60,11 +58,13 @@ func NewResiliencyServiceDrivenClientWithNoCredential(endpoint string, serviceDe
 	if options.APIVersion != "" {
 		apiVersion = options.APIVersion
 	}
+	host := "resiliency/service-driven/client:v2/service:{serviceDeploymentVersion}/api-version:{apiVersion}"
+	host = strings.ReplaceAll(host, "{serviceDeploymentVersion}", serviceDeploymentVersion)
+	host = strings.ReplaceAll(host, "{apiVersion}", apiVersion)
+	endpoint = runtime.JoinPaths(endpoint, host)
 	client := &ResiliencyServiceDrivenClient{
-		endpoint:                 endpoint,
-		serviceDeploymentVersion: serviceDeploymentVersion,
-		apiVersion:               apiVersion,
-		internal:                 cl,
+		endpoint: endpoint,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -96,12 +96,8 @@ func (client *ResiliencyServiceDrivenClient) AddOperation(ctx context.Context, o
 
 // addOperationCreateRequest creates the AddOperation request.
 func (client *ResiliencyServiceDrivenClient) addOperationCreateRequest(ctx context.Context, _ *ResiliencyServiceDrivenClientAddOperationOptions) (*policy.Request, error) {
-	host := "{endpoint}/resiliency/service-driven/client:v2/service:{serviceDeploymentVersion}/api-version:{apiVersion}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{serviceDeploymentVersion}", client.serviceDeploymentVersion)
-	host = strings.ReplaceAll(host, "{apiVersion}", client.apiVersion)
 	urlPath := "/add-operation"
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -134,12 +130,8 @@ func (client *ResiliencyServiceDrivenClient) FromNone(ctx context.Context, optio
 
 // fromNoneCreateRequest creates the FromNone request.
 func (client *ResiliencyServiceDrivenClient) fromNoneCreateRequest(ctx context.Context, options *ResiliencyServiceDrivenClientFromNoneOptions) (*policy.Request, error) {
-	host := "{endpoint}/resiliency/service-driven/client:v2/service:{serviceDeploymentVersion}/api-version:{apiVersion}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{serviceDeploymentVersion}", client.serviceDeploymentVersion)
-	host = strings.ReplaceAll(host, "{apiVersion}", client.apiVersion)
 	urlPath := "/add-optional-param/from-none"
-	req, err := runtime.NewRequest(ctx, http.MethodHead, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodHead, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -179,12 +171,8 @@ func (client *ResiliencyServiceDrivenClient) FromOneOptional(ctx context.Context
 
 // fromOneOptionalCreateRequest creates the FromOneOptional request.
 func (client *ResiliencyServiceDrivenClient) fromOneOptionalCreateRequest(ctx context.Context, options *ResiliencyServiceDrivenClientFromOneOptionalOptions) (*policy.Request, error) {
-	host := "{endpoint}/resiliency/service-driven/client:v2/service:{serviceDeploymentVersion}/api-version:{apiVersion}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{serviceDeploymentVersion}", client.serviceDeploymentVersion)
-	host = strings.ReplaceAll(host, "{apiVersion}", client.apiVersion)
 	urlPath := "/add-optional-param/from-one-optional"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -228,12 +216,8 @@ func (client *ResiliencyServiceDrivenClient) FromOneRequired(ctx context.Context
 
 // fromOneRequiredCreateRequest creates the FromOneRequired request.
 func (client *ResiliencyServiceDrivenClient) fromOneRequiredCreateRequest(ctx context.Context, parameter string, options *ResiliencyServiceDrivenClientFromOneRequiredOptions) (*policy.Request, error) {
-	host := "{endpoint}/resiliency/service-driven/client:v2/service:{serviceDeploymentVersion}/api-version:{apiVersion}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{serviceDeploymentVersion}", client.serviceDeploymentVersion)
-	host = strings.ReplaceAll(host, "{apiVersion}", client.apiVersion)
 	urlPath := "/add-optional-param/from-one-required"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/azure-http-specs/resiliency/srvdrivenoldgroup/zz_resiliencyservicedriven_client.go
+++ b/packages/typespec-go/test/azure-http-specs/resiliency/srvdrivenoldgroup/zz_resiliencyservicedriven_client.go
@@ -17,10 +17,8 @@ import (
 // with full client support.
 // Don't use this type directly, use NewResiliencyServiceDrivenClientWithNoCredential() instead.
 type ResiliencyServiceDrivenClient struct {
-	internal                 *azcore.Client
-	endpoint                 string
-	serviceDeploymentVersion string
-	apiVersion               string
+	internal *azcore.Client
+	endpoint string
 }
 
 // ResiliencyServiceDrivenClientOptions contains the optional values for creating a [ResiliencyServiceDrivenClient].
@@ -50,11 +48,13 @@ func NewResiliencyServiceDrivenClientWithNoCredential(endpoint string, serviceDe
 	if options.APIVersion != "" {
 		apiVersion = options.APIVersion
 	}
+	host := "resiliency/service-driven/client:v1/service:{serviceDeploymentVersion}/api-version:{apiVersion}"
+	host = strings.ReplaceAll(host, "{serviceDeploymentVersion}", serviceDeploymentVersion)
+	host = strings.ReplaceAll(host, "{apiVersion}", apiVersion)
+	endpoint = runtime.JoinPaths(endpoint, host)
 	client := &ResiliencyServiceDrivenClient{
-		endpoint:                 endpoint,
-		serviceDeploymentVersion: serviceDeploymentVersion,
-		apiVersion:               apiVersion,
-		internal:                 cl,
+		endpoint: endpoint,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -86,12 +86,8 @@ func (client *ResiliencyServiceDrivenClient) FromNone(ctx context.Context, optio
 
 // fromNoneCreateRequest creates the FromNone request.
 func (client *ResiliencyServiceDrivenClient) fromNoneCreateRequest(ctx context.Context, _ *ResiliencyServiceDrivenClientFromNoneOptions) (*policy.Request, error) {
-	host := "{endpoint}/resiliency/service-driven/client:v1/service:{serviceDeploymentVersion}/api-version:{apiVersion}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{serviceDeploymentVersion}", client.serviceDeploymentVersion)
-	host = strings.ReplaceAll(host, "{apiVersion}", client.apiVersion)
 	urlPath := "/add-optional-param/from-none"
-	req, err := runtime.NewRequest(ctx, http.MethodHead, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodHead, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -126,12 +122,8 @@ func (client *ResiliencyServiceDrivenClient) FromOneOptional(ctx context.Context
 
 // fromOneOptionalCreateRequest creates the FromOneOptional request.
 func (client *ResiliencyServiceDrivenClient) fromOneOptionalCreateRequest(ctx context.Context, options *ResiliencyServiceDrivenClientFromOneOptionalOptions) (*policy.Request, error) {
-	host := "{endpoint}/resiliency/service-driven/client:v1/service:{serviceDeploymentVersion}/api-version:{apiVersion}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{serviceDeploymentVersion}", client.serviceDeploymentVersion)
-	host = strings.ReplaceAll(host, "{apiVersion}", client.apiVersion)
 	urlPath := "/add-optional-param/from-one-optional"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -172,12 +164,8 @@ func (client *ResiliencyServiceDrivenClient) FromOneRequired(ctx context.Context
 
 // fromOneRequiredCreateRequest creates the FromOneRequired request.
 func (client *ResiliencyServiceDrivenClient) fromOneRequiredCreateRequest(ctx context.Context, parameter string, _ *ResiliencyServiceDrivenClientFromOneRequiredOptions) (*policy.Request, error) {
-	host := "{endpoint}/resiliency/service-driven/client:v1/service:{serviceDeploymentVersion}/api-version:{apiVersion}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{serviceDeploymentVersion}", client.serviceDeploymentVersion)
-	host = strings.ReplaceAll(host, "{apiVersion}", client.apiVersion)
 	urlPath := "/add-optional-param/from-one-required"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/authentication/apikeygroup/zz_apikey_client.go
+++ b/packages/typespec-go/test/http-specs/authentication/apikeygroup/zz_apikey_client.go
@@ -19,6 +19,11 @@ type APIKeyClient struct {
 	endpoint string
 }
 
+// APIKeyClientOptions contains the optional values for creating a [APIKeyClient].
+type APIKeyClientOptions struct {
+	azcore.ClientOptions
+}
+
 // Invalid - Check whether client is authenticated.
 // If the operation fails it returns an *azcore.ResponseError type.
 //   - options - APIKeyClientInvalidOptions contains the optional parameters for the APIKeyClient.Invalid method.

--- a/packages/typespec-go/test/http-specs/authentication/http/customgroup/zz_custom_client.go
+++ b/packages/typespec-go/test/http-specs/authentication/http/customgroup/zz_custom_client.go
@@ -19,6 +19,11 @@ type CustomClient struct {
 	endpoint string
 }
 
+// CustomClientOptions contains the optional values for creating a [CustomClient].
+type CustomClientOptions struct {
+	azcore.ClientOptions
+}
+
 // Invalid - Check whether client is authenticated.
 // If the operation fails it returns an *azcore.ResponseError type.
 //   - options - CustomClientInvalidOptions contains the optional parameters for the CustomClient.Invalid method.

--- a/packages/typespec-go/test/http-specs/server/path/multiplegroup/zz_multiple_client.go
+++ b/packages/typespec-go/test/http-specs/server/path/multiplegroup/zz_multiple_client.go
@@ -18,9 +18,8 @@ import (
 // MultipleClient contains the methods for the Multiple group.
 // Don't use this type directly, use NewMultipleClientWithNoCredential() instead.
 type MultipleClient struct {
-	internal   *azcore.Client
-	endpoint   string
-	apiVersion string
+	internal *azcore.Client
+	endpoint string
 }
 
 // MultipleClientOptions contains the optional values for creating a [MultipleClient].
@@ -47,10 +46,12 @@ func NewMultipleClientWithNoCredential(endpoint string, options *MultipleClientO
 	if options.APIVersion != "" {
 		apiVersion = options.APIVersion
 	}
+	host := "server/path/multiple/{apiVersion}"
+	host = strings.ReplaceAll(host, "{apiVersion}", apiVersion)
+	endpoint = runtime.JoinPaths(endpoint, host)
 	client := &MultipleClient{
-		endpoint:   endpoint,
-		apiVersion: apiVersion,
-		internal:   cl,
+		endpoint: endpoint,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -82,10 +83,7 @@ func (client *MultipleClient) NoOperationParams(ctx context.Context, options *Mu
 
 // noOperationParamsCreateRequest creates the NoOperationParams request.
 func (client *MultipleClient) noOperationParamsCreateRequest(ctx context.Context, _ *MultipleClientNoOperationParamsOptions) (*policy.Request, error) {
-	host := "{endpoint}/server/path/multiple/{apiVersion}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{apiVersion}", client.apiVersion)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, host)
+	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -119,15 +117,12 @@ func (client *MultipleClient) WithOperationPathParam(ctx context.Context, keywor
 
 // withOperationPathParamCreateRequest creates the WithOperationPathParam request.
 func (client *MultipleClient) withOperationPathParamCreateRequest(ctx context.Context, keyword string, _ *MultipleClientWithOperationPathParamOptions) (*policy.Request, error) {
-	host := "{endpoint}/server/path/multiple/{apiVersion}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{apiVersion}", client.apiVersion)
 	urlPath := "/{keyword}"
 	if keyword == "" {
 		return nil, errors.New("parameter keyword cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{keyword}", url.PathEscape(keyword))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/versioning/madeoptionalgroup/zz_madeoptional_client.go
+++ b/packages/typespec-go/test/http-specs/versioning/madeoptionalgroup/zz_madeoptional_client.go
@@ -18,7 +18,6 @@ import (
 type MadeOptionalClient struct {
 	internal *azcore.Client
 	endpoint string
-	version  string
 }
 
 // MadeOptionalClientOptions contains the optional values for creating a [MadeOptionalClient].
@@ -45,9 +44,11 @@ func NewMadeOptionalClientWithNoCredential(endpoint string, options *MadeOptiona
 	if options.APIVersion != "" {
 		version = options.APIVersion
 	}
+	host := "versioning/made-optional/api-version:{version}"
+	host = strings.ReplaceAll(host, "{version}", version)
+	endpoint = runtime.JoinPaths(endpoint, host)
 	client := &MadeOptionalClient{
 		endpoint: endpoint,
-		version:  version,
 		internal: cl,
 	}
 	return client, nil
@@ -80,11 +81,8 @@ func (client *MadeOptionalClient) Test(ctx context.Context, body TestModel, opti
 
 // testCreateRequest creates the Test request.
 func (client *MadeOptionalClient) testCreateRequest(ctx context.Context, body TestModel, options *MadeOptionalClientTestOptions) (*policy.Request, error) {
-	host := "{endpoint}/versioning/made-optional/api-version:{version}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{version}", client.version)
 	urlPath := "/test"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/versioning/rettypechangedfromgroup/zz_returntypechangedfrom_client.go
+++ b/packages/typespec-go/test/http-specs/versioning/rettypechangedfromgroup/zz_returntypechangedfrom_client.go
@@ -18,7 +18,6 @@ import (
 type ReturnTypeChangedFromClient struct {
 	internal *azcore.Client
 	endpoint string
-	version  string
 }
 
 // ReturnTypeChangedFromClientOptions contains the optional values for creating a [ReturnTypeChangedFromClient].
@@ -45,9 +44,11 @@ func NewReturnTypeChangedFromClientWithNoCredential(endpoint string, options *Re
 	if options.APIVersion != "" {
 		version = options.APIVersion
 	}
+	host := "versioning/return-type-changed-from/api-version:{version}"
+	host = strings.ReplaceAll(host, "{version}", version)
+	endpoint = runtime.JoinPaths(endpoint, host)
 	client := &ReturnTypeChangedFromClient{
 		endpoint: endpoint,
-		version:  version,
 		internal: cl,
 	}
 	return client, nil
@@ -81,11 +82,8 @@ func (client *ReturnTypeChangedFromClient) Test(ctx context.Context, body string
 
 // testCreateRequest creates the Test request.
 func (client *ReturnTypeChangedFromClient) testCreateRequest(ctx context.Context, body string, _ *ReturnTypeChangedFromClientTestOptions) (*policy.Request, error) {
-	host := "{endpoint}/versioning/return-type-changed-from/api-version:{version}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{version}", client.version)
 	urlPath := "/test"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/versioning/typechangedfromgroup/zz_typechangedfrom_client.go
+++ b/packages/typespec-go/test/http-specs/versioning/typechangedfromgroup/zz_typechangedfrom_client.go
@@ -18,7 +18,6 @@ import (
 type TypeChangedFromClient struct {
 	internal *azcore.Client
 	endpoint string
-	version  string
 }
 
 // TypeChangedFromClientOptions contains the optional values for creating a [TypeChangedFromClient].
@@ -45,9 +44,11 @@ func NewTypeChangedFromClientWithNoCredential(endpoint string, options *TypeChan
 	if options.APIVersion != "" {
 		version = options.APIVersion
 	}
+	host := "versioning/type-changed-from/api-version:{version}"
+	host = strings.ReplaceAll(host, "{version}", version)
+	endpoint = runtime.JoinPaths(endpoint, host)
 	client := &TypeChangedFromClient{
 		endpoint: endpoint,
-		version:  version,
 		internal: cl,
 	}
 	return client, nil
@@ -80,11 +81,8 @@ func (client *TypeChangedFromClient) Test(ctx context.Context, body TestModel, p
 
 // testCreateRequest creates the Test request.
 func (client *TypeChangedFromClient) testCreateRequest(ctx context.Context, body TestModel, param string, _ *TypeChangedFromClientTestOptions) (*policy.Request, error) {
-	host := "{endpoint}/versioning/type-changed-from/api-version:{version}"
-	host = strings.ReplaceAll(host, "{endpoint}", client.endpoint)
-	host = strings.ReplaceAll(host, "{version}", client.version)
 	urlPath := "/test"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/local/rawjson/subpkg/zz_rawjson_client.go
+++ b/packages/typespec-go/test/local/rawjson/subpkg/zz_rawjson_client.go
@@ -13,6 +13,11 @@ type RawJSONClient struct {
 	endpoint string
 }
 
+// RawJSONClientOptions contains the optional values for creating a [RawJSONClient].
+type RawJSONClientOptions struct {
+	azcore.ClientOptions
+}
+
 // NewRawJSONInputOnlyClient creates a new instance of [RawJSONInputOnlyClient].
 func (client *RawJSONClient) NewRawJSONInputOnlyClient() *RawJSONInputOnlyClient {
 	return &RawJSONInputOnlyClient{


### PR DESCRIPTION
Replace endpoint template values inside client constructors instead of per method. This means that the replacement only happens once and removes the need for the template params to be stored on the client. Refactored the code model to group data unique to instantible clients into their own type.
The handling of templatedHost, which is unique to Autorest, was also split into its own type.