### PR TITLE
Fix doc for client options param

### DIFF
--- a/packages/autorest.go/test/compute/armcompute/zz_availabilitysets_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_availabilitysets_client.go
@@ -28,7 +28,7 @@ type AvailabilitySetsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAvailabilitySetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailabilitySetsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_capacityreservationgroups_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_capacityreservationgroups_client.go
@@ -28,7 +28,7 @@ type CapacityReservationGroupsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCapacityReservationGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CapacityReservationGroupsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_capacityreservations_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_capacityreservations_client.go
@@ -28,7 +28,7 @@ type CapacityReservationsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCapacityReservationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CapacityReservationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_cloudserviceoperatingsystems_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_cloudserviceoperatingsystems_client.go
@@ -28,7 +28,7 @@ type CloudServiceOperatingSystemsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCloudServiceOperatingSystemsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CloudServiceOperatingSystemsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_cloudserviceroleinstances_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_cloudserviceroleinstances_client.go
@@ -28,7 +28,7 @@ type CloudServiceRoleInstancesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCloudServiceRoleInstancesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CloudServiceRoleInstancesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_cloudserviceroles_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_cloudserviceroles_client.go
@@ -28,7 +28,7 @@ type CloudServiceRolesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCloudServiceRolesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CloudServiceRolesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_cloudservices_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_cloudservices_client.go
@@ -28,7 +28,7 @@ type CloudServicesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCloudServicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CloudServicesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_cloudservicesupdatedomain_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_cloudservicesupdatedomain_client.go
@@ -29,7 +29,7 @@ type CloudServicesUpdateDomainClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCloudServicesUpdateDomainClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CloudServicesUpdateDomainClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_communitygalleries_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_communitygalleries_client.go
@@ -28,7 +28,7 @@ type CommunityGalleriesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCommunityGalleriesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CommunityGalleriesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_communitygalleryimages_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_communitygalleryimages_client.go
@@ -28,7 +28,7 @@ type CommunityGalleryImagesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCommunityGalleryImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CommunityGalleryImagesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_communitygalleryimageversions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_communitygalleryimageversions_client.go
@@ -28,7 +28,7 @@ type CommunityGalleryImageVersionsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCommunityGalleryImageVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CommunityGalleryImageVersionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_dedicatedhostgroups_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_dedicatedhostgroups_client.go
@@ -28,7 +28,7 @@ type DedicatedHostGroupsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDedicatedHostGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DedicatedHostGroupsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_dedicatedhosts_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_dedicatedhosts_client.go
@@ -28,7 +28,7 @@ type DedicatedHostsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDedicatedHostsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DedicatedHostsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_diskaccesses_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_diskaccesses_client.go
@@ -28,7 +28,7 @@ type DiskAccessesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDiskAccessesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DiskAccessesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_diskencryptionsets_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_diskencryptionsets_client.go
@@ -28,7 +28,7 @@ type DiskEncryptionSetsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDiskEncryptionSetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DiskEncryptionSetsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_diskrestorepoint_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_diskrestorepoint_client.go
@@ -28,7 +28,7 @@ type DiskRestorePointClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDiskRestorePointClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DiskRestorePointClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_disks_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_disks_client.go
@@ -28,7 +28,7 @@ type DisksClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDisksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DisksClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_galleries_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_galleries_client.go
@@ -28,7 +28,7 @@ type GalleriesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewGalleriesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GalleriesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_galleryapplications_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_galleryapplications_client.go
@@ -28,7 +28,7 @@ type GalleryApplicationsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewGalleryApplicationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GalleryApplicationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_galleryapplicationversions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_galleryapplicationversions_client.go
@@ -28,7 +28,7 @@ type GalleryApplicationVersionsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewGalleryApplicationVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GalleryApplicationVersionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_galleryimages_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_galleryimages_client.go
@@ -28,7 +28,7 @@ type GalleryImagesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewGalleryImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GalleryImagesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_galleryimageversions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_galleryimageversions_client.go
@@ -28,7 +28,7 @@ type GalleryImageVersionsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewGalleryImageVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GalleryImageVersionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_gallerysharingprofile_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_gallerysharingprofile_client.go
@@ -28,7 +28,7 @@ type GallerySharingProfileClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewGallerySharingProfileClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GallerySharingProfileClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_images_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_images_client.go
@@ -28,7 +28,7 @@ type ImagesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ImagesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_loganalytics_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_loganalytics_client.go
@@ -28,7 +28,7 @@ type LogAnalyticsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewLogAnalyticsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LogAnalyticsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_operations_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_operations_client.go
@@ -22,7 +22,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_proximityplacementgroups_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_proximityplacementgroups_client.go
@@ -28,7 +28,7 @@ type ProximityPlacementGroupsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewProximityPlacementGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ProximityPlacementGroupsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_resourceskus_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_resourceskus_client.go
@@ -28,7 +28,7 @@ type ResourceSKUsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewResourceSKUsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ResourceSKUsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_restorepointcollections_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_restorepointcollections_client.go
@@ -28,7 +28,7 @@ type RestorePointCollectionsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewRestorePointCollectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RestorePointCollectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_restorepoints_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_restorepoints_client.go
@@ -28,7 +28,7 @@ type RestorePointsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewRestorePointsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RestorePointsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_sharedgalleries_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_sharedgalleries_client.go
@@ -28,7 +28,7 @@ type SharedGalleriesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSharedGalleriesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SharedGalleriesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_sharedgalleryimages_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_sharedgalleryimages_client.go
@@ -28,7 +28,7 @@ type SharedGalleryImagesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSharedGalleryImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SharedGalleryImagesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_sharedgalleryimageversions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_sharedgalleryimageversions_client.go
@@ -28,7 +28,7 @@ type SharedGalleryImageVersionsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSharedGalleryImageVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SharedGalleryImageVersionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_snapshots_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_snapshots_client.go
@@ -28,7 +28,7 @@ type SnapshotsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSnapshotsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SnapshotsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_sshpublickeys_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_sshpublickeys_client.go
@@ -28,7 +28,7 @@ type SSHPublicKeysClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSSHPublicKeysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SSHPublicKeysClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_usage_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_usage_client.go
@@ -28,7 +28,7 @@ type UsageClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewUsageClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*UsageClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachineextensionimages_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachineextensionimages_client.go
@@ -29,7 +29,7 @@ type VirtualMachineExtensionImagesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualMachineExtensionImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineExtensionImagesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachineextensions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachineextensions_client.go
@@ -28,7 +28,7 @@ type VirtualMachineExtensionsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualMachineExtensionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineExtensionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachineimages_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachineimages_client.go
@@ -29,7 +29,7 @@ type VirtualMachineImagesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualMachineImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineImagesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachineimagesedgezone_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachineimagesedgezone_client.go
@@ -29,7 +29,7 @@ type VirtualMachineImagesEdgeZoneClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualMachineImagesEdgeZoneClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineImagesEdgeZoneClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachineruncommands_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachineruncommands_client.go
@@ -28,7 +28,7 @@ type VirtualMachineRunCommandsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualMachineRunCommandsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineRunCommandsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachines_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachines_client.go
@@ -29,7 +29,7 @@ type VirtualMachinesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualMachinesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachinesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetextensions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetextensions_client.go
@@ -28,7 +28,7 @@ type VirtualMachineScaleSetExtensionsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualMachineScaleSetExtensionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetExtensionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetrollingupgrades_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetrollingupgrades_client.go
@@ -28,7 +28,7 @@ type VirtualMachineScaleSetRollingUpgradesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualMachineScaleSetRollingUpgradesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetRollingUpgradesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesets_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesets_client.go
@@ -29,7 +29,7 @@ type VirtualMachineScaleSetsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualMachineScaleSetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvmextensions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvmextensions_client.go
@@ -28,7 +28,7 @@ type VirtualMachineScaleSetVMExtensionsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualMachineScaleSetVMExtensionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetVMExtensionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvmruncommands_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvmruncommands_client.go
@@ -28,7 +28,7 @@ type VirtualMachineScaleSetVMRunCommandsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualMachineScaleSetVMRunCommandsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetVMRunCommandsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvms_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvms_client.go
@@ -29,7 +29,7 @@ type VirtualMachineScaleSetVMsClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualMachineScaleSetVMsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetVMsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinesizes_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinesizes_client.go
@@ -28,7 +28,7 @@ type VirtualMachineSizesClient struct {
 //   - subscriptionID - Subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms
 //     part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualMachineSizesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineSizesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_aggregatedcost_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_aggregatedcost_client.go
@@ -25,7 +25,7 @@ type AggregatedCostClient struct {
 
 // NewAggregatedCostClient creates a new instance of AggregatedCostClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAggregatedCostClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*AggregatedCostClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_balances_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_balances_client.go
@@ -25,7 +25,7 @@ type BalancesClient struct {
 
 // NewBalancesClient creates a new instance of BalancesClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBalancesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*BalancesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_budgets_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_budgets_client.go
@@ -25,7 +25,7 @@ type BudgetsClient struct {
 
 // NewBudgetsClient creates a new instance of BudgetsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBudgetsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*BudgetsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_charges_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_charges_client.go
@@ -23,7 +23,7 @@ type ChargesClient struct {
 
 // NewChargesClient creates a new instance of ChargesClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewChargesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ChargesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_credits_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_credits_client.go
@@ -23,7 +23,7 @@ type CreditsClient struct {
 
 // NewCreditsClient creates a new instance of CreditsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCreditsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*CreditsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_events_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_events_client.go
@@ -23,7 +23,7 @@ type EventsClient struct {
 
 // NewEventsClient creates a new instance of EventsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewEventsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*EventsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_forecasts_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_forecasts_client.go
@@ -27,7 +27,7 @@ type ForecastsClient struct {
 // NewForecastsClient creates a new instance of ForecastsClient with the specified values.
 //   - subscriptionID - Azure Subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewForecastsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ForecastsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_lots_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_lots_client.go
@@ -23,7 +23,7 @@ type LotsClient struct {
 
 // NewLotsClient creates a new instance of LotsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewLotsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*LotsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_marketplaces_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_marketplaces_client.go
@@ -24,7 +24,7 @@ type MarketplacesClient struct {
 
 // NewMarketplacesClient creates a new instance of MarketplacesClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewMarketplacesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*MarketplacesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_operations_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_operations_client.go
@@ -22,7 +22,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_pricesheet_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_pricesheet_client.go
@@ -28,7 +28,7 @@ type PriceSheetClient struct {
 // NewPriceSheetClient creates a new instance of PriceSheetClient with the specified values.
 //   - subscriptionID - Azure Subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPriceSheetClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PriceSheetClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_reservationrecommendationdetails_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_reservationrecommendationdetails_client.go
@@ -23,7 +23,7 @@ type ReservationRecommendationDetailsClient struct {
 
 // NewReservationRecommendationDetailsClient creates a new instance of ReservationRecommendationDetailsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewReservationRecommendationDetailsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationRecommendationDetailsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_reservationrecommendations_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_reservationrecommendations_client.go
@@ -23,7 +23,7 @@ type ReservationRecommendationsClient struct {
 
 // NewReservationRecommendationsClient creates a new instance of ReservationRecommendationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewReservationRecommendationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationRecommendationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_reservationsdetails_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_reservationsdetails_client.go
@@ -25,7 +25,7 @@ type ReservationsDetailsClient struct {
 
 // NewReservationsDetailsClient creates a new instance of ReservationsDetailsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewReservationsDetailsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationsDetailsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_reservationssummaries_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_reservationssummaries_client.go
@@ -25,7 +25,7 @@ type ReservationsSummariesClient struct {
 
 // NewReservationsSummariesClient creates a new instance of ReservationsSummariesClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewReservationsSummariesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationsSummariesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_reservationtransactions_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_reservationtransactions_client.go
@@ -25,7 +25,7 @@ type ReservationTransactionsClient struct {
 
 // NewReservationTransactionsClient creates a new instance of ReservationTransactionsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewReservationTransactionsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationTransactionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_tags_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_tags_client.go
@@ -23,7 +23,7 @@ type TagsClient struct {
 
 // NewTagsClient creates a new instance of TagsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewTagsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*TagsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/consumption/armconsumption/zz_usagedetails_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_usagedetails_client.go
@@ -24,7 +24,7 @@ type UsageDetailsClient struct {
 
 // NewUsageDetailsClient creates a new instance of UsageDetailsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewUsageDetailsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*UsageDetailsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_addons_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_addons_client.go
@@ -27,7 +27,7 @@ type AddonsClient struct {
 // NewAddonsClient creates a new instance of AddonsClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAddonsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AddonsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_alerts_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_alerts_client.go
@@ -27,7 +27,7 @@ type AlertsClient struct {
 // NewAlertsClient creates a new instance of AlertsClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAlertsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AlertsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_availableskus_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_availableskus_client.go
@@ -27,7 +27,7 @@ type AvailableSKUsClient struct {
 // NewAvailableSKUsClient creates a new instance of AvailableSKUsClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAvailableSKUsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableSKUsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_bandwidthschedules_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_bandwidthschedules_client.go
@@ -27,7 +27,7 @@ type BandwidthSchedulesClient struct {
 // NewBandwidthSchedulesClient creates a new instance of BandwidthSchedulesClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBandwidthSchedulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BandwidthSchedulesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_containers_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_containers_client.go
@@ -27,7 +27,7 @@ type ContainersClient struct {
 // NewContainersClient creates a new instance of ContainersClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewContainersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ContainersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_devices_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_devices_client.go
@@ -27,7 +27,7 @@ type DevicesClient struct {
 // NewDevicesClient creates a new instance of DevicesClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDevicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DevicesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_diagnosticsettings_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_diagnosticsettings_client.go
@@ -27,7 +27,7 @@ type DiagnosticSettingsClient struct {
 // NewDiagnosticSettingsClient creates a new instance of DiagnosticSettingsClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDiagnosticSettingsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DiagnosticSettingsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_jobs_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_jobs_client.go
@@ -27,7 +27,7 @@ type JobsClient struct {
 // NewJobsClient creates a new instance of JobsClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewJobsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*JobsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_monitoringconfig_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_monitoringconfig_client.go
@@ -27,7 +27,7 @@ type MonitoringConfigClient struct {
 // NewMonitoringConfigClient creates a new instance of MonitoringConfigClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewMonitoringConfigClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*MonitoringConfigClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_nodes_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_nodes_client.go
@@ -27,7 +27,7 @@ type NodesClient struct {
 // NewNodesClient creates a new instance of NodesClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewNodesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*NodesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_operations_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_operations_client.go
@@ -22,7 +22,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_operationsstatus_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_operationsstatus_client.go
@@ -27,7 +27,7 @@ type OperationsStatusClient struct {
 // NewOperationsStatusClient creates a new instance of OperationsStatusClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsStatusClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsStatusClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_orders_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_orders_client.go
@@ -27,7 +27,7 @@ type OrdersClient struct {
 // NewOrdersClient creates a new instance of OrdersClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOrdersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OrdersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_roles_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_roles_client.go
@@ -27,7 +27,7 @@ type RolesClient struct {
 // NewRolesClient creates a new instance of RolesClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewRolesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RolesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_shares_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_shares_client.go
@@ -27,7 +27,7 @@ type SharesClient struct {
 // NewSharesClient creates a new instance of SharesClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSharesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SharesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_storageaccountcredentials_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_storageaccountcredentials_client.go
@@ -27,7 +27,7 @@ type StorageAccountCredentialsClient struct {
 // NewStorageAccountCredentialsClient creates a new instance of StorageAccountCredentialsClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewStorageAccountCredentialsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*StorageAccountCredentialsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_storageaccounts_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_storageaccounts_client.go
@@ -27,7 +27,7 @@ type StorageAccountsClient struct {
 // NewStorageAccountsClient creates a new instance of StorageAccountsClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewStorageAccountsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*StorageAccountsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_supportpackages_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_supportpackages_client.go
@@ -27,7 +27,7 @@ type SupportPackagesClient struct {
 // NewSupportPackagesClient creates a new instance of SupportPackagesClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSupportPackagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SupportPackagesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_triggers_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_triggers_client.go
@@ -27,7 +27,7 @@ type TriggersClient struct {
 // NewTriggersClient creates a new instance of TriggersClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewTriggersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*TriggersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_users_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_users_client.go
@@ -27,7 +27,7 @@ type UsersClient struct {
 // NewUsersClient creates a new instance of UsersClient with the specified values.
 //   - subscriptionID - The subscription ID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewUsersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*UsersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_backupinstances_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_backupinstances_client.go
@@ -27,7 +27,7 @@ type BackupInstancesClient struct {
 // NewBackupInstancesClient creates a new instance of BackupInstancesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBackupInstancesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BackupInstancesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_backupinstancesextensionrouting_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_backupinstancesextensionrouting_client.go
@@ -23,7 +23,7 @@ type BackupInstancesExtensionRoutingClient struct {
 
 // NewBackupInstancesExtensionRoutingClient creates a new instance of BackupInstancesExtensionRoutingClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBackupInstancesExtensionRoutingClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*BackupInstancesExtensionRoutingClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_backuppolicies_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_backuppolicies_client.go
@@ -27,7 +27,7 @@ type BackupPoliciesClient struct {
 // NewBackupPoliciesClient creates a new instance of BackupPoliciesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBackupPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BackupPoliciesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_backupvaultoperationresults_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_backupvaultoperationresults_client.go
@@ -28,7 +28,7 @@ type BackupVaultOperationResultsClient struct {
 // NewBackupVaultOperationResultsClient creates a new instance of BackupVaultOperationResultsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBackupVaultOperationResultsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BackupVaultOperationResultsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_backupvaults_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_backupvaults_client.go
@@ -27,7 +27,7 @@ type BackupVaultsClient struct {
 // NewBackupVaultsClient creates a new instance of BackupVaultsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBackupVaultsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BackupVaultsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_client.go
@@ -27,7 +27,7 @@ type Client struct {
 // NewClient creates a new instance of Client with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*Client, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_deletedbackupinstances_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_deletedbackupinstances_client.go
@@ -27,7 +27,7 @@ type DeletedBackupInstancesClient struct {
 // NewDeletedBackupInstancesClient creates a new instance of DeletedBackupInstancesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDeletedBackupInstancesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DeletedBackupInstancesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_dppresourceguardproxy_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_dppresourceguardproxy_client.go
@@ -27,7 +27,7 @@ type DppResourceGuardProxyClient struct {
 // NewDppResourceGuardProxyClient creates a new instance of DppResourceGuardProxyClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDppResourceGuardProxyClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DppResourceGuardProxyClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_exportjobs_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_exportjobs_client.go
@@ -27,7 +27,7 @@ type ExportJobsClient struct {
 // NewExportJobsClient creates a new instance of ExportJobsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExportJobsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExportJobsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_exportjobsoperationresult_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_exportjobsoperationresult_client.go
@@ -27,7 +27,7 @@ type ExportJobsOperationResultClient struct {
 // NewExportJobsOperationResultClient creates a new instance of ExportJobsOperationResultClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExportJobsOperationResultClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExportJobsOperationResultClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_fetchcrossregionrestorejob_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_fetchcrossregionrestorejob_client.go
@@ -27,7 +27,7 @@ type FetchCrossRegionRestoreJobClient struct {
 // NewFetchCrossRegionRestoreJobClient creates a new instance of FetchCrossRegionRestoreJobClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewFetchCrossRegionRestoreJobClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FetchCrossRegionRestoreJobClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_fetchcrossregionrestorejobs_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_fetchcrossregionrestorejobs_client.go
@@ -27,7 +27,7 @@ type FetchCrossRegionRestoreJobsClient struct {
 // NewFetchCrossRegionRestoreJobsClient creates a new instance of FetchCrossRegionRestoreJobsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewFetchCrossRegionRestoreJobsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FetchCrossRegionRestoreJobsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_fetchsecondaryrecoverypoints_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_fetchsecondaryrecoverypoints_client.go
@@ -27,7 +27,7 @@ type FetchSecondaryRecoveryPointsClient struct {
 // NewFetchSecondaryRecoveryPointsClient creates a new instance of FetchSecondaryRecoveryPointsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewFetchSecondaryRecoveryPointsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FetchSecondaryRecoveryPointsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_jobs_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_jobs_client.go
@@ -27,7 +27,7 @@ type JobsClient struct {
 // NewJobsClient creates a new instance of JobsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewJobsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*JobsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_operationresult_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_operationresult_client.go
@@ -28,7 +28,7 @@ type OperationResultClient struct {
 // NewOperationResultClient creates a new instance of OperationResultClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationResultClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationResultClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_operations_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_operations_client.go
@@ -22,7 +22,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_operationstatus_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_operationstatus_client.go
@@ -27,7 +27,7 @@ type OperationStatusClient struct {
 // NewOperationStatusClient creates a new instance of OperationStatusClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationStatusClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationStatusClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_operationstatusbackupvaultcontext_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_operationstatusbackupvaultcontext_client.go
@@ -27,7 +27,7 @@ type OperationStatusBackupVaultContextClient struct {
 // NewOperationStatusBackupVaultContextClient creates a new instance of OperationStatusBackupVaultContextClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationStatusBackupVaultContextClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationStatusBackupVaultContextClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_operationstatusresourcegroupcontext_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_operationstatusresourcegroupcontext_client.go
@@ -27,7 +27,7 @@ type OperationStatusResourceGroupContextClient struct {
 // NewOperationStatusResourceGroupContextClient creates a new instance of OperationStatusResourceGroupContextClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationStatusResourceGroupContextClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationStatusResourceGroupContextClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_recoverypoints_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_recoverypoints_client.go
@@ -27,7 +27,7 @@ type RecoveryPointsClient struct {
 // NewRecoveryPointsClient creates a new instance of RecoveryPointsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewRecoveryPointsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RecoveryPointsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_resourceguards_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_resourceguards_client.go
@@ -27,7 +27,7 @@ type ResourceGuardsClient struct {
 // NewResourceGuardsClient creates a new instance of ResourceGuardsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewResourceGuardsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ResourceGuardsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/dataprotection/armdataprotection/zz_restorabletimeranges_client.go
+++ b/packages/autorest.go/test/dataprotection/armdataprotection/zz_restorabletimeranges_client.go
@@ -27,7 +27,7 @@ type RestorableTimeRangesClient struct {
 // NewRestorableTimeRangesClient creates a new instance of RestorableTimeRangesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewRestorableTimeRangesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RestorableTimeRangesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_batchdeployments_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_batchdeployments_client.go
@@ -28,7 +28,7 @@ type BatchDeploymentsClient struct {
 // NewBatchDeploymentsClient creates a new instance of BatchDeploymentsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBatchDeploymentsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BatchDeploymentsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_batchendpoints_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_batchendpoints_client.go
@@ -28,7 +28,7 @@ type BatchEndpointsClient struct {
 // NewBatchEndpointsClient creates a new instance of BatchEndpointsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBatchEndpointsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BatchEndpointsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_codecontainers_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_codecontainers_client.go
@@ -27,7 +27,7 @@ type CodeContainersClient struct {
 // NewCodeContainersClient creates a new instance of CodeContainersClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCodeContainersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CodeContainersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_codeversions_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_codeversions_client.go
@@ -28,7 +28,7 @@ type CodeVersionsClient struct {
 // NewCodeVersionsClient creates a new instance of CodeVersionsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCodeVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CodeVersionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_componentcontainers_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_componentcontainers_client.go
@@ -27,7 +27,7 @@ type ComponentContainersClient struct {
 // NewComponentContainersClient creates a new instance of ComponentContainersClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewComponentContainersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ComponentContainersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_componentversions_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_componentversions_client.go
@@ -28,7 +28,7 @@ type ComponentVersionsClient struct {
 // NewComponentVersionsClient creates a new instance of ComponentVersionsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewComponentVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ComponentVersionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_compute_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_compute_client.go
@@ -27,7 +27,7 @@ type ComputeClient struct {
 // NewComputeClient creates a new instance of ComputeClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewComputeClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ComputeClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_datacontainers_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_datacontainers_client.go
@@ -27,7 +27,7 @@ type DataContainersClient struct {
 // NewDataContainersClient creates a new instance of DataContainersClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDataContainersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DataContainersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_datastores_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_datastores_client.go
@@ -28,7 +28,7 @@ type DatastoresClient struct {
 // NewDatastoresClient creates a new instance of DatastoresClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDatastoresClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DatastoresClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_dataversions_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_dataversions_client.go
@@ -28,7 +28,7 @@ type DataVersionsClient struct {
 // NewDataVersionsClient creates a new instance of DataVersionsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDataVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DataVersionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_environmentcontainers_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_environmentcontainers_client.go
@@ -27,7 +27,7 @@ type EnvironmentContainersClient struct {
 // NewEnvironmentContainersClient creates a new instance of EnvironmentContainersClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewEnvironmentContainersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*EnvironmentContainersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_environmentversions_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_environmentversions_client.go
@@ -28,7 +28,7 @@ type EnvironmentVersionsClient struct {
 // NewEnvironmentVersionsClient creates a new instance of EnvironmentVersionsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewEnvironmentVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*EnvironmentVersionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_jobs_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_jobs_client.go
@@ -28,7 +28,7 @@ type JobsClient struct {
 // NewJobsClient creates a new instance of JobsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewJobsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*JobsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_modelcontainers_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_modelcontainers_client.go
@@ -28,7 +28,7 @@ type ModelContainersClient struct {
 // NewModelContainersClient creates a new instance of ModelContainersClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewModelContainersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ModelContainersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_modelversions_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_modelversions_client.go
@@ -28,7 +28,7 @@ type ModelVersionsClient struct {
 // NewModelVersionsClient creates a new instance of ModelVersionsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewModelVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ModelVersionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_onlinedeployments_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_onlinedeployments_client.go
@@ -28,7 +28,7 @@ type OnlineDeploymentsClient struct {
 // NewOnlineDeploymentsClient creates a new instance of OnlineDeploymentsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOnlineDeploymentsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OnlineDeploymentsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_onlineendpoints_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_onlineendpoints_client.go
@@ -28,7 +28,7 @@ type OnlineEndpointsClient struct {
 // NewOnlineEndpointsClient creates a new instance of OnlineEndpointsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOnlineEndpointsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OnlineEndpointsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_operations_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_operations_client.go
@@ -22,7 +22,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_privateendpointconnections_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_privateendpointconnections_client.go
@@ -27,7 +27,7 @@ type PrivateEndpointConnectionsClient struct {
 // NewPrivateEndpointConnectionsClient creates a new instance of PrivateEndpointConnectionsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPrivateEndpointConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateEndpointConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_privatelinkresources_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_privatelinkresources_client.go
@@ -27,7 +27,7 @@ type PrivateLinkResourcesClient struct {
 // NewPrivateLinkResourcesClient creates a new instance of PrivateLinkResourcesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPrivateLinkResourcesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateLinkResourcesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_quotas_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_quotas_client.go
@@ -27,7 +27,7 @@ type QuotasClient struct {
 // NewQuotasClient creates a new instance of QuotasClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewQuotasClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*QuotasClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_usages_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_usages_client.go
@@ -27,7 +27,7 @@ type UsagesClient struct {
 // NewUsagesClient creates a new instance of UsagesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewUsagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*UsagesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_virtualmachinesizes_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_virtualmachinesizes_client.go
@@ -27,7 +27,7 @@ type VirtualMachineSizesClient struct {
 // NewVirtualMachineSizesClient creates a new instance of VirtualMachineSizesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualMachineSizesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineSizesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspaceconnections_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspaceconnections_client.go
@@ -27,7 +27,7 @@ type WorkspaceConnectionsClient struct {
 // NewWorkspaceConnectionsClient creates a new instance of WorkspaceConnectionsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewWorkspaceConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WorkspaceConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspacefeatures_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspacefeatures_client.go
@@ -27,7 +27,7 @@ type WorkspaceFeaturesClient struct {
 // NewWorkspaceFeaturesClient creates a new instance of WorkspaceFeaturesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewWorkspaceFeaturesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WorkspaceFeaturesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspaces_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspaces_client.go
@@ -27,7 +27,7 @@ type WorkspacesClient struct {
 // NewWorkspacesClient creates a new instance of WorkspacesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewWorkspacesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WorkspacesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_adminrulecollections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_adminrulecollections_client.go
@@ -29,7 +29,7 @@ type AdminRuleCollectionsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAdminRuleCollectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AdminRuleCollectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_adminrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_adminrules_client.go
@@ -29,7 +29,7 @@ type AdminRulesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAdminRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AdminRulesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationgatewayprivateendpointconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationgatewayprivateendpointconnections_client.go
@@ -29,7 +29,7 @@ type ApplicationGatewayPrivateEndpointConnectionsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewApplicationGatewayPrivateEndpointConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationGatewayPrivateEndpointConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationgatewayprivatelinkresources_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationgatewayprivatelinkresources_client.go
@@ -28,7 +28,7 @@ type ApplicationGatewayPrivateLinkResourcesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewApplicationGatewayPrivateLinkResourcesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationGatewayPrivateLinkResourcesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationgateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationgateways_client.go
@@ -28,7 +28,7 @@ type ApplicationGatewaysClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewApplicationGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationGatewaysClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationgatewaywafdynamicmanifests_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationgatewaywafdynamicmanifests_client.go
@@ -28,7 +28,7 @@ type ApplicationGatewayWafDynamicManifestsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewApplicationGatewayWafDynamicManifestsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationGatewayWafDynamicManifestsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationgatewaywafdynamicmanifestsdefault_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationgatewaywafdynamicmanifestsdefault_client.go
@@ -29,7 +29,7 @@ type ApplicationGatewayWafDynamicManifestsDefaultClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewApplicationGatewayWafDynamicManifestsDefaultClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationGatewayWafDynamicManifestsDefaultClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationsecuritygroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationsecuritygroups_client.go
@@ -28,7 +28,7 @@ type ApplicationSecurityGroupsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewApplicationSecurityGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationSecurityGroupsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_availabledelegations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_availabledelegations_client.go
@@ -28,7 +28,7 @@ type AvailableDelegationsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAvailableDelegationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableDelegationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_availableendpointservices_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_availableendpointservices_client.go
@@ -28,7 +28,7 @@ type AvailableEndpointServicesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAvailableEndpointServicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableEndpointServicesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_availableprivateendpointtypes_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_availableprivateendpointtypes_client.go
@@ -28,7 +28,7 @@ type AvailablePrivateEndpointTypesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAvailablePrivateEndpointTypesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailablePrivateEndpointTypesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_availableresourcegroupdelegations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_availableresourcegroupdelegations_client.go
@@ -28,7 +28,7 @@ type AvailableResourceGroupDelegationsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAvailableResourceGroupDelegationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableResourceGroupDelegationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_availableservicealiases_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_availableservicealiases_client.go
@@ -28,7 +28,7 @@ type AvailableServiceAliasesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAvailableServiceAliasesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableServiceAliasesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_azurefirewallfqdntags_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_azurefirewallfqdntags_client.go
@@ -28,7 +28,7 @@ type AzureFirewallFqdnTagsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAzureFirewallFqdnTagsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AzureFirewallFqdnTagsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_azurefirewalls_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_azurefirewalls_client.go
@@ -28,7 +28,7 @@ type AzureFirewallsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAzureFirewallsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AzureFirewallsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_bastionhosts_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_bastionhosts_client.go
@@ -28,7 +28,7 @@ type BastionHostsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBastionHostsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BastionHostsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_bgpservicecommunities_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_bgpservicecommunities_client.go
@@ -28,7 +28,7 @@ type BgpServiceCommunitiesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBgpServiceCommunitiesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BgpServiceCommunitiesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_configurationpolicygroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_configurationpolicygroups_client.go
@@ -28,7 +28,7 @@ type ConfigurationPolicyGroupsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewConfigurationPolicyGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ConfigurationPolicyGroupsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_connectionmonitors_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_connectionmonitors_client.go
@@ -28,7 +28,7 @@ type ConnectionMonitorsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewConnectionMonitorsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ConnectionMonitorsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_connectivityconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_connectivityconfigurations_client.go
@@ -29,7 +29,7 @@ type ConnectivityConfigurationsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewConnectivityConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ConnectivityConfigurationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_customipprefixes_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_customipprefixes_client.go
@@ -28,7 +28,7 @@ type CustomIPPrefixesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCustomIPPrefixesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CustomIPPrefixesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_ddoscustompolicies_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_ddoscustompolicies_client.go
@@ -28,7 +28,7 @@ type DdosCustomPoliciesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDdosCustomPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DdosCustomPoliciesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_ddosprotectionplans_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_ddosprotectionplans_client.go
@@ -28,7 +28,7 @@ type DdosProtectionPlansClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDdosProtectionPlansClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DdosProtectionPlansClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_defaultsecurityrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_defaultsecurityrules_client.go
@@ -28,7 +28,7 @@ type DefaultSecurityRulesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDefaultSecurityRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DefaultSecurityRulesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_dscpconfiguration_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_dscpconfiguration_client.go
@@ -28,7 +28,7 @@ type DscpConfigurationClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDscpConfigurationClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DscpConfigurationClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitauthorizations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitauthorizations_client.go
@@ -28,7 +28,7 @@ type ExpressRouteCircuitAuthorizationsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExpressRouteCircuitAuthorizationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitAuthorizationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitconnections_client.go
@@ -28,7 +28,7 @@ type ExpressRouteCircuitConnectionsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExpressRouteCircuitConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitpeerings_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitpeerings_client.go
@@ -28,7 +28,7 @@ type ExpressRouteCircuitPeeringsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExpressRouteCircuitPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitPeeringsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuits_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuits_client.go
@@ -28,7 +28,7 @@ type ExpressRouteCircuitsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExpressRouteCircuitsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteconnections_client.go
@@ -28,7 +28,7 @@ type ExpressRouteConnectionsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExpressRouteConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecrossconnectionpeerings_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecrossconnectionpeerings_client.go
@@ -28,7 +28,7 @@ type ExpressRouteCrossConnectionPeeringsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExpressRouteCrossConnectionPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCrossConnectionPeeringsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecrossconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecrossconnections_client.go
@@ -28,7 +28,7 @@ type ExpressRouteCrossConnectionsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExpressRouteCrossConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCrossConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutegateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutegateways_client.go
@@ -28,7 +28,7 @@ type ExpressRouteGatewaysClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExpressRouteGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteGatewaysClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutelinks_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutelinks_client.go
@@ -28,7 +28,7 @@ type ExpressRouteLinksClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExpressRouteLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteLinksClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteportauthorizations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteportauthorizations_client.go
@@ -28,7 +28,7 @@ type ExpressRoutePortAuthorizationsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExpressRoutePortAuthorizationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRoutePortAuthorizationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteports_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteports_client.go
@@ -28,7 +28,7 @@ type ExpressRoutePortsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExpressRoutePortsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRoutePortsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteportslocations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteportslocations_client.go
@@ -28,7 +28,7 @@ type ExpressRoutePortsLocationsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExpressRoutePortsLocationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRoutePortsLocationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteproviderportslocation_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteproviderportslocation_client.go
@@ -28,7 +28,7 @@ type ExpressRouteProviderPortsLocationClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExpressRouteProviderPortsLocationClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteProviderPortsLocationClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteserviceproviders_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteserviceproviders_client.go
@@ -28,7 +28,7 @@ type ExpressRouteServiceProvidersClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExpressRouteServiceProvidersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteServiceProvidersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_firewallpolicies_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_firewallpolicies_client.go
@@ -28,7 +28,7 @@ type FirewallPoliciesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewFirewallPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FirewallPoliciesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyidpssignatures_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyidpssignatures_client.go
@@ -28,7 +28,7 @@ type FirewallPolicyIdpsSignaturesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewFirewallPolicyIdpsSignaturesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FirewallPolicyIdpsSignaturesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyidpssignaturesfiltervalues_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyidpssignaturesfiltervalues_client.go
@@ -28,7 +28,7 @@ type FirewallPolicyIdpsSignaturesFilterValuesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewFirewallPolicyIdpsSignaturesFilterValuesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FirewallPolicyIdpsSignaturesFilterValuesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyidpssignaturesoverrides_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyidpssignaturesoverrides_client.go
@@ -28,7 +28,7 @@ type FirewallPolicyIdpsSignaturesOverridesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewFirewallPolicyIdpsSignaturesOverridesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FirewallPolicyIdpsSignaturesOverridesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyrulecollectiongroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyrulecollectiongroups_client.go
@@ -28,7 +28,7 @@ type FirewallPolicyRuleCollectionGroupsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewFirewallPolicyRuleCollectionGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FirewallPolicyRuleCollectionGroupsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_flowlogs_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_flowlogs_client.go
@@ -28,7 +28,7 @@ type FlowLogsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewFlowLogsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FlowLogsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_groups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_groups_client.go
@@ -29,7 +29,7 @@ type GroupsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GroupsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_hubroutetables_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_hubroutetables_client.go
@@ -28,7 +28,7 @@ type HubRouteTablesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewHubRouteTablesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*HubRouteTablesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_hubvirtualnetworkconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_hubvirtualnetworkconnections_client.go
@@ -28,7 +28,7 @@ type HubVirtualNetworkConnectionsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewHubVirtualNetworkConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*HubVirtualNetworkConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_inboundnatrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_inboundnatrules_client.go
@@ -28,7 +28,7 @@ type InboundNatRulesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewInboundNatRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InboundNatRulesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_inboundsecurityrule_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_inboundsecurityrule_client.go
@@ -28,7 +28,7 @@ type InboundSecurityRuleClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewInboundSecurityRuleClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InboundSecurityRuleClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_interfaceipconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_interfaceipconfigurations_client.go
@@ -28,7 +28,7 @@ type InterfaceIPConfigurationsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewInterfaceIPConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InterfaceIPConfigurationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_interfaceloadbalancers_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_interfaceloadbalancers_client.go
@@ -28,7 +28,7 @@ type InterfaceLoadBalancersClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewInterfaceLoadBalancersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InterfaceLoadBalancersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_interfaces_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_interfaces_client.go
@@ -28,7 +28,7 @@ type InterfacesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewInterfacesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InterfacesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_interfacetapconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_interfacetapconfigurations_client.go
@@ -28,7 +28,7 @@ type InterfaceTapConfigurationsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewInterfaceTapConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InterfaceTapConfigurationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_ipallocations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_ipallocations_client.go
@@ -28,7 +28,7 @@ type IPAllocationsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewIPAllocationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*IPAllocationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_ipgroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_ipgroups_client.go
@@ -28,7 +28,7 @@ type IPGroupsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewIPGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*IPGroupsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancerbackendaddresspools_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancerbackendaddresspools_client.go
@@ -28,7 +28,7 @@ type LoadBalancerBackendAddressPoolsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewLoadBalancerBackendAddressPoolsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerBackendAddressPoolsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancerfrontendipconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancerfrontendipconfigurations_client.go
@@ -28,7 +28,7 @@ type LoadBalancerFrontendIPConfigurationsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewLoadBalancerFrontendIPConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerFrontendIPConfigurationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancerloadbalancingrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancerloadbalancingrules_client.go
@@ -28,7 +28,7 @@ type LoadBalancerLoadBalancingRulesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewLoadBalancerLoadBalancingRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerLoadBalancingRulesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancernetworkinterfaces_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancernetworkinterfaces_client.go
@@ -28,7 +28,7 @@ type LoadBalancerNetworkInterfacesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewLoadBalancerNetworkInterfacesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerNetworkInterfacesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalanceroutboundrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalanceroutboundrules_client.go
@@ -28,7 +28,7 @@ type LoadBalancerOutboundRulesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewLoadBalancerOutboundRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerOutboundRulesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancerprobes_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancerprobes_client.go
@@ -28,7 +28,7 @@ type LoadBalancerProbesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewLoadBalancerProbesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerProbesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancers_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancers_client.go
@@ -28,7 +28,7 @@ type LoadBalancersClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewLoadBalancersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_localnetworkgateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_localnetworkgateways_client.go
@@ -28,7 +28,7 @@ type LocalNetworkGatewaysClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewLocalNetworkGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LocalNetworkGatewaysClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_management_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_management_client.go
@@ -29,7 +29,7 @@ type ManagementClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewManagementClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ManagementClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_managementgroupnetworkmanagerconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_managementgroupnetworkmanagerconnections_client.go
@@ -26,7 +26,7 @@ type ManagementGroupNetworkManagerConnectionsClient struct {
 
 // NewManagementGroupNetworkManagerConnectionsClient creates a new instance of ManagementGroupNetworkManagerConnectionsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewManagementGroupNetworkManagerConnectionsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ManagementGroupNetworkManagerConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_managercommits_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_managercommits_client.go
@@ -28,7 +28,7 @@ type ManagerCommitsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewManagerCommitsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ManagerCommitsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_managerdeploymentstatus_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_managerdeploymentstatus_client.go
@@ -29,7 +29,7 @@ type ManagerDeploymentStatusClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewManagerDeploymentStatusClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ManagerDeploymentStatusClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_managers_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_managers_client.go
@@ -29,7 +29,7 @@ type ManagersClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewManagersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ManagersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_natgateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_natgateways_client.go
@@ -28,7 +28,7 @@ type NatGatewaysClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewNatGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*NatGatewaysClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_natrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_natrules_client.go
@@ -28,7 +28,7 @@ type NatRulesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewNatRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*NatRulesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_operations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_operations_client.go
@@ -22,7 +22,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_p2svpngateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_p2svpngateways_client.go
@@ -28,7 +28,7 @@ type P2SVPNGatewaysClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewP2SVPNGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*P2SVPNGatewaysClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_packetcaptures_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_packetcaptures_client.go
@@ -28,7 +28,7 @@ type PacketCapturesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPacketCapturesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PacketCapturesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_peerexpressroutecircuitconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_peerexpressroutecircuitconnections_client.go
@@ -28,7 +28,7 @@ type PeerExpressRouteCircuitConnectionsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPeerExpressRouteCircuitConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PeerExpressRouteCircuitConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_privatednszonegroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_privatednszonegroups_client.go
@@ -28,7 +28,7 @@ type PrivateDNSZoneGroupsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPrivateDNSZoneGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateDNSZoneGroupsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_privateendpoints_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_privateendpoints_client.go
@@ -28,7 +28,7 @@ type PrivateEndpointsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPrivateEndpointsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateEndpointsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_privatelinkservices_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_privatelinkservices_client.go
@@ -28,7 +28,7 @@ type PrivateLinkServicesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPrivateLinkServicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateLinkServicesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_profiles_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_profiles_client.go
@@ -28,7 +28,7 @@ type ProfilesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewProfilesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ProfilesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_publicipaddresses_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_publicipaddresses_client.go
@@ -28,7 +28,7 @@ type PublicIPAddressesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPublicIPAddressesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PublicIPAddressesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_publicipprefixes_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_publicipprefixes_client.go
@@ -28,7 +28,7 @@ type PublicIPPrefixesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPublicIPPrefixesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PublicIPPrefixesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_resourcenavigationlinks_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_resourcenavigationlinks_client.go
@@ -28,7 +28,7 @@ type ResourceNavigationLinksClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewResourceNavigationLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ResourceNavigationLinksClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_routefilterrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routefilterrules_client.go
@@ -28,7 +28,7 @@ type RouteFilterRulesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewRouteFilterRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RouteFilterRulesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_routefilters_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routefilters_client.go
@@ -28,7 +28,7 @@ type RouteFiltersClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewRouteFiltersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RouteFiltersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_routemaps_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routemaps_client.go
@@ -28,7 +28,7 @@ type RouteMapsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewRouteMapsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RouteMapsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_routes_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routes_client.go
@@ -28,7 +28,7 @@ type RoutesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewRoutesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RoutesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_routetables_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routetables_client.go
@@ -28,7 +28,7 @@ type RouteTablesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewRouteTablesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RouteTablesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_routingintent_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routingintent_client.go
@@ -28,7 +28,7 @@ type RoutingIntentClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewRoutingIntentClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RoutingIntentClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_scopeconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_scopeconnections_client.go
@@ -29,7 +29,7 @@ type ScopeConnectionsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewScopeConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ScopeConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_securityadminconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_securityadminconfigurations_client.go
@@ -29,7 +29,7 @@ type SecurityAdminConfigurationsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSecurityAdminConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SecurityAdminConfigurationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_securitygroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_securitygroups_client.go
@@ -28,7 +28,7 @@ type SecurityGroupsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSecurityGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SecurityGroupsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_securitypartnerproviders_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_securitypartnerproviders_client.go
@@ -28,7 +28,7 @@ type SecurityPartnerProvidersClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSecurityPartnerProvidersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SecurityPartnerProvidersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_securityrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_securityrules_client.go
@@ -28,7 +28,7 @@ type SecurityRulesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSecurityRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SecurityRulesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_serviceassociationlinks_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_serviceassociationlinks_client.go
@@ -28,7 +28,7 @@ type ServiceAssociationLinksClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewServiceAssociationLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceAssociationLinksClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_serviceendpointpolicies_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_serviceendpointpolicies_client.go
@@ -28,7 +28,7 @@ type ServiceEndpointPoliciesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewServiceEndpointPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceEndpointPoliciesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_serviceendpointpolicydefinitions_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_serviceendpointpolicydefinitions_client.go
@@ -28,7 +28,7 @@ type ServiceEndpointPolicyDefinitionsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewServiceEndpointPolicyDefinitionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceEndpointPolicyDefinitionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_servicetaginformation_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_servicetaginformation_client.go
@@ -29,7 +29,7 @@ type ServiceTagInformationClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewServiceTagInformationClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceTagInformationClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_servicetags_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_servicetags_client.go
@@ -28,7 +28,7 @@ type ServiceTagsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewServiceTagsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceTagsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_staticmembers_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_staticmembers_client.go
@@ -29,7 +29,7 @@ type StaticMembersClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewStaticMembersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*StaticMembersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_subnets_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_subnets_client.go
@@ -28,7 +28,7 @@ type SubnetsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSubnetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SubnetsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_subscriptionnetworkmanagerconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_subscriptionnetworkmanagerconnections_client.go
@@ -29,7 +29,7 @@ type SubscriptionNetworkManagerConnectionsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSubscriptionNetworkManagerConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SubscriptionNetworkManagerConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_usages_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_usages_client.go
@@ -28,7 +28,7 @@ type UsagesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewUsagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*UsagesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_vipswap_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vipswap_client.go
@@ -28,7 +28,7 @@ type VipSwapClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVipSwapClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VipSwapClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualappliances_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualappliances_client.go
@@ -28,7 +28,7 @@ type VirtualAppliancesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualAppliancesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualAppliancesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualappliancesites_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualappliancesites_client.go
@@ -28,7 +28,7 @@ type VirtualApplianceSitesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualApplianceSitesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualApplianceSitesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualapplianceskus_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualapplianceskus_client.go
@@ -28,7 +28,7 @@ type VirtualApplianceSKUsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualApplianceSKUsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualApplianceSKUsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualhubbgpconnection_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualhubbgpconnection_client.go
@@ -28,7 +28,7 @@ type VirtualHubBgpConnectionClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualHubBgpConnectionClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualHubBgpConnectionClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualhubbgpconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualhubbgpconnections_client.go
@@ -28,7 +28,7 @@ type VirtualHubBgpConnectionsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualHubBgpConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualHubBgpConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualhubipconfiguration_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualhubipconfiguration_client.go
@@ -28,7 +28,7 @@ type VirtualHubIPConfigurationClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualHubIPConfigurationClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualHubIPConfigurationClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualhubroutetablev2s_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualhubroutetablev2s_client.go
@@ -28,7 +28,7 @@ type VirtualHubRouteTableV2SClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualHubRouteTableV2SClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualHubRouteTableV2SClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualhubs_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualhubs_client.go
@@ -28,7 +28,7 @@ type VirtualHubsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualHubsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualHubsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgatewayconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgatewayconnections_client.go
@@ -28,7 +28,7 @@ type VirtualNetworkGatewayConnectionsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualNetworkGatewayConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkGatewayConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgatewaynatrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgatewaynatrules_client.go
@@ -28,7 +28,7 @@ type VirtualNetworkGatewayNatRulesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualNetworkGatewayNatRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkGatewayNatRulesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgateways_client.go
@@ -28,7 +28,7 @@ type VirtualNetworkGatewaysClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualNetworkGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkGatewaysClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkpeerings_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkpeerings_client.go
@@ -28,7 +28,7 @@ type VirtualNetworkPeeringsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualNetworkPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkPeeringsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworks_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworks_client.go
@@ -29,7 +29,7 @@ type VirtualNetworksClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualNetworksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworksClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworktaps_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworktaps_client.go
@@ -28,7 +28,7 @@ type VirtualNetworkTapsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualNetworkTapsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkTapsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualrouterpeerings_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualrouterpeerings_client.go
@@ -28,7 +28,7 @@ type VirtualRouterPeeringsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualRouterPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualRouterPeeringsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualrouters_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualrouters_client.go
@@ -28,7 +28,7 @@ type VirtualRoutersClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualRoutersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualRoutersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualwans_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualwans_client.go
@@ -28,7 +28,7 @@ type VirtualWansClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVirtualWansClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualWansClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnconnections_client.go
@@ -28,7 +28,7 @@ type VPNConnectionsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVPNConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_vpngateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpngateways_client.go
@@ -28,7 +28,7 @@ type VPNGatewaysClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVPNGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNGatewaysClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnlinkconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnlinkconnections_client.go
@@ -28,7 +28,7 @@ type VPNLinkConnectionsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVPNLinkConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNLinkConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnserverconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnserverconfigurations_client.go
@@ -28,7 +28,7 @@ type VPNServerConfigurationsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVPNServerConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNServerConfigurationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnserverconfigurationsassociatedwithvirtualwan_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnserverconfigurationsassociatedwithvirtualwan_client.go
@@ -29,7 +29,7 @@ type VPNServerConfigurationsAssociatedWithVirtualWanClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVPNServerConfigurationsAssociatedWithVirtualWanClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNServerConfigurationsAssociatedWithVirtualWanClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnsitelinkconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnsitelinkconnections_client.go
@@ -28,7 +28,7 @@ type VPNSiteLinkConnectionsClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVPNSiteLinkConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSiteLinkConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnsitelinks_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnsitelinks_client.go
@@ -28,7 +28,7 @@ type VPNSiteLinksClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVPNSiteLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSiteLinksClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnsites_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnsites_client.go
@@ -28,7 +28,7 @@ type VPNSitesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVPNSitesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSitesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnsitesconfiguration_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnsitesconfiguration_client.go
@@ -28,7 +28,7 @@ type VPNSitesConfigurationClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVPNSitesConfigurationClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSitesConfigurationClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_watchers_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_watchers_client.go
@@ -28,7 +28,7 @@ type WatchersClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewWatchersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WatchersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_webapplicationfirewallpolicies_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_webapplicationfirewallpolicies_client.go
@@ -28,7 +28,7 @@ type WebApplicationFirewallPoliciesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewWebApplicationFirewallPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WebApplicationFirewallPoliciesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/autorest.go/test/network/armnetwork/zz_webcategories_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_webcategories_client.go
@@ -28,7 +28,7 @@ type WebCategoriesClient struct {
 //   - subscriptionID - The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription
 //     ID forms part of the URI for every service call.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewWebCategoriesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WebCategoriesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -322,7 +322,7 @@ function generateConstructors(client: go.Client, imports: ImportManager): string
 
     // add client options last
     ctorParams.push(`options ${helpers.formatParameterTypeName(clientOptions)}`);
-    paramDocs.push(helpers.formatCommentAsBulletItem('options', clientOptions.docs));
+    paramDocs.push(helpers.formatCommentAsBulletItem('options', { summary: 'Contains optional client configuration. Pass nil to accept the default values.' }));
 
     ctorText += `// ${constructor.name} creates a new instance of ${client.name} with the specified values.\n`;
     for (const doc of paramDocs) {

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -53,7 +53,7 @@
     "@azure-tools/typespec-autorest": "0.60.0",
     "@azure-tools/typespec-azure-core": "0.60.0",
     "@azure-tools/typespec-azure-resource-manager": "0.60.0",
-    "@azure-tools/typespec-client-generator-core": "0.60.2",
+    "@azure-tools/typespec-client-generator-core": "0.60.3",
     "@types/node": "catalog:",
     "@typespec/compiler": "1.4.0",
     "@typespec/events": "0.74.0",

--- a/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/accessgroup/zz_access_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/accessgroup/zz_access_client.go
@@ -23,7 +23,7 @@ type AccessClientOptions struct {
 
 // NewAccessClientWithNoCredential creates a new instance of AccessClient with the specified values.
 //   - endpoint - Service host
-//   - options - AccessClientOptions contains the optional values for creating a [AccessClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAccessClientWithNoCredential(endpoint string, options *AccessClientOptions) (*AccessClient, error) {
 	if options == nil {
 		options = &AccessClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/coreclientlocationgroup/zz_clientlocation_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/coreclientlocationgroup/zz_clientlocation_client.go
@@ -26,7 +26,7 @@ type ClientLocationClientOptions struct {
 
 // NewClientLocationClientWithNoCredential creates a new instance of ClientLocationClient with the specified values.
 //   - endpoint - Service host
-//   - options - ClientLocationClientOptions contains the optional values for creating a [ClientLocationClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewClientLocationClientWithNoCredential(endpoint string, options *ClientLocationClientOptions) (*ClientLocationClient, error) {
 	if options == nil {
 		options = &ClientLocationClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/coreusagegroup/zz_usage_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/coreusagegroup/zz_usage_client.go
@@ -23,7 +23,7 @@ type UsageClientOptions struct {
 
 // NewUsageClientWithNoCredential creates a new instance of UsageClient with the specified values.
 //   - endpoint - Service host
-//   - options - UsageClientOptions contains the optional values for creating a [UsageClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewUsageClientWithNoCredential(endpoint string, options *UsageClientOptions) (*UsageClient, error) {
 	if options == nil {
 		options = &UsageClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/flattengroup/zz_flattenproperty_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/flattengroup/zz_flattenproperty_client.go
@@ -26,7 +26,7 @@ type FlattenPropertyClientOptions struct {
 
 // NewFlattenPropertyClientWithNoCredential creates a new instance of FlattenPropertyClient with the specified values.
 //   - endpoint - Service host
-//   - options - FlattenPropertyClientOptions contains the optional values for creating a [FlattenPropertyClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewFlattenPropertyClientWithNoCredential(endpoint string, options *FlattenPropertyClientOptions) (*FlattenPropertyClient, error) {
 	if options == nil {
 		options = &FlattenPropertyClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/hierarchygroup/zz_hierarchybuilding_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/hierarchygroup/zz_hierarchybuilding_client.go
@@ -23,7 +23,7 @@ type HierarchyBuildingClientOptions struct {
 
 // NewHierarchyBuildingClientWithNoCredential creates a new instance of HierarchyBuildingClient with the specified values.
 //   - endpoint - Service host
-//   - options - HierarchyBuildingClientOptions contains the optional values for creating a [HierarchyBuildingClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewHierarchyBuildingClientWithNoCredential(endpoint string, options *HierarchyBuildingClientOptions) (*HierarchyBuildingClient, error) {
 	if options == nil {
 		options = &HierarchyBuildingClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/azure/core/azurepagegroup/zz_page_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/core/azurepagegroup/zz_page_client.go
@@ -26,7 +26,7 @@ type PageClientOptions struct {
 
 // NewPageClientWithNoCredential creates a new instance of PageClient with the specified values.
 //   - endpoint - Service host
-//   - options - PageClientOptions contains the optional values for creating a [PageClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPageClientWithNoCredential(endpoint string, options *PageClientOptions) (*PageClient, error) {
 	if options == nil {
 		options = &PageClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/azure/core/basicgroup/zz_basic_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/core/basicgroup/zz_basic_client.go
@@ -29,7 +29,7 @@ type BasicClientOptions struct {
 
 // NewBasicClientWithNoCredential creates a new instance of BasicClient with the specified values.
 //   - endpoint - Service host
-//   - options - BasicClientOptions contains the optional values for creating a [BasicClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBasicClientWithNoCredential(endpoint string, options *BasicClientOptions) (*BasicClient, error) {
 	if options == nil {
 		options = &BasicClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/azure/core/coremodelgroup/zz_model_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/core/coremodelgroup/zz_model_client.go
@@ -23,7 +23,7 @@ type ModelClientOptions struct {
 
 // NewModelClientWithNoCredential creates a new instance of ModelClient with the specified values.
 //   - endpoint - Service host
-//   - options - ModelClientOptions contains the optional values for creating a [ModelClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewModelClientWithNoCredential(endpoint string, options *ModelClientOptions) (*ModelClient, error) {
 	if options == nil {
 		options = &ModelClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/azure/core/corescalargroup/zz_scalar_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/core/corescalargroup/zz_scalar_client.go
@@ -23,7 +23,7 @@ type ScalarClientOptions struct {
 
 // NewScalarClientWithNoCredential creates a new instance of ScalarClient with the specified values.
 //   - endpoint - Service host
-//   - options - ScalarClientOptions contains the optional values for creating a [ScalarClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewScalarClientWithNoCredential(endpoint string, options *ScalarClientOptions) (*ScalarClient, error) {
 	if options == nil {
 		options = &ScalarClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/azure/core/lro/lrorpcgroup/zz_rpc_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/core/lro/lrorpcgroup/zz_rpc_client.go
@@ -26,7 +26,7 @@ type RPCClientOptions struct {
 
 // NewRPCClientWithNoCredential creates a new instance of RPCClient with the specified values.
 //   - endpoint - Service host
-//   - options - RPCClientOptions contains the optional values for creating a [RPCClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewRPCClientWithNoCredential(endpoint string, options *RPCClientOptions) (*RPCClient, error) {
 	if options == nil {
 		options = &RPCClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/azure/core/lro/lrostdgroup/zz_standard_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/core/lro/lrostdgroup/zz_standard_client.go
@@ -29,7 +29,7 @@ type StandardClientOptions struct {
 
 // NewStandardClientWithNoCredential creates a new instance of StandardClient with the specified values.
 //   - endpoint - Service host
-//   - options - StandardClientOptions contains the optional values for creating a [StandardClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewStandardClientWithNoCredential(endpoint string, options *StandardClientOptions) (*StandardClient, error) {
 	if options == nil {
 		options = &StandardClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/azure/core/traitsgroup/zz_traits_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/core/traitsgroup/zz_traits_client.go
@@ -30,7 +30,7 @@ type TraitsClientOptions struct {
 
 // NewTraitsClientWithNoCredential creates a new instance of TraitsClient with the specified values.
 //   - endpoint - Service host
-//   - options - TraitsClientOptions contains the optional values for creating a [TraitsClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewTraitsClientWithNoCredential(endpoint string, options *TraitsClientOptions) (*TraitsClient, error) {
 	if options == nil {
 		options = &TraitsClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/azure/encode/encodedurationgroup/zz_duration_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/encode/encodedurationgroup/zz_duration_client.go
@@ -26,7 +26,7 @@ type DurationClientOptions struct {
 
 // NewDurationClientWithNoCredential creates a new instance of DurationClient with the specified values.
 //   - endpoint - Service host
-//   - options - DurationClientOptions contains the optional values for creating a [DurationClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDurationClientWithNoCredential(endpoint string, options *DurationClientOptions) (*DurationClient, error) {
 	if options == nil {
 		options = &DurationClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/azure/example/examplebasicgroup/zz_azureexample_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/example/examplebasicgroup/zz_azureexample_client.go
@@ -26,7 +26,7 @@ type AzureExampleClientOptions struct {
 
 // NewAzureExampleClientWithNoCredential creates a new instance of AzureExampleClient with the specified values.
 //   - endpoint - Service host
-//   - options - AzureExampleClientOptions contains the optional values for creating a [AzureExampleClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAzureExampleClientWithNoCredential(endpoint string, options *AzureExampleClientOptions) (*AzureExampleClient, error) {
 	if options == nil {
 		options = &AzureExampleClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/azure/payload/pageablegroup/zz_pageable_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/payload/pageablegroup/zz_pageable_client.go
@@ -27,7 +27,7 @@ type PageableClientOptions struct {
 
 // NewPageableClientWithNoCredential creates a new instance of PageableClient with the specified values.
 //   - endpoint - Service host
-//   - options - PageableClientOptions contains the optional values for creating a [PageableClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPageableClientWithNoCredential(endpoint string, options *PageableClientOptions) (*PageableClient, error) {
 	if options == nil {
 		options = &PageableClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/commonpropsgroup/zz_error_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/commonpropsgroup/zz_error_client.go
@@ -26,7 +26,7 @@ type ErrorClient struct {
 // NewErrorClient creates a new instance of ErrorClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewErrorClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ErrorClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/commonpropsgroup/zz_managedidentity_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/commonpropsgroup/zz_managedidentity_client.go
@@ -26,7 +26,7 @@ type ManagedIdentityClient struct {
 // NewManagedIdentityClient creates a new instance of ManagedIdentityClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewManagedIdentityClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ManagedIdentityClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/largeheadergroup/zz_largeheaders_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/largeheadergroup/zz_largeheaders_client.go
@@ -26,7 +26,7 @@ type LargeHeadersClient struct {
 // NewLargeHeadersClient creates a new instance of LargeHeadersClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewLargeHeadersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LargeHeadersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/methodsubscriptionidgroup/zz_operations_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/methodsubscriptionidgroup/zz_operations_client.go
@@ -21,7 +21,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/methodsubscriptionidgroup/zz_resourcegroupresourceoperations_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/methodsubscriptionidgroup/zz_resourcegroupresourceoperations_client.go
@@ -26,7 +26,7 @@ type ResourceGroupResourceOperationsClient struct {
 // NewResourceGroupResourceOperationsClient creates a new instance of ResourceGroupResourceOperationsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewResourceGroupResourceOperationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ResourceGroupResourceOperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/methodsubscriptionidgroup/zz_subscriptionresource1operations_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/methodsubscriptionidgroup/zz_subscriptionresource1operations_client.go
@@ -24,7 +24,7 @@ type SubscriptionResource1OperationsClient struct {
 
 // NewSubscriptionResource1OperationsClient creates a new instance of SubscriptionResource1OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSubscriptionResource1OperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*SubscriptionResource1OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/methodsubscriptionidgroup/zz_subscriptionresource2operations_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/methodsubscriptionidgroup/zz_subscriptionresource2operations_client.go
@@ -24,7 +24,7 @@ type SubscriptionResource2OperationsClient struct {
 
 // NewSubscriptionResource2OperationsClient creates a new instance of SubscriptionResource2OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSubscriptionResource2OperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*SubscriptionResource2OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/methodsubscriptionidgroup/zz_subscriptionresourceoperations_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/methodsubscriptionidgroup/zz_subscriptionresourceoperations_client.go
@@ -24,7 +24,7 @@ type SubscriptionResourceOperationsClient struct {
 
 // NewSubscriptionResourceOperationsClient creates a new instance of SubscriptionResourceOperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSubscriptionResourceOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*SubscriptionResourceOperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/nonresourcegroup/zz_nonresourceoperations_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/nonresourcegroup/zz_nonresourceoperations_client.go
@@ -26,7 +26,7 @@ type NonResourceOperationsClient struct {
 // NewNonResourceOperationsClient creates a new instance of NonResourceOperationsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewNonResourceOperationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*NonResourceOperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_extensionsresources_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_extensionsresources_client.go
@@ -25,7 +25,7 @@ type ExtensionsResourcesClient struct {
 
 // NewExtensionsResourcesClient creates a new instance of ExtensionsResourcesClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExtensionsResourcesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ExtensionsResourcesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_locationresources_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_locationresources_client.go
@@ -26,7 +26,7 @@ type LocationResourcesClient struct {
 // NewLocationResourcesClient creates a new instance of LocationResourcesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewLocationResourcesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LocationResourcesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_nested_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_nested_client.go
@@ -26,7 +26,7 @@ type NestedClient struct {
 // NewNestedClient creates a new instance of NestedClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewNestedClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*NestedClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_singleton_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_singleton_client.go
@@ -26,7 +26,7 @@ type SingletonClient struct {
 // NewSingletonClient creates a new instance of SingletonClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSingletonClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SingletonClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_toplevel_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/zz_toplevel_client.go
@@ -26,7 +26,7 @@ type TopLevelClient struct {
 // NewTopLevelClient creates a new instance of TopLevelClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewTopLevelClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*TopLevelClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/templatesgroup/zz_checknameavailability_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/templatesgroup/zz_checknameavailability_client.go
@@ -26,7 +26,7 @@ type CheckNameAvailabilityClient struct {
 // NewCheckNameAvailabilityClient creates a new instance of CheckNameAvailabilityClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCheckNameAvailabilityClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CheckNameAvailabilityClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/templatesgroup/zz_lro_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/templatesgroup/zz_lro_client.go
@@ -26,7 +26,7 @@ type LroClient struct {
 // NewLroClient creates a new instance of LroClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewLroClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LroClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/templatesgroup/zz_operations_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/templatesgroup/zz_operations_client.go
@@ -21,7 +21,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/templatesgroup/zz_optionalbody_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/templatesgroup/zz_optionalbody_client.go
@@ -26,7 +26,7 @@ type OptionalBodyClient struct {
 // NewOptionalBodyClient creates a new instance of OptionalBodyClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOptionalBodyClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OptionalBodyClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/azure-http-specs/azure/special-headers/xmsclientreqidgroup/zz_xmsclientrequestid_client.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/special-headers/xmsclientreqidgroup/zz_xmsclientrequestid_client.go
@@ -26,7 +26,7 @@ type XMSClientRequestIDClientOptions struct {
 
 // NewXMSClientRequestIDClientWithNoCredential creates a new instance of XMSClientRequestIDClient with the specified values.
 //   - endpoint - Service host
-//   - options - XMSClientRequestIDClientOptions contains the optional values for creating a [XMSClientRequestIDClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewXMSClientRequestIDClientWithNoCredential(endpoint string, options *XMSClientRequestIDClientOptions) (*XMSClientRequestIDClient, error) {
 	if options == nil {
 		options = &XMSClientRequestIDClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/client/clientnamespacegroup/zz_clientnamespacefirst_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/clientnamespacegroup/zz_clientnamespacefirst_client.go
@@ -26,7 +26,7 @@ type ClientNamespaceFirstClientOptions struct {
 
 // NewClientNamespaceFirstClientWithNoCredential creates a new instance of ClientNamespaceFirstClient with the specified values.
 //   - endpoint - Service host
-//   - options - ClientNamespaceFirstClientOptions contains the optional values for creating a [ClientNamespaceFirstClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewClientNamespaceFirstClientWithNoCredential(endpoint string, options *ClientNamespaceFirstClientOptions) (*ClientNamespaceFirstClient, error) {
 	if options == nil {
 		options = &ClientNamespaceFirstClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/client/clientnamespacegroup/zz_clientnamespacesecond_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/clientnamespacegroup/zz_clientnamespacesecond_client.go
@@ -26,7 +26,7 @@ type ClientNamespaceSecondClientOptions struct {
 
 // NewClientNamespaceSecondClientWithNoCredential creates a new instance of ClientNamespaceSecondClient with the specified values.
 //   - endpoint - Service host
-//   - options - ClientNamespaceSecondClientOptions contains the optional values for creating a [ClientNamespaceSecondClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewClientNamespaceSecondClientWithNoCredential(endpoint string, options *ClientNamespaceSecondClientOptions) (*ClientNamespaceSecondClient, error) {
 	if options == nil {
 		options = &ClientNamespaceSecondClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/client/naminggroup/zz_naming_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/naminggroup/zz_naming_client.go
@@ -26,7 +26,7 @@ type NamingClientOptions struct {
 
 // NewNamingClientWithNoCredential creates a new instance of NamingClient with the specified values.
 //   - endpoint - Service host
-//   - options - NamingClientOptions contains the optional values for creating a [NamingClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewNamingClientWithNoCredential(endpoint string, options *NamingClientOptions) (*NamingClient, error) {
 	if options == nil {
 		options = &NamingClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/clientopgroup/zz_first_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/clientopgroup/zz_first_client.go
@@ -28,7 +28,7 @@ type FirstClientOptions struct {
 // NewFirstClientWithNoCredential creates a new instance of FirstClient with the specified values.
 //   - endpoint - Service host
 //   - client - Need to be set as 'default', 'multi-client', 'renamed-operation', 'two-operation-group' in client.
-//   - options - FirstClientOptions contains the optional values for creating a [FirstClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewFirstClientWithNoCredential(endpoint string, client ClientType, options *FirstClientOptions) (*FirstClient, error) {
 	if options == nil {
 		options = &FirstClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/clientopgroup/zz_second_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/clientopgroup/zz_second_client.go
@@ -28,7 +28,7 @@ type SecondClientOptions struct {
 // NewSecondClientWithNoCredential creates a new instance of SecondClient with the specified values.
 //   - endpoint - Service host
 //   - client - Need to be set as 'default', 'multi-client', 'renamed-operation', 'two-operation-group' in client.
-//   - options - SecondClientOptions contains the optional values for creating a [SecondClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSecondClientWithNoCredential(endpoint string, client ClientType, options *SecondClientOptions) (*SecondClient, error) {
 	if options == nil {
 		options = &SecondClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_service_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/zz_service_client.go
@@ -35,7 +35,7 @@ type ServiceClientOptions struct {
 // NewServiceClientWithNoCredential creates a new instance of ServiceClient with the specified values.
 //   - endpoint - Service host
 //   - client - Need to be set as 'default', 'multi-client', 'renamed-operation', 'two-operation-group' in client.
-//   - options - ServiceClientOptions contains the optional values for creating a [ServiceClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewServiceClientWithNoCredential(endpoint string, client ClientType, options *ServiceClientOptions) (*ServiceClient, error) {
 	if options == nil {
 		options = &ServiceClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/multiclientgroup/zz_clienta_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/multiclientgroup/zz_clienta_client.go
@@ -28,7 +28,7 @@ type ClientAClientOptions struct {
 // NewClientAClientWithNoCredential creates a new instance of ClientAClient with the specified values.
 //   - endpoint - Service host
 //   - client - Need to be set as 'default', 'multi-client', 'renamed-operation', 'two-operation-group' in client.
-//   - options - ClientAClientOptions contains the optional values for creating a [ClientAClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewClientAClientWithNoCredential(endpoint string, client ClientType, options *ClientAClientOptions) (*ClientAClient, error) {
 	if options == nil {
 		options = &ClientAClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/multiclientgroup/zz_clientb_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/multiclientgroup/zz_clientb_client.go
@@ -28,7 +28,7 @@ type ClientBClientOptions struct {
 // NewClientBClientWithNoCredential creates a new instance of ClientBClient with the specified values.
 //   - endpoint - Service host
 //   - client - Need to be set as 'default', 'multi-client', 'renamed-operation', 'two-operation-group' in client.
-//   - options - ClientBClientOptions contains the optional values for creating a [ClientBClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewClientBClientWithNoCredential(endpoint string, client ClientType, options *ClientBClientOptions) (*ClientBClient, error) {
 	if options == nil {
 		options = &ClientBClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/renamedopgroup/zz_renamedoperation_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/renamedopgroup/zz_renamedoperation_client.go
@@ -28,7 +28,7 @@ type RenamedOperationClientOptions struct {
 // NewRenamedOperationClientWithNoCredential creates a new instance of RenamedOperationClient with the specified values.
 //   - endpoint - Service host
 //   - client - Need to be set as 'default', 'multi-client', 'renamed-operation', 'two-operation-group' in client.
-//   - options - RenamedOperationClientOptions contains the optional values for creating a [RenamedOperationClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewRenamedOperationClientWithNoCredential(endpoint string, client ClientType, options *RenamedOperationClientOptions) (*RenamedOperationClient, error) {
 	if options == nil {
 		options = &RenamedOperationClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/client/structure/twoopgroup/zz_twooperationgroup_client.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/twoopgroup/zz_twooperationgroup_client.go
@@ -25,7 +25,7 @@ type TwoOperationGroupClientOptions struct {
 // NewTwoOperationGroupClientWithNoCredential creates a new instance of TwoOperationGroupClient with the specified values.
 //   - endpoint - Service host
 //   - client - Need to be set as 'default', 'multi-client', 'renamed-operation', 'two-operation-group' in client.
-//   - options - TwoOperationGroupClientOptions contains the optional values for creating a [TwoOperationGroupClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewTwoOperationGroupClientWithNoCredential(endpoint string, client ClientType, options *TwoOperationGroupClientOptions) (*TwoOperationGroupClient, error) {
 	if options == nil {
 		options = &TwoOperationGroupClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/resiliency/srvdrivennewgroup/zz_resiliencyservicedriven_client.go
+++ b/packages/typespec-go/test/azure-http-specs/resiliency/srvdrivennewgroup/zz_resiliencyservicedriven_client.go
@@ -41,7 +41,7 @@ type ResiliencyServiceDrivenClientOptions struct {
 //   - serviceDeploymentVersion - Pass in either 'v1' or 'v2'. This represents a version of the service deployment in history.
 //     'v1' is for the deployment when the service had only one api version. 'v2' is for the deployment when the service had api-versions
 //     'v1' and 'v2'.
-//   - options - ResiliencyServiceDrivenClientOptions contains the optional values for creating a [ResiliencyServiceDrivenClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewResiliencyServiceDrivenClientWithNoCredential(endpoint string, serviceDeploymentVersion string, options *ResiliencyServiceDrivenClientOptions) (*ResiliencyServiceDrivenClient, error) {
 	if options == nil {
 		options = &ResiliencyServiceDrivenClientOptions{}

--- a/packages/typespec-go/test/azure-http-specs/resiliency/srvdrivenoldgroup/zz_resiliencyservicedriven_client.go
+++ b/packages/typespec-go/test/azure-http-specs/resiliency/srvdrivenoldgroup/zz_resiliencyservicedriven_client.go
@@ -31,7 +31,7 @@ type ResiliencyServiceDrivenClientOptions struct {
 //   - serviceDeploymentVersion - Pass in either 'v1' or 'v2'. This represents a version of the service deployment in history.
 //     'v1' is for the deployment when the service had only one api version. 'v2' is for the deployment when the service had api-versions
 //     'v1' and 'v2'.
-//   - options - ResiliencyServiceDrivenClientOptions contains the optional values for creating a [ResiliencyServiceDrivenClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewResiliencyServiceDrivenClientWithNoCredential(endpoint string, serviceDeploymentVersion string, options *ResiliencyServiceDrivenClientOptions) (*ResiliencyServiceDrivenClient, error) {
 	if options == nil {
 		options = &ResiliencyServiceDrivenClientOptions{}

--- a/packages/typespec-go/test/http-specs/authentication/oauth2group/zz_oauth2_client.go
+++ b/packages/typespec-go/test/http-specs/authentication/oauth2group/zz_oauth2_client.go
@@ -30,7 +30,7 @@ type OAuth2ClientOptions struct {
 // NewOAuth2Client creates a new instance of OAuth2Client with the specified values.
 //   - endpoint - Service host
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - OAuth2ClientOptions contains the optional values for creating a [OAuth2Client]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOAuth2Client(endpoint string, credential azcore.TokenCredential, options *OAuth2ClientOptions) (*OAuth2Client, error) {
 	if options == nil {
 		options = &OAuth2ClientOptions{}

--- a/packages/typespec-go/test/http-specs/authentication/unionauthgroup/zz_union_client.go
+++ b/packages/typespec-go/test/http-specs/authentication/unionauthgroup/zz_union_client.go
@@ -30,7 +30,7 @@ type UnionClientOptions struct {
 // NewUnionClient creates a new instance of UnionClient with the specified values.
 //   - endpoint - Service host
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - UnionClientOptions contains the optional values for creating a [UnionClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewUnionClient(endpoint string, credential azcore.TokenCredential, options *UnionClientOptions) (*UnionClient, error) {
 	if options == nil {
 		options = &UnionClientOptions{}

--- a/packages/typespec-go/test/http-specs/encode/bytesgroup/zz_bytes_client.go
+++ b/packages/typespec-go/test/http-specs/encode/bytesgroup/zz_bytes_client.go
@@ -23,7 +23,7 @@ type BytesClientOptions struct {
 
 // NewBytesClientWithNoCredential creates a new instance of BytesClient with the specified values.
 //   - endpoint - Service host
-//   - options - BytesClientOptions contains the optional values for creating a [BytesClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBytesClientWithNoCredential(endpoint string, options *BytesClientOptions) (*BytesClient, error) {
 	if options == nil {
 		options = &BytesClientOptions{}

--- a/packages/typespec-go/test/http-specs/encode/datetimegroup/zz_datetime_client.go
+++ b/packages/typespec-go/test/http-specs/encode/datetimegroup/zz_datetime_client.go
@@ -23,7 +23,7 @@ type DatetimeClientOptions struct {
 
 // NewDatetimeClientWithNoCredential creates a new instance of DatetimeClient with the specified values.
 //   - endpoint - Service host
-//   - options - DatetimeClientOptions contains the optional values for creating a [DatetimeClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDatetimeClientWithNoCredential(endpoint string, options *DatetimeClientOptions) (*DatetimeClient, error) {
 	if options == nil {
 		options = &DatetimeClientOptions{}

--- a/packages/typespec-go/test/http-specs/encode/durationgroup/zz_duration_client.go
+++ b/packages/typespec-go/test/http-specs/encode/durationgroup/zz_duration_client.go
@@ -23,7 +23,7 @@ type DurationClientOptions struct {
 
 // NewDurationClientWithNoCredential creates a new instance of DurationClient with the specified values.
 //   - endpoint - Service host
-//   - options - DurationClientOptions contains the optional values for creating a [DurationClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDurationClientWithNoCredential(endpoint string, options *DurationClientOptions) (*DurationClient, error) {
 	if options == nil {
 		options = &DurationClientOptions{}

--- a/packages/typespec-go/test/http-specs/encode/numericgroup/zz_numeric_client.go
+++ b/packages/typespec-go/test/http-specs/encode/numericgroup/zz_numeric_client.go
@@ -23,7 +23,7 @@ type NumericClientOptions struct {
 
 // NewNumericClientWithNoCredential creates a new instance of NumericClient with the specified values.
 //   - endpoint - Service host
-//   - options - NumericClientOptions contains the optional values for creating a [NumericClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewNumericClientWithNoCredential(endpoint string, options *NumericClientOptions) (*NumericClient, error) {
 	if options == nil {
 		options = &NumericClientOptions{}

--- a/packages/typespec-go/test/http-specs/parameters/basicparamsgroup/zz_basic_client.go
+++ b/packages/typespec-go/test/http-specs/parameters/basicparamsgroup/zz_basic_client.go
@@ -23,7 +23,7 @@ type BasicClientOptions struct {
 
 // NewBasicClientWithNoCredential creates a new instance of BasicClient with the specified values.
 //   - endpoint - Service host
-//   - options - BasicClientOptions contains the optional values for creating a [BasicClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBasicClientWithNoCredential(endpoint string, options *BasicClientOptions) (*BasicClient, error) {
 	if options == nil {
 		options = &BasicClientOptions{}

--- a/packages/typespec-go/test/http-specs/parameters/bodyoptionalgroup/zz_bodyoptionality_client.go
+++ b/packages/typespec-go/test/http-specs/parameters/bodyoptionalgroup/zz_bodyoptionality_client.go
@@ -26,7 +26,7 @@ type BodyOptionalityClientOptions struct {
 
 // NewBodyOptionalityClientWithNoCredential creates a new instance of BodyOptionalityClient with the specified values.
 //   - endpoint - Service host
-//   - options - BodyOptionalityClientOptions contains the optional values for creating a [BodyOptionalityClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBodyOptionalityClientWithNoCredential(endpoint string, options *BodyOptionalityClientOptions) (*BodyOptionalityClient, error) {
 	if options == nil {
 		options = &BodyOptionalityClientOptions{}

--- a/packages/typespec-go/test/http-specs/parameters/collectionfmtgroup/zz_collectionformat_client.go
+++ b/packages/typespec-go/test/http-specs/parameters/collectionfmtgroup/zz_collectionformat_client.go
@@ -23,7 +23,7 @@ type CollectionFormatClientOptions struct {
 
 // NewCollectionFormatClientWithNoCredential creates a new instance of CollectionFormatClient with the specified values.
 //   - endpoint - Service host
-//   - options - CollectionFormatClientOptions contains the optional values for creating a [CollectionFormatClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCollectionFormatClientWithNoCredential(endpoint string, options *CollectionFormatClientOptions) (*CollectionFormatClient, error) {
 	if options == nil {
 		options = &CollectionFormatClientOptions{}

--- a/packages/typespec-go/test/http-specs/parameters/pathgroup/zz_path_client.go
+++ b/packages/typespec-go/test/http-specs/parameters/pathgroup/zz_path_client.go
@@ -29,7 +29,7 @@ type PathClientOptions struct {
 
 // NewPathClientWithNoCredential creates a new instance of PathClient with the specified values.
 //   - endpoint - Service host
-//   - options - PathClientOptions contains the optional values for creating a [PathClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPathClientWithNoCredential(endpoint string, options *PathClientOptions) (*PathClient, error) {
 	if options == nil {
 		options = &PathClientOptions{}

--- a/packages/typespec-go/test/http-specs/parameters/spreadgroup/zz_spread_client.go
+++ b/packages/typespec-go/test/http-specs/parameters/spreadgroup/zz_spread_client.go
@@ -23,7 +23,7 @@ type SpreadClientOptions struct {
 
 // NewSpreadClientWithNoCredential creates a new instance of SpreadClient with the specified values.
 //   - endpoint - Service host
-//   - options - SpreadClientOptions contains the optional values for creating a [SpreadClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSpreadClientWithNoCredential(endpoint string, options *SpreadClientOptions) (*SpreadClient, error) {
 	if options == nil {
 		options = &SpreadClientOptions{}

--- a/packages/typespec-go/test/http-specs/payload/contentneggroup/zz_contentnegotiation_client.go
+++ b/packages/typespec-go/test/http-specs/payload/contentneggroup/zz_contentnegotiation_client.go
@@ -23,7 +23,7 @@ type ContentNegotiationClientOptions struct {
 
 // NewContentNegotiationClientWithNoCredential creates a new instance of ContentNegotiationClient with the specified values.
 //   - endpoint - Service host
-//   - options - ContentNegotiationClientOptions contains the optional values for creating a [ContentNegotiationClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewContentNegotiationClientWithNoCredential(endpoint string, options *ContentNegotiationClientOptions) (*ContentNegotiationClient, error) {
 	if options == nil {
 		options = &ContentNegotiationClientOptions{}

--- a/packages/typespec-go/test/http-specs/payload/jmergepatchgroup/zz_jsonmergepatch_client.go
+++ b/packages/typespec-go/test/http-specs/payload/jmergepatchgroup/zz_jsonmergepatch_client.go
@@ -26,7 +26,7 @@ type JSONMergePatchClientOptions struct {
 
 // NewJSONMergePatchClientWithNoCredential creates a new instance of JSONMergePatchClient with the specified values.
 //   - endpoint - Service host
-//   - options - JSONMergePatchClientOptions contains the optional values for creating a [JSONMergePatchClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewJSONMergePatchClientWithNoCredential(endpoint string, options *JSONMergePatchClientOptions) (*JSONMergePatchClient, error) {
 	if options == nil {
 		options = &JSONMergePatchClientOptions{}

--- a/packages/typespec-go/test/http-specs/payload/mediatypegroup/zz_mediatype_client.go
+++ b/packages/typespec-go/test/http-specs/payload/mediatypegroup/zz_mediatype_client.go
@@ -23,7 +23,7 @@ type MediaTypeClientOptions struct {
 
 // NewMediaTypeClientWithNoCredential creates a new instance of MediaTypeClient with the specified values.
 //   - endpoint - Service host
-//   - options - MediaTypeClientOptions contains the optional values for creating a [MediaTypeClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewMediaTypeClientWithNoCredential(endpoint string, options *MediaTypeClientOptions) (*MediaTypeClient, error) {
 	if options == nil {
 		options = &MediaTypeClientOptions{}

--- a/packages/typespec-go/test/http-specs/payload/pageablegroup/zz_pageable_client.go
+++ b/packages/typespec-go/test/http-specs/payload/pageablegroup/zz_pageable_client.go
@@ -26,7 +26,7 @@ type PageableClientOptions struct {
 
 // NewPageableClientWithNoCredential creates a new instance of PageableClient with the specified values.
 //   - endpoint - Service host
-//   - options - PageableClientOptions contains the optional values for creating a [PageableClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPageableClientWithNoCredential(endpoint string, options *PageableClientOptions) (*PageableClient, error) {
 	if options == nil {
 		options = &PageableClientOptions{}

--- a/packages/typespec-go/test/http-specs/payload/xmlgroup/zz_xml_client.go
+++ b/packages/typespec-go/test/http-specs/payload/xmlgroup/zz_xml_client.go
@@ -23,7 +23,7 @@ type XMLClientOptions struct {
 
 // NewXMLClientWithNoCredential creates a new instance of XMLClient with the specified values.
 //   - endpoint - Service host
-//   - options - XMLClientOptions contains the optional values for creating a [XMLClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewXMLClientWithNoCredential(endpoint string, options *XMLClientOptions) (*XMLClient, error) {
 	if options == nil {
 		options = &XMLClientOptions{}

--- a/packages/typespec-go/test/http-specs/serialization/encoded-name/jsongroup/zz_json_client.go
+++ b/packages/typespec-go/test/http-specs/serialization/encoded-name/jsongroup/zz_json_client.go
@@ -23,7 +23,7 @@ type JSONClientOptions struct {
 
 // NewJSONClientWithNoCredential creates a new instance of JSONClient with the specified values.
 //   - endpoint - Service host
-//   - options - JSONClientOptions contains the optional values for creating a [JSONClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewJSONClientWithNoCredential(endpoint string, options *JSONClientOptions) (*JSONClient, error) {
 	if options == nil {
 		options = &JSONClientOptions{}

--- a/packages/typespec-go/test/http-specs/server/endpoint/noendpointgroup/zz_notdefined_client.go
+++ b/packages/typespec-go/test/http-specs/server/endpoint/noendpointgroup/zz_notdefined_client.go
@@ -27,7 +27,7 @@ type NotDefinedClientOptions struct {
 
 // NewNotDefinedClientWithNoCredential creates a new instance of NotDefinedClient with the specified values.
 //   - endpoint - Service host
-//   - options - NotDefinedClientOptions contains the optional values for creating a [NotDefinedClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewNotDefinedClientWithNoCredential(endpoint string, options *NotDefinedClientOptions) (*NotDefinedClient, error) {
 	if options == nil {
 		options = &NotDefinedClientOptions{}

--- a/packages/typespec-go/test/http-specs/server/path/multiplegroup/zz_multiple_client.go
+++ b/packages/typespec-go/test/http-specs/server/path/multiplegroup/zz_multiple_client.go
@@ -29,7 +29,7 @@ type MultipleClientOptions struct {
 
 // NewMultipleClientWithNoCredential creates a new instance of MultipleClient with the specified values.
 //   - endpoint - Service host
-//   - options - MultipleClientOptions contains the optional values for creating a [MultipleClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewMultipleClientWithNoCredential(endpoint string, options *MultipleClientOptions) (*MultipleClient, error) {
 	if options == nil {
 		options = &MultipleClientOptions{}

--- a/packages/typespec-go/test/http-specs/server/path/singlegroup/zz_single_client.go
+++ b/packages/typespec-go/test/http-specs/server/path/singlegroup/zz_single_client.go
@@ -26,7 +26,7 @@ type SingleClientOptions struct {
 
 // NewSingleClientWithNoCredential creates a new instance of SingleClient with the specified values.
 //   - endpoint - Service host
-//   - options - SingleClientOptions contains the optional values for creating a [SingleClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSingleClientWithNoCredential(endpoint string, options *SingleClientOptions) (*SingleClient, error) {
 	if options == nil {
 		options = &SingleClientOptions{}

--- a/packages/typespec-go/test/http-specs/server/versions/unversionedgroup/zz_notversioned_client.go
+++ b/packages/typespec-go/test/http-specs/server/versions/unversionedgroup/zz_notversioned_client.go
@@ -29,7 +29,7 @@ type NotVersionedClientOptions struct {
 
 // NewNotVersionedClientWithNoCredential creates a new instance of NotVersionedClient with the specified values.
 //   - endpoint - Service host
-//   - options - NotVersionedClientOptions contains the optional values for creating a [NotVersionedClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewNotVersionedClientWithNoCredential(endpoint string, options *NotVersionedClientOptions) (*NotVersionedClient, error) {
 	if options == nil {
 		options = &NotVersionedClientOptions{}

--- a/packages/typespec-go/test/http-specs/server/versions/versionedgroup/zz_versioned_client.go
+++ b/packages/typespec-go/test/http-specs/server/versions/versionedgroup/zz_versioned_client.go
@@ -28,7 +28,7 @@ type VersionedClientOptions struct {
 
 // NewVersionedClientWithNoCredential creates a new instance of VersionedClient with the specified values.
 //   - endpoint - Service host
-//   - options - VersionedClientOptions contains the optional values for creating a [VersionedClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVersionedClientWithNoCredential(endpoint string, options *VersionedClientOptions) (*VersionedClient, error) {
 	if options == nil {
 		options = &VersionedClientOptions{}

--- a/packages/typespec-go/test/http-specs/special-headers/condreqgroup/zz_conditionalrequest_client.go
+++ b/packages/typespec-go/test/http-specs/special-headers/condreqgroup/zz_conditionalrequest_client.go
@@ -27,7 +27,7 @@ type ConditionalRequestClientOptions struct {
 
 // NewConditionalRequestClientWithNoCredential creates a new instance of ConditionalRequestClient with the specified values.
 //   - endpoint - Service host
-//   - options - ConditionalRequestClientOptions contains the optional values for creating a [ConditionalRequestClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewConditionalRequestClientWithNoCredential(endpoint string, options *ConditionalRequestClientOptions) (*ConditionalRequestClient, error) {
 	if options == nil {
 		options = &ConditionalRequestClientOptions{}

--- a/packages/typespec-go/test/http-specs/specialwordsgroup/zz_specialwords_client.go
+++ b/packages/typespec-go/test/http-specs/specialwordsgroup/zz_specialwords_client.go
@@ -59,7 +59,7 @@ type SpecialWordsClientOptions struct {
 
 // NewSpecialWordsClientWithNoCredential creates a new instance of SpecialWordsClient with the specified values.
 //   - endpoint - Service host
-//   - options - SpecialWordsClientOptions contains the optional values for creating a [SpecialWordsClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSpecialWordsClientWithNoCredential(endpoint string, options *SpecialWordsClientOptions) (*SpecialWordsClient, error) {
 	if options == nil {
 		options = &SpecialWordsClientOptions{}

--- a/packages/typespec-go/test/http-specs/type/arraygroup/zz_array_client.go
+++ b/packages/typespec-go/test/http-specs/type/arraygroup/zz_array_client.go
@@ -23,7 +23,7 @@ type ArrayClientOptions struct {
 
 // NewArrayClientWithNoCredential creates a new instance of ArrayClient with the specified values.
 //   - endpoint - Service host
-//   - options - ArrayClientOptions contains the optional values for creating a [ArrayClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewArrayClientWithNoCredential(endpoint string, options *ArrayClientOptions) (*ArrayClient, error) {
 	if options == nil {
 		options = &ArrayClientOptions{}

--- a/packages/typespec-go/test/http-specs/type/dictionarygroup/zz_dictionary_client.go
+++ b/packages/typespec-go/test/http-specs/type/dictionarygroup/zz_dictionary_client.go
@@ -23,7 +23,7 @@ type DictionaryClientOptions struct {
 
 // NewDictionaryClientWithNoCredential creates a new instance of DictionaryClient with the specified values.
 //   - endpoint - Service host
-//   - options - DictionaryClientOptions contains the optional values for creating a [DictionaryClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDictionaryClientWithNoCredential(endpoint string, options *DictionaryClientOptions) (*DictionaryClient, error) {
 	if options == nil {
 		options = &DictionaryClientOptions{}

--- a/packages/typespec-go/test/http-specs/type/enum/extensiblegroup/zz_extensible_client.go
+++ b/packages/typespec-go/test/http-specs/type/enum/extensiblegroup/zz_extensible_client.go
@@ -23,7 +23,7 @@ type ExtensibleClientOptions struct {
 
 // NewExtensibleClientWithNoCredential creates a new instance of ExtensibleClient with the specified values.
 //   - endpoint - Service host
-//   - options - ExtensibleClientOptions contains the optional values for creating a [ExtensibleClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewExtensibleClientWithNoCredential(endpoint string, options *ExtensibleClientOptions) (*ExtensibleClient, error) {
 	if options == nil {
 		options = &ExtensibleClientOptions{}

--- a/packages/typespec-go/test/http-specs/type/enum/fixedgroup/zz_fixed_client.go
+++ b/packages/typespec-go/test/http-specs/type/enum/fixedgroup/zz_fixed_client.go
@@ -23,7 +23,7 @@ type FixedClientOptions struct {
 
 // NewFixedClientWithNoCredential creates a new instance of FixedClient with the specified values.
 //   - endpoint - Service host
-//   - options - FixedClientOptions contains the optional values for creating a [FixedClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewFixedClientWithNoCredential(endpoint string, options *FixedClientOptions) (*FixedClient, error) {
 	if options == nil {
 		options = &FixedClientOptions{}

--- a/packages/typespec-go/test/http-specs/type/model/emptygroup/zz_empty_client.go
+++ b/packages/typespec-go/test/http-specs/type/model/emptygroup/zz_empty_client.go
@@ -26,7 +26,7 @@ type EmptyClientOptions struct {
 
 // NewEmptyClientWithNoCredential creates a new instance of EmptyClient with the specified values.
 //   - endpoint - Service host
-//   - options - EmptyClientOptions contains the optional values for creating a [EmptyClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewEmptyClientWithNoCredential(endpoint string, options *EmptyClientOptions) (*EmptyClient, error) {
 	if options == nil {
 		options = &EmptyClientOptions{}

--- a/packages/typespec-go/test/http-specs/type/model/inheritance/enumdiscgroup/zz_enumdiscriminator_client.go
+++ b/packages/typespec-go/test/http-specs/type/model/inheritance/enumdiscgroup/zz_enumdiscriminator_client.go
@@ -26,7 +26,7 @@ type EnumDiscriminatorClientOptions struct {
 
 // NewEnumDiscriminatorClientWithNoCredential creates a new instance of EnumDiscriminatorClient with the specified values.
 //   - endpoint - Service host
-//   - options - EnumDiscriminatorClientOptions contains the optional values for creating a [EnumDiscriminatorClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewEnumDiscriminatorClientWithNoCredential(endpoint string, options *EnumDiscriminatorClientOptions) (*EnumDiscriminatorClient, error) {
 	if options == nil {
 		options = &EnumDiscriminatorClientOptions{}

--- a/packages/typespec-go/test/http-specs/type/model/inheritance/nodiscgroup/zz_notdiscriminated_client.go
+++ b/packages/typespec-go/test/http-specs/type/model/inheritance/nodiscgroup/zz_notdiscriminated_client.go
@@ -26,7 +26,7 @@ type NotDiscriminatedClientOptions struct {
 
 // NewNotDiscriminatedClientWithNoCredential creates a new instance of NotDiscriminatedClient with the specified values.
 //   - endpoint - Service host
-//   - options - NotDiscriminatedClientOptions contains the optional values for creating a [NotDiscriminatedClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewNotDiscriminatedClientWithNoCredential(endpoint string, options *NotDiscriminatedClientOptions) (*NotDiscriminatedClient, error) {
 	if options == nil {
 		options = &NotDiscriminatedClientOptions{}

--- a/packages/typespec-go/test/http-specs/type/model/inheritance/recursivegroup/zz_recursive_client.go
+++ b/packages/typespec-go/test/http-specs/type/model/inheritance/recursivegroup/zz_recursive_client.go
@@ -26,7 +26,7 @@ type RecursiveClientOptions struct {
 
 // NewRecursiveClientWithNoCredential creates a new instance of RecursiveClient with the specified values.
 //   - endpoint - Service host
-//   - options - RecursiveClientOptions contains the optional values for creating a [RecursiveClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewRecursiveClientWithNoCredential(endpoint string, options *RecursiveClientOptions) (*RecursiveClient, error) {
 	if options == nil {
 		options = &RecursiveClientOptions{}

--- a/packages/typespec-go/test/http-specs/type/model/inheritance/singlediscgroup/zz_singlediscriminator_client.go
+++ b/packages/typespec-go/test/http-specs/type/model/inheritance/singlediscgroup/zz_singlediscriminator_client.go
@@ -26,7 +26,7 @@ type SingleDiscriminatorClientOptions struct {
 
 // NewSingleDiscriminatorClientWithNoCredential creates a new instance of SingleDiscriminatorClient with the specified values.
 //   - endpoint - Service host
-//   - options - SingleDiscriminatorClientOptions contains the optional values for creating a [SingleDiscriminatorClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSingleDiscriminatorClientWithNoCredential(endpoint string, options *SingleDiscriminatorClientOptions) (*SingleDiscriminatorClient, error) {
 	if options == nil {
 		options = &SingleDiscriminatorClientOptions{}

--- a/packages/typespec-go/test/http-specs/type/model/usagegroup/zz_usage_client.go
+++ b/packages/typespec-go/test/http-specs/type/model/usagegroup/zz_usage_client.go
@@ -26,7 +26,7 @@ type UsageClientOptions struct {
 
 // NewUsageClientWithNoCredential creates a new instance of UsageClient with the specified values.
 //   - endpoint - Service host
-//   - options - UsageClientOptions contains the optional values for creating a [UsageClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewUsageClientWithNoCredential(endpoint string, options *UsageClientOptions) (*UsageClient, error) {
 	if options == nil {
 		options = &UsageClientOptions{}

--- a/packages/typespec-go/test/http-specs/type/model/visibilitygroup/zz_visibility_client.go
+++ b/packages/typespec-go/test/http-specs/type/model/visibilitygroup/zz_visibility_client.go
@@ -27,7 +27,7 @@ type VisibilityClientOptions struct {
 
 // NewVisibilityClientWithNoCredential creates a new instance of VisibilityClient with the specified values.
 //   - endpoint - Service host
-//   - options - VisibilityClientOptions contains the optional values for creating a [VisibilityClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewVisibilityClientWithNoCredential(endpoint string, options *VisibilityClientOptions) (*VisibilityClient, error) {
 	if options == nil {
 		options = &VisibilityClientOptions{}

--- a/packages/typespec-go/test/http-specs/type/property/nullablegroup/zz_nullable_client.go
+++ b/packages/typespec-go/test/http-specs/type/property/nullablegroup/zz_nullable_client.go
@@ -23,7 +23,7 @@ type NullableClientOptions struct {
 
 // NewNullableClientWithNoCredential creates a new instance of NullableClient with the specified values.
 //   - endpoint - Service host
-//   - options - NullableClientOptions contains the optional values for creating a [NullableClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewNullableClientWithNoCredential(endpoint string, options *NullableClientOptions) (*NullableClient, error) {
 	if options == nil {
 		options = &NullableClientOptions{}

--- a/packages/typespec-go/test/http-specs/type/property/optionalitygroup/zz_optional_client.go
+++ b/packages/typespec-go/test/http-specs/type/property/optionalitygroup/zz_optional_client.go
@@ -23,7 +23,7 @@ type OptionalClientOptions struct {
 
 // NewOptionalClientWithNoCredential creates a new instance of OptionalClient with the specified values.
 //   - endpoint - Service host
-//   - options - OptionalClientOptions contains the optional values for creating a [OptionalClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOptionalClientWithNoCredential(endpoint string, options *OptionalClientOptions) (*OptionalClient, error) {
 	if options == nil {
 		options = &OptionalClientOptions{}

--- a/packages/typespec-go/test/http-specs/type/property/valuetypesgroup/zz_valuetypes_client.go
+++ b/packages/typespec-go/test/http-specs/type/property/valuetypesgroup/zz_valuetypes_client.go
@@ -23,7 +23,7 @@ type ValueTypesClientOptions struct {
 
 // NewValueTypesClientWithNoCredential creates a new instance of ValueTypesClient with the specified values.
 //   - endpoint - Service host
-//   - options - ValueTypesClientOptions contains the optional values for creating a [ValueTypesClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewValueTypesClientWithNoCredential(endpoint string, options *ValueTypesClientOptions) (*ValueTypesClient, error) {
 	if options == nil {
 		options = &ValueTypesClientOptions{}

--- a/packages/typespec-go/test/http-specs/type/scalargroup/zz_scalar_client.go
+++ b/packages/typespec-go/test/http-specs/type/scalargroup/zz_scalar_client.go
@@ -23,7 +23,7 @@ type ScalarClientOptions struct {
 
 // NewScalarClientWithNoCredential creates a new instance of ScalarClient with the specified values.
 //   - endpoint - Service host
-//   - options - ScalarClientOptions contains the optional values for creating a [ScalarClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewScalarClientWithNoCredential(endpoint string, options *ScalarClientOptions) (*ScalarClient, error) {
 	if options == nil {
 		options = &ScalarClientOptions{}

--- a/packages/typespec-go/test/http-specs/versioning/madeoptionalgroup/zz_madeoptional_client.go
+++ b/packages/typespec-go/test/http-specs/versioning/madeoptionalgroup/zz_madeoptional_client.go
@@ -27,7 +27,7 @@ type MadeOptionalClientOptions struct {
 
 // NewMadeOptionalClientWithNoCredential creates a new instance of MadeOptionalClient with the specified values.
 //   - endpoint - Service host
-//   - options - MadeOptionalClientOptions contains the optional values for creating a [MadeOptionalClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewMadeOptionalClientWithNoCredential(endpoint string, options *MadeOptionalClientOptions) (*MadeOptionalClient, error) {
 	if options == nil {
 		options = &MadeOptionalClientOptions{}

--- a/packages/typespec-go/test/http-specs/versioning/rettypechangedfromgroup/zz_returntypechangedfrom_client.go
+++ b/packages/typespec-go/test/http-specs/versioning/rettypechangedfromgroup/zz_returntypechangedfrom_client.go
@@ -27,7 +27,7 @@ type ReturnTypeChangedFromClientOptions struct {
 
 // NewReturnTypeChangedFromClientWithNoCredential creates a new instance of ReturnTypeChangedFromClient with the specified values.
 //   - endpoint - Service host
-//   - options - ReturnTypeChangedFromClientOptions contains the optional values for creating a [ReturnTypeChangedFromClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewReturnTypeChangedFromClientWithNoCredential(endpoint string, options *ReturnTypeChangedFromClientOptions) (*ReturnTypeChangedFromClient, error) {
 	if options == nil {
 		options = &ReturnTypeChangedFromClientOptions{}

--- a/packages/typespec-go/test/http-specs/versioning/typechangedfromgroup/zz_typechangedfrom_client.go
+++ b/packages/typespec-go/test/http-specs/versioning/typechangedfromgroup/zz_typechangedfrom_client.go
@@ -27,7 +27,7 @@ type TypeChangedFromClientOptions struct {
 
 // NewTypeChangedFromClientWithNoCredential creates a new instance of TypeChangedFromClient with the specified values.
 //   - endpoint - Service host
-//   - options - TypeChangedFromClientOptions contains the optional values for creating a [TypeChangedFromClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewTypeChangedFromClientWithNoCredential(endpoint string, options *TypeChangedFromClientOptions) (*TypeChangedFromClient, error) {
 	if options == nil {
 		options = &TypeChangedFromClientOptions{}

--- a/packages/typespec-go/test/local/armapicenter/zz_apidefinitions_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_apidefinitions_client.go
@@ -26,7 +26,7 @@ type APIDefinitionsClient struct {
 // NewAPIDefinitionsClient creates a new instance of APIDefinitionsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAPIDefinitionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*APIDefinitionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armapicenter/zz_apis_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_apis_client.go
@@ -26,7 +26,7 @@ type ApisClient struct {
 // NewApisClient creates a new instance of ApisClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewApisClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApisClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armapicenter/zz_apiversions_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_apiversions_client.go
@@ -26,7 +26,7 @@ type APIVersionsClient struct {
 // NewAPIVersionsClient creates a new instance of APIVersionsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAPIVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*APIVersionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armapicenter/zz_deletedservices_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_deletedservices_client.go
@@ -26,7 +26,7 @@ type DeletedServicesClient struct {
 // NewDeletedServicesClient creates a new instance of DeletedServicesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDeletedServicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DeletedServicesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armapicenter/zz_deployments_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_deployments_client.go
@@ -26,7 +26,7 @@ type DeploymentsClient struct {
 // NewDeploymentsClient creates a new instance of DeploymentsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDeploymentsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DeploymentsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armapicenter/zz_environments_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_environments_client.go
@@ -26,7 +26,7 @@ type EnvironmentsClient struct {
 // NewEnvironmentsClient creates a new instance of EnvironmentsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewEnvironmentsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*EnvironmentsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armapicenter/zz_metadataschemas_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_metadataschemas_client.go
@@ -26,7 +26,7 @@ type MetadataSchemasClient struct {
 // NewMetadataSchemasClient creates a new instance of MetadataSchemasClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewMetadataSchemasClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*MetadataSchemasClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armapicenter/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_operations_client.go
@@ -21,7 +21,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armapicenter/zz_services_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_services_client.go
@@ -26,7 +26,7 @@ type ServicesClient struct {
 // NewServicesClient creates a new instance of ServicesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewServicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServicesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armapicenter/zz_workspaces_client.go
+++ b/packages/typespec-go/test/local/armapicenter/zz_workspaces_client.go
@@ -26,7 +26,7 @@ type WorkspacesClient struct {
 // NewWorkspacesClient creates a new instance of WorkspacesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewWorkspacesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WorkspacesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armbillingbenefits/zz_discounts_client.go
+++ b/packages/typespec-go/test/local/armbillingbenefits/zz_discounts_client.go
@@ -26,7 +26,7 @@ type DiscountsClient struct {
 // NewDiscountsClient creates a new instance of DiscountsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDiscountsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DiscountsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armbillingbenefits/zz_discountsoperationgroup_client.go
+++ b/packages/typespec-go/test/local/armbillingbenefits/zz_discountsoperationgroup_client.go
@@ -24,7 +24,7 @@ type DiscountsOperationGroupClient struct {
 
 // NewDiscountsOperationGroupClient creates a new instance of DiscountsOperationGroupClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDiscountsOperationGroupClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*DiscountsOperationGroupClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armbillingbenefits/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armbillingbenefits/zz_operations_client.go
@@ -21,7 +21,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armbillingbenefits/zz_reservationorderaliasresponses_client.go
+++ b/packages/typespec-go/test/local/armbillingbenefits/zz_reservationorderaliasresponses_client.go
@@ -24,7 +24,7 @@ type ReservationOrderAliasResponsesClient struct {
 
 // NewReservationOrderAliasResponsesClient creates a new instance of ReservationOrderAliasResponsesClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewReservationOrderAliasResponsesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationOrderAliasResponsesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armbillingbenefits/zz_savingsplanmodels_client.go
+++ b/packages/typespec-go/test/local/armbillingbenefits/zz_savingsplanmodels_client.go
@@ -24,7 +24,7 @@ type SavingsPlanModelsClient struct {
 
 // NewSavingsPlanModelsClient creates a new instance of SavingsPlanModelsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSavingsPlanModelsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*SavingsPlanModelsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armbillingbenefits/zz_savingsplanoperationgroup_client.go
+++ b/packages/typespec-go/test/local/armbillingbenefits/zz_savingsplanoperationgroup_client.go
@@ -22,7 +22,7 @@ type SavingsPlanOperationGroupClient struct {
 
 // NewSavingsPlanOperationGroupClient creates a new instance of SavingsPlanOperationGroupClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSavingsPlanOperationGroupClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*SavingsPlanOperationGroupClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armbillingbenefits/zz_savingsplanorderaliasmodels_client.go
+++ b/packages/typespec-go/test/local/armbillingbenefits/zz_savingsplanorderaliasmodels_client.go
@@ -24,7 +24,7 @@ type SavingsPlanOrderAliasModelsClient struct {
 
 // NewSavingsPlanOrderAliasModelsClient creates a new instance of SavingsPlanOrderAliasModelsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSavingsPlanOrderAliasModelsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*SavingsPlanOrderAliasModelsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armbillingbenefits/zz_savingsplanordermodels_client.go
+++ b/packages/typespec-go/test/local/armbillingbenefits/zz_savingsplanordermodels_client.go
@@ -24,7 +24,7 @@ type SavingsPlanOrderModelsClient struct {
 
 // NewSavingsPlanOrderModelsClient creates a new instance of SavingsPlanOrderModelsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSavingsPlanOrderModelsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*SavingsPlanOrderModelsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armcodesigning/zz_accounts_client.go
+++ b/packages/typespec-go/test/local/armcodesigning/zz_accounts_client.go
@@ -26,7 +26,7 @@ type AccountsClient struct {
 // NewAccountsClient creates a new instance of AccountsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAccountsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AccountsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armcodesigning/zz_certificateprofiles_client.go
+++ b/packages/typespec-go/test/local/armcodesigning/zz_certificateprofiles_client.go
@@ -26,7 +26,7 @@ type CertificateProfilesClient struct {
 // NewCertificateProfilesClient creates a new instance of CertificateProfilesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCertificateProfilesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CertificateProfilesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armcodesigning/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armcodesigning/zz_operations_client.go
@@ -21,7 +21,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armcommunitymanagement/zz_communitytrainings_client.go
+++ b/packages/typespec-go/test/local/armcommunitymanagement/zz_communitytrainings_client.go
@@ -26,7 +26,7 @@ type CommunityTrainingsClient struct {
 // NewCommunityTrainingsClient creates a new instance of CommunityTrainingsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCommunityTrainingsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CommunityTrainingsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armcommunitymanagement/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armcommunitymanagement/zz_operations_client.go
@@ -21,7 +21,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armcomputeschedule/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armcomputeschedule/zz_operations_client.go
@@ -21,7 +21,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armcomputeschedule/zz_scheduledactions_client.go
+++ b/packages/typespec-go/test/local/armcomputeschedule/zz_scheduledactions_client.go
@@ -26,7 +26,7 @@ type ScheduledActionsClient struct {
 // NewScheduledActionsClient creates a new instance of ScheduledActionsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewScheduledActionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ScheduledActionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_bgppeers_client.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_bgppeers_client.go
@@ -24,7 +24,7 @@ type BgpPeersClient struct {
 
 // NewBgpPeersClient creates a new instance of BgpPeersClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBgpPeersClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*BgpPeersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_loadbalancers_client.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_loadbalancers_client.go
@@ -24,7 +24,7 @@ type LoadBalancersClient struct {
 
 // NewLoadBalancersClient creates a new instance of LoadBalancersClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewLoadBalancersClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_operations_client.go
@@ -21,7 +21,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_services_client.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_services_client.go
@@ -24,7 +24,7 @@ type ServicesClient struct {
 
 // NewServicesClient creates a new instance of ServicesClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewServicesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ServicesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_storageclass_client.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_storageclass_client.go
@@ -24,7 +24,7 @@ type StorageClassClient struct {
 
 // NewStorageClassClient creates a new instance of StorageClassClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewStorageClassClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*StorageClassClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armdatabasewatcher/zz_alertruleresources_client.go
+++ b/packages/typespec-go/test/local/armdatabasewatcher/zz_alertruleresources_client.go
@@ -26,7 +26,7 @@ type AlertRuleResourcesClient struct {
 // NewAlertRuleResourcesClient creates a new instance of AlertRuleResourcesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAlertRuleResourcesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AlertRuleResourcesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armdatabasewatcher/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armdatabasewatcher/zz_operations_client.go
@@ -21,7 +21,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armdatabasewatcher/zz_sharedprivatelinkresources_client.go
+++ b/packages/typespec-go/test/local/armdatabasewatcher/zz_sharedprivatelinkresources_client.go
@@ -26,7 +26,7 @@ type SharedPrivateLinkResourcesClient struct {
 // NewSharedPrivateLinkResourcesClient creates a new instance of SharedPrivateLinkResourcesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSharedPrivateLinkResourcesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SharedPrivateLinkResourcesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armdatabasewatcher/zz_targets_client.go
+++ b/packages/typespec-go/test/local/armdatabasewatcher/zz_targets_client.go
@@ -26,7 +26,7 @@ type TargetsClient struct {
 // NewTargetsClient creates a new instance of TargetsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewTargetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*TargetsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armdatabasewatcher/zz_watchers_client.go
+++ b/packages/typespec-go/test/local/armdatabasewatcher/zz_watchers_client.go
@@ -26,7 +26,7 @@ type WatchersClient struct {
 // NewWatchersClient creates a new instance of WatchersClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewWatchersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WatchersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armdevopsinfrastructure/zz_imageversions_client.go
+++ b/packages/typespec-go/test/local/armdevopsinfrastructure/zz_imageversions_client.go
@@ -26,7 +26,7 @@ type ImageVersionsClient struct {
 // NewImageVersionsClient creates a new instance of ImageVersionsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewImageVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ImageVersionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armdevopsinfrastructure/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armdevopsinfrastructure/zz_operations_client.go
@@ -21,7 +21,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armdevopsinfrastructure/zz_pools_client.go
+++ b/packages/typespec-go/test/local/armdevopsinfrastructure/zz_pools_client.go
@@ -26,7 +26,7 @@ type PoolsClient struct {
 // NewPoolsClient creates a new instance of PoolsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPoolsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PoolsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armdevopsinfrastructure/zz_resourcedetails_client.go
+++ b/packages/typespec-go/test/local/armdevopsinfrastructure/zz_resourcedetails_client.go
@@ -26,7 +26,7 @@ type ResourceDetailsClient struct {
 // NewResourceDetailsClient creates a new instance of ResourceDetailsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewResourceDetailsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ResourceDetailsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armdevopsinfrastructure/zz_sku_client.go
+++ b/packages/typespec-go/test/local/armdevopsinfrastructure/zz_sku_client.go
@@ -26,7 +26,7 @@ type SKUClient struct {
 // NewSKUClient creates a new instance of SKUClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSKUClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SKUClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armdevopsinfrastructure/zz_subscriptionusages_client.go
+++ b/packages/typespec-go/test/local/armdevopsinfrastructure/zz_subscriptionusages_client.go
@@ -26,7 +26,7 @@ type SubscriptionUsagesClient struct {
 // NewSubscriptionUsagesClient creates a new instance of SubscriptionUsagesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSubscriptionUsagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SubscriptionUsagesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armhardwaresecuritymodules/zz_cloudhsmclusters_client.go
+++ b/packages/typespec-go/test/local/armhardwaresecuritymodules/zz_cloudhsmclusters_client.go
@@ -27,7 +27,7 @@ type CloudHsmClustersClient struct {
 // NewCloudHsmClustersClient creates a new instance of CloudHsmClustersClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewCloudHsmClustersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CloudHsmClustersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armhardwaresecuritymodules/zz_dedicatedhsms_client.go
+++ b/packages/typespec-go/test/local/armhardwaresecuritymodules/zz_dedicatedhsms_client.go
@@ -27,7 +27,7 @@ type DedicatedHsmsClient struct {
 // NewDedicatedHsmsClient creates a new instance of DedicatedHsmsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewDedicatedHsmsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DedicatedHsmsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armhardwaresecuritymodules/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armhardwaresecuritymodules/zz_operations_client.go
@@ -21,7 +21,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armhardwaresecuritymodules/zz_privateendpointconnections_client.go
+++ b/packages/typespec-go/test/local/armhardwaresecuritymodules/zz_privateendpointconnections_client.go
@@ -26,7 +26,7 @@ type PrivateEndpointConnectionsClient struct {
 // NewPrivateEndpointConnectionsClient creates a new instance of PrivateEndpointConnectionsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPrivateEndpointConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateEndpointConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armhealthbot/zz_healthbots_client.go
+++ b/packages/typespec-go/test/local/armhealthbot/zz_healthbots_client.go
@@ -26,7 +26,7 @@ type HealthBotsClient struct {
 // NewHealthBotsClient creates a new instance of HealthBotsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewHealthBotsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*HealthBotsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armhealthbot/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armhealthbot/zz_operations_client.go
@@ -24,7 +24,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armlargeinstance/zz_azurelargestorageinstance_client.go
+++ b/packages/typespec-go/test/local/armlargeinstance/zz_azurelargestorageinstance_client.go
@@ -26,7 +26,7 @@ type AzureLargeStorageInstanceClient struct {
 // NewAzureLargeStorageInstanceClient creates a new instance of AzureLargeStorageInstanceClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewAzureLargeStorageInstanceClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AzureLargeStorageInstanceClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armlargeinstance/zz_client.go
+++ b/packages/typespec-go/test/local/armlargeinstance/zz_client.go
@@ -26,7 +26,7 @@ type Client struct {
 // NewClient creates a new instance of Client with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*Client, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armlargeinstance/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armlargeinstance/zz_operations_client.go
@@ -21,7 +21,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armloadtestservice/zz_loadtestmgmt_client.go
+++ b/packages/typespec-go/test/local/armloadtestservice/zz_loadtestmgmt_client.go
@@ -26,7 +26,7 @@ type LoadTestMgmtClient struct {
 // NewLoadTestMgmtClient creates a new instance of LoadTestMgmtClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewLoadTestMgmtClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadTestMgmtClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armmongocluster/zz_firewallrules_client.go
+++ b/packages/typespec-go/test/local/armmongocluster/zz_firewallrules_client.go
@@ -26,7 +26,7 @@ type FirewallRulesClient struct {
 // NewFirewallRulesClient creates a new instance of FirewallRulesClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewFirewallRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FirewallRulesClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armmongocluster/zz_mongoclusters_client.go
+++ b/packages/typespec-go/test/local/armmongocluster/zz_mongoclusters_client.go
@@ -26,7 +26,7 @@ type MongoClustersClient struct {
 // NewMongoClustersClient creates a new instance of MongoClustersClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewMongoClustersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*MongoClustersClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armmongocluster/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armmongocluster/zz_operations_client.go
@@ -21,7 +21,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armmongocluster/zz_privateendpointconnections_client.go
+++ b/packages/typespec-go/test/local/armmongocluster/zz_privateendpointconnections_client.go
@@ -26,7 +26,7 @@ type PrivateEndpointConnectionsClient struct {
 // NewPrivateEndpointConnectionsClient creates a new instance of PrivateEndpointConnectionsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPrivateEndpointConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateEndpointConnectionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armmongocluster/zz_privatelinks_client.go
+++ b/packages/typespec-go/test/local/armmongocluster/zz_privatelinks_client.go
@@ -26,7 +26,7 @@ type PrivateLinksClient struct {
 // NewPrivateLinksClient creates a new instance of PrivateLinksClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPrivateLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateLinksClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armmongocluster/zz_replicas_client.go
+++ b/packages/typespec-go/test/local/armmongocluster/zz_replicas_client.go
@@ -26,7 +26,7 @@ type ReplicasClient struct {
 // NewReplicasClient creates a new instance of ReplicasClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewReplicasClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ReplicasClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armoracledatabase/zz_operations_client.go
+++ b/packages/typespec-go/test/local/armoracledatabase/zz_operations_client.go
@@ -21,7 +21,7 @@ type OperationsClient struct {
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armoracledatabase/zz_oraclesubscriptions_client.go
+++ b/packages/typespec-go/test/local/armoracledatabase/zz_oraclesubscriptions_client.go
@@ -26,7 +26,7 @@ type OracleSubscriptionsClient struct {
 // NewOracleSubscriptionsClient creates a new instance of OracleSubscriptionsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewOracleSubscriptionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OracleSubscriptionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armrandom/zz_client.go
+++ b/packages/typespec-go/test/local/armrandom/zz_client.go
@@ -26,7 +26,7 @@ type Client struct {
 // NewClient creates a new instance of Client with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*Client, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armrandom/zz_someservice_client.go
+++ b/packages/typespec-go/test/local/armrandom/zz_someservice_client.go
@@ -21,7 +21,7 @@ type SomeServiceClient struct {
 
 // NewSomeServiceClient creates a new instance of SomeServiceClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewSomeServiceClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*SomeServiceClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/armtest/zz_bodyroots_client.go
+++ b/packages/typespec-go/test/local/armtest/zz_bodyroots_client.go
@@ -26,7 +26,7 @@ type BodyRootsClient struct {
 // NewBodyRootsClient creates a new instance of BodyRootsClient with the specified values.
 //   - subscriptionID - The ID of the target subscription. The value must be an UUID.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - pass nil to accept the default values.
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewBodyRootsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BodyRootsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {

--- a/packages/typespec-go/test/local/azkeys/zz_client.go
+++ b/packages/typespec-go/test/local/azkeys/zz_client.go
@@ -33,7 +33,7 @@ type ClientOptions struct {
 // NewClient creates a new instance of Client with the specified values.
 //   - vaultBaseUrl - Service host
 //   - credential - used to authorize requests. Usually a credential from azidentity.
-//   - options - ClientOptions contains the optional values for creating a [Client]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewClient(vaultBaseUrl string, credential azcore.TokenCredential, options *ClientOptions) (*Client, error) {
 	if options == nil {
 		options = &ClientOptions{}

--- a/packages/typespec-go/test/local/internalpager/zz_pager_client.go
+++ b/packages/typespec-go/test/local/internalpager/zz_pager_client.go
@@ -23,7 +23,7 @@ type PagerClientOptions struct {
 
 // NewPagerClientWithNoCredential creates a new instance of PagerClient with the specified values.
 //   - endpoint - Service host
-//   - options - PagerClientOptions contains the optional values for creating a [PagerClient]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewPagerClientWithNoCredential(endpoint string, options *PagerClientOptions) (*PagerClient, error) {
 	if options == nil {
 		options = &PagerClientOptions{}

--- a/packages/typespec-go/test/local/nooptionalbody/zz_client.go
+++ b/packages/typespec-go/test/local/nooptionalbody/zz_client.go
@@ -26,7 +26,7 @@ type ClientOptions struct {
 
 // NewClientWithNoCredential creates a new instance of Client with the specified values.
 //   - endpoint - Service host
-//   - options - ClientOptions contains the optional values for creating a [Client]
+//   - options - Contains optional client configuration. Pass nil to accept the default values.
 func NewClientWithNoCredential(endpoint string, options *ClientOptions) (*Client, error) {
 	if options == nil {
 		options = &ClientOptions{}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,7 +251,7 @@ importers:
         version: 0.1.0-alpha.29(f62ea912328429f54bfd1f403089335c)
       '@azure-tools/typespec-autorest':
         specifier: 0.60.0
-        version: 0.60.0(13020869687f4fc3e1d05b6bee5746ac)
+        version: 0.60.0(b8600f8c8a864454aa9f8f677f832045)
       '@azure-tools/typespec-azure-core':
         specifier: 0.60.0
         version: 0.60.0(@typespec/compiler@1.4.0(@types/node@20.17.40))(@typespec/http@1.4.0(@typespec/compiler@1.4.0(@types/node@20.17.40))(@typespec/streams@0.74.0(@typespec/compiler@1.4.0(@types/node@20.17.40))))(@typespec/rest@0.74.0(@typespec/compiler@1.4.0(@types/node@20.17.40))(@typespec/http@1.4.0(@typespec/compiler@1.4.0(@types/node@20.17.40))(@typespec/streams@0.74.0(@typespec/compiler@1.4.0(@types/node@20.17.40)))))
@@ -259,8 +259,8 @@ importers:
         specifier: 0.60.0
         version: 0.60.0(10dad23d6d324dec2c34d6aa5a31e691)
       '@azure-tools/typespec-client-generator-core':
-        specifier: 0.60.2
-        version: 0.60.2(0a5169718dd8d59b120ac22cf67044e9)
+        specifier: 0.60.3
+        version: 0.60.3(0a5169718dd8d59b120ac22cf67044e9)
       '@types/node':
         specifier: 'catalog:'
         version: 20.17.40
@@ -424,8 +424,8 @@ packages:
       '@typespec/rest': ^0.74.0
       '@typespec/versioning': ^0.74.0
 
-  '@azure-tools/typespec-client-generator-core@0.60.2':
-    resolution: {integrity: sha512-o2IYEDl8aMQyLi5tlvmg3Fgc6Mhr1uUTGcV95tbrHP9f6SdiOG1nlwZE7Qc/gYairZRJD707XTGq6sN7W5/Zqw==}
+  '@azure-tools/typespec-client-generator-core@0.60.3':
+    resolution: {integrity: sha512-gcaLRoAJnvqg2tNyEYk+vOMhyP0PJpoZZERuDPB9VLiAAdxl3eTz22vAa3wKvnGFpLDxuvo4+ootEYguRCiwdg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@azure-tools/typespec-azure-core': ^0.60.0
@@ -5612,11 +5612,11 @@ snapshots:
 
   '@azure-tools/tasks@4.0.246': {}
 
-  '@azure-tools/typespec-autorest@0.60.0(13020869687f4fc3e1d05b6bee5746ac)':
+  '@azure-tools/typespec-autorest@0.60.0(b8600f8c8a864454aa9f8f677f832045)':
     dependencies:
       '@azure-tools/typespec-azure-core': 0.60.0(@typespec/compiler@1.4.0(@types/node@20.17.40))(@typespec/http@1.4.0(@typespec/compiler@1.4.0(@types/node@20.17.40))(@typespec/streams@0.74.0(@typespec/compiler@1.4.0(@types/node@20.17.40))))(@typespec/rest@0.74.0(@typespec/compiler@1.4.0(@types/node@20.17.40))(@typespec/http@1.4.0(@typespec/compiler@1.4.0(@types/node@20.17.40))(@typespec/streams@0.74.0(@typespec/compiler@1.4.0(@types/node@20.17.40)))))
       '@azure-tools/typespec-azure-resource-manager': 0.60.0(10dad23d6d324dec2c34d6aa5a31e691)
-      '@azure-tools/typespec-client-generator-core': 0.60.2(0a5169718dd8d59b120ac22cf67044e9)
+      '@azure-tools/typespec-client-generator-core': 0.60.3(0a5169718dd8d59b120ac22cf67044e9)
       '@typespec/compiler': 1.4.0(@types/node@20.17.40)
       '@typespec/http': 1.4.0(@typespec/compiler@1.4.0(@types/node@20.17.40))(@typespec/streams@0.74.0(@typespec/compiler@1.4.0(@types/node@20.17.40)))
       '@typespec/openapi': 1.4.0(@typespec/compiler@1.4.0(@types/node@20.17.40))(@typespec/http@1.4.0(@typespec/compiler@1.4.0(@types/node@20.17.40))(@typespec/streams@0.74.0(@typespec/compiler@1.4.0(@types/node@20.17.40))))
@@ -5640,7 +5640,7 @@ snapshots:
       change-case: 5.4.4
       pluralize: 8.0.0
 
-  '@azure-tools/typespec-client-generator-core@0.60.2(0a5169718dd8d59b120ac22cf67044e9)':
+  '@azure-tools/typespec-client-generator-core@0.60.3(0a5169718dd8d59b120ac22cf67044e9)':
     dependencies:
       '@azure-tools/typespec-azure-core': 0.60.0(@typespec/compiler@1.4.0(@types/node@20.17.40))(@typespec/http@1.4.0(@typespec/compiler@1.4.0(@types/node@20.17.40))(@typespec/streams@0.74.0(@typespec/compiler@1.4.0(@types/node@20.17.40))))(@typespec/rest@0.74.0(@typespec/compiler@1.4.0(@types/node@20.17.40))(@typespec/http@1.4.0(@typespec/compiler@1.4.0(@types/node@20.17.40))(@typespec/streams@0.74.0(@typespec/compiler@1.4.0(@types/node@20.17.40)))))
       '@typespec/compiler': 1.4.0(@types/node@20.17.40)


### PR DESCRIPTION
The tsp emitter was using the doc string for the type. This consolidates the doc string.

No functional changes.