### PR TITLE
Refactor client construction code model

### DIFF
--- a/packages/codegen.go/src/cloudConfig.ts
+++ b/packages/codegen.go/src/cloudConfig.ts
@@ -20,14 +20,19 @@ export function generateCloudConfig(codeModel: go.CodeModel): string {
   }
 
   // check if this SDK uses token auth
-  let tokenCred: go.TokenAuthentication | undefined;
+  let tokenCred: go.TokenCredential | undefined;
   for (const client of codeModel.clients) {
     if (client.instance?.kind !== 'constructable') {
       continue;
     }
     for (const constructor of client.instance.constructors) {
-      if (constructor.authentication.kind === 'token') {
-        tokenCred = constructor.authentication;
+      for (const param of constructor.parameters) {
+        if (param.kind === 'credentialParam' && param.type.kind === 'tokenCredential') {
+          tokenCred = param.type;
+          break;
+        }
+      }
+      if (tokenCred) {
         break;
       }
     }

--- a/packages/codemodel.go/src/examples.ts
+++ b/packages/codemodel.go/src/examples.ts
@@ -8,7 +8,7 @@ import * as param from './param.js';
 import * as result from './result.js';
 import * as type from './type.js';
 
-export type ExampleType = AnyExample | ArrayExample | BooleanExample | DictionaryExample | NullExample | NumberExample | StringExample | StructExample;
+export type ExampleType = AnyExample | ArrayExample | BooleanExample | DictionaryExample | NullExample | NumberExample | StringExample | StructExample | TokenCredentialExample;
 
 export interface AnyExample {
   kind: 'any';
@@ -42,9 +42,9 @@ export interface MethodExample {
 
   filePath: string;
 
-  parameters: Array<ParameterExample>;
+  parameters: Array<ParameterExample<param.MethodParameter>>;
 
-  optionalParamsGroup: Array<ParameterExample>;
+  optionalParamsGroup: Array<ParameterExample<param.MethodParameter>>;
 
   responseEnvelope?: ResponseEnvelopeExample;
 }
@@ -61,15 +61,15 @@ export interface NumberExample {
   type: type.Constant | type.Literal | type.Scalar | type.Time;
 }
 
-export interface ParameterExample {
-  parameter: client.ClientParameter;
+export interface ParameterExample<T extends client.ClientParameter = client.ClientParameter> {
+  parameter: T;
   value: ExampleType;
 }
 
 export interface ResponseEnvelopeExample {
   response: result.ResponseEnvelope;
   headers: Array<ResponseHeaderExample>;
-  result: ExampleType;
+  result: Exclude<ExampleType, TokenCredentialExample>;
 }
 
 export interface ResponseHeaderExample {
@@ -88,6 +88,11 @@ export interface StructExample {
   value: Record<string, ExampleType>;
   additionalProperties?: Record<string, ExampleType>;
   type: type.Model | type.PolymorphicModel;
+}
+
+export interface TokenCredentialExample {
+  kind: 'tokenCredential';
+  value: string;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -150,8 +155,8 @@ export class NumberExample implements NumberExample {
   }
 }
 
-export class ParameterExample implements ParameterExample {
-  constructor(parameter: param.MethodParameter, value: ExampleType) {
+export class ParameterExample<T> implements ParameterExample<T> {
+  constructor(parameter: T, value: ExampleType) {
     this.parameter = parameter;
     this.value = value;
   }
@@ -184,5 +189,12 @@ export class StructExample implements StructExample {
     this.kind = 'model';
     this.type = type;
     this.value = {};
+  }
+}
+
+export class TokenCredentialExample implements TokenCredentialExample {
+  constructor(value: string) {
+    this.kind = 'tokenCredential';
+    this.value = value;
   }
 }

--- a/packages/codemodel.go/src/index.ts
+++ b/packages/codemodel.go/src/index.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 export * from './client.js';
-//export * from './method.js';
+export * from './method.js';
 export * from './package.js';
 export * from './param.js';
 export * from './result.js';

--- a/packages/codemodel.go/src/package.ts
+++ b/packages/codemodel.go/src/package.ts
@@ -158,7 +158,7 @@ export class CodeModel implements CodeModel {
       if (client.instance?.kind === 'constructable') {
         client.instance.constructors.sort((a: client.Constructor, b: client.Constructor) => sortAscending(a.name, b.name));
         if (client.instance.options.kind === 'clientOptions') {
-          client.instance.options.params.sort((a: client.ClientParameter, b: client.ClientParameter) => sortAscending(a.name, b.name));
+          client.instance.options.parameters.sort((a: client.ClientParameter, b: client.ClientParameter) => sortAscending(a.name, b.name));
         }
       }
       client.parameters.sort((a: client.ClientParameter, b: client.ClientParameter) => sortAscending(a.name, b.name));

--- a/packages/codemodel.go/src/param.ts
+++ b/packages/codemodel.go/src/param.ts
@@ -140,11 +140,6 @@ export type ParameterStyle = 'required' | 'optional' | 'literal' | 'flag' | Clie
 /** indicates where the value of a parameter originates */
 export type ParameterLocation = 'client' | 'method';
 
-/** a parameter that's not used for creating HTTP requests (e.g. a credential parameter) */
-export interface Parameter extends HttpParameterBase {
-  kind: 'parameter';
-}
-
 /** a struct that contains a grouping of parameters */
 export interface ParameterGroup {
   kind: 'paramGroup';
@@ -292,24 +287,6 @@ export interface URIParameter extends HttpParameterBase {
 
 /** defines the possible types for a URIParameter */
 export type URIParameterType = type.Constant | type.Scalar | type.String;
-
-/**
- * returns true if the provided parameter is for the service API version
- * 
- * @param param the parameter to inspect
- * @returns true if the parameter is for the API version
- */
-export function isAPIVersionParameter(param: MethodParameter | Parameter): boolean {
-  switch (param.kind) {
-    case 'headerScalarParam':
-    case 'pathScalarParam':
-    case 'queryScalarParam':
-    case 'uriParam':
-      return param.isApiVersion;
-    default:
-      return false;
-  }
-}
 
 /** narrows style to a ClientSideDefault within the conditional block */
 export function isClientSideDefault(style: ParameterStyle): style is ClientSideDefault {
@@ -505,13 +482,6 @@ export class MultipartFormBodyParameter extends HttpParameterBase implements Mul
   constructor(name: string, type: type.WireType, style: ParameterStyle, byValue: boolean) {
     super(name, type, style, byValue, 'method');
     this.kind = 'multipartFormBodyParam';
-  }
-}
-
-export class Parameter extends HttpParameterBase implements Parameter {
-  constructor(name: string, type: type.WireType, style: ParameterStyle, byValue: boolean, location: ParameterLocation) {
-    super(name, type, style, byValue, location);
-    this.kind = 'parameter';
   }
 }
 


### PR DESCRIPTION
A client's endpoint is now a discrete field on the client constructable which simplifies parameter ordering.
Updated client options modeling to reflect the generated code. Credendtial parameters are their own client parameter type. TokenCredential parameters are now reflected in the examples code model instead of hard coded.
The param.Parameter type has been replaced by the method.Parameter type. Added some more types to the code model.

No functional changes.