### PR TITLE
change the default value of `UseLatestSpec` to true

### DIFF
--- a/eng/pipelines/sdk-regenerate.yml
+++ b/eng/pipelines/sdk-regenerate.yml
@@ -10,7 +10,7 @@ schedules:
 
 parameters:
 - name: UseLatestSpec
-  default: false
+  default: true
   type: boolean
 - name: ServiceFilter
   type: string


### PR DESCRIPTION
Currently, the default value of `UseLatestSpec`  is false, which will cause weekly regen pipeline task failure: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5473871&view=logs&j=c28f120c-e125-5ec5-8d4c-ba1a4d871fcc&t=8400cb88-1923-54fa-d487-70fbfcd5d927
It should be set up to true by default, since the outdated typespec will cause compile error.