### PR TITLE
[spector] add http-specs tests

### DIFF
--- a/packages/typespec-go/.scripts/tspcompile.js
+++ b/packages/typespec-go/.scripts/tspcompile.js
@@ -63,7 +63,7 @@ const httpSpecsGroup = {
   'visibilitygroup': ['type/model/visibility'],
   //'addlpropsgroup': ['type/property/additional-properties'], // requires union support (remove hand-written client when done)
   'nullablegroup': ['type/property/nullable'],
-  'optionalitygroup': ['type/property/optionality', 'slice-elements-byval=true'],
+  'optionalitygroup': ['type/property/optionality', 'slice-elements-byval=true'], // missing support for plain time https://github.com/Azure/autorest.go/issues/1732
   'valuetypesgroup': ['type/property/value-types', 'slice-elements-byval=true'],
   'scalargroup': ['type/scalar', 'slice-elements-byval=true'],
   //'uniongroup': ['type/union'], // requires union support

--- a/packages/typespec-go/test/http-specs/type/property/nullablegroup/collectionsstring_client_test.go
+++ b/packages/typespec-go/test/http-specs/type/property/nullablegroup/collectionsstring_client_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package nullablegroup_test
+
+import (
+	"context"
+	"nullablegroup"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectionsStringClientGetNonNull(t *testing.T) {
+	client, err := nullablegroup.NewNullableClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	resp, err := client.NewNullableCollectionsStringClient().GetNonNull(context.Background(), nil)
+	require.NoError(t, err)
+	require.EqualValues(t, nullablegroup.CollectionsStringProperty{
+		NullableProperty: []*string{to.Ptr("hello"), to.Ptr("world")},
+		RequiredProperty: to.Ptr("foo"),
+	}, resp.CollectionsStringProperty)
+}
+
+func TestCollectionsStringClientGetNull(t *testing.T) {
+	client, err := nullablegroup.NewNullableClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	resp, err := client.NewNullableCollectionsStringClient().GetNull(context.Background(), nil)
+	require.NoError(t, err)
+	require.EqualValues(t, nullablegroup.CollectionsStringProperty{
+		RequiredProperty: to.Ptr("foo"),
+	}, resp.CollectionsStringProperty)
+}
+
+func TestCollectionsStringClientPatchNonNull(t *testing.T) {
+	client, err := nullablegroup.NewNullableClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	_, err = client.NewNullableCollectionsStringClient().PatchNonNull(context.Background(), nullablegroup.CollectionsStringProperty{
+		NullableProperty: []*string{to.Ptr("hello"), to.Ptr("world")},
+		RequiredProperty: to.Ptr("foo"),
+	}, nil)
+	require.NoError(t, err)
+}
+
+func TestCollectionsStringClientPatchNull(t *testing.T) {
+	client, err := nullablegroup.NewNullableClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	_, err = client.NewNullableCollectionsStringClient().PatchNull(context.Background(), nullablegroup.CollectionsStringProperty{
+		NullableProperty: azcore.NullValue[[]*string](),
+		RequiredProperty: to.Ptr("foo"),
+	}, nil)
+	require.NoError(t, err)
+}

--- a/packages/typespec-go/test/http-specs/type/property/optionalitygroup/optionalplaindate_client_test.go
+++ b/packages/typespec-go/test/http-specs/type/property/optionalitygroup/optionalplaindate_client_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package optionalitygroup_test
+
+import (
+	"context"
+	"optionalitygroup"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionalPlainDateClient_GetAll(t *testing.T) {
+	client, err := optionalitygroup.NewOptionalClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	resp, err := client.NewOptionalPlainDateClient().GetAll(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Property)
+	require.WithinDuration(t, time.Date(2022, 12, 12, 0, 0, 0, 0, time.UTC), *resp.Property, 0)
+}
+
+func TestOptionalPlainDateClient_GetDefault(t *testing.T) {
+	client, err := optionalitygroup.NewOptionalClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	resp, err := client.NewOptionalPlainDateClient().GetDefault(context.Background(), nil)
+	require.NoError(t, err)
+	require.Nil(t, resp.Property)
+}
+
+func TestOptionalPlainDateClient_PutAll(t *testing.T) {
+	client, err := optionalitygroup.NewOptionalClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	_, err = client.NewOptionalPlainDateClient().PutAll(context.Background(), optionalitygroup.PlainDateProperty{Property: to.Ptr(time.Date(2022, 12, 12, 0, 0, 0, 0, time.UTC))}, nil)
+	require.NoError(t, err)
+}
+
+func TestOptionalPlainDateClient_PutDefault(t *testing.T) {
+	client, err := optionalitygroup.NewOptionalClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	_, err = client.NewOptionalPlainDateClient().PutDefault(context.Background(), optionalitygroup.PlainDateProperty{}, nil)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Adding spector tests for:
 * http-specs/type/property/nullable/collectionstring
 * http-specs/type/optional/plaindate