### PR TITLE
Update spec to fix nightly build

### DIFF
--- a/packages/typespec-go/test/tsp/BillingBenefits.Management/ReservationOrderAliasResponse.tsp
+++ b/packages/typespec-go/test/tsp/BillingBenefits.Management/ReservationOrderAliasResponse.tsp
@@ -39,9 +39,7 @@ model ReservationOrderAliasResponse extends Foundations.ProxyResource {
   location?: string;
 
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
-  #suppress "@azure-tools/typespec-azure-core/no-private-usage"
   @doc("The resource-specific properties for this resource.")
-  @Azure.ResourceManager.Private.conditionalClientFlatten
   properties?: ReservationOrderAliasResponseProperties;
 }
 

--- a/packages/typespec-go/test/tsp/BillingBenefits.Management/SavingsPlanModel.tsp
+++ b/packages/typespec-go/test/tsp/BillingBenefits.Management/SavingsPlanModel.tsp
@@ -34,9 +34,7 @@ model SavingsPlanModel extends Foundations.ProxyResource {
   sku: ResourceSku;
 
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
-  #suppress "@azure-tools/typespec-azure-core/no-private-usage"
   @doc("The resource-specific properties for this resource.")
-  @Azure.ResourceManager.Private.conditionalClientFlatten
   properties?: SavingsPlanModelProperties;
 }
 

--- a/packages/typespec-go/test/tsp/BillingBenefits.Management/SavingsPlanOrderAliasModel.tsp
+++ b/packages/typespec-go/test/tsp/BillingBenefits.Management/SavingsPlanOrderAliasModel.tsp
@@ -39,9 +39,7 @@ model SavingsPlanOrderAliasModel extends Foundations.ProxyResource {
   kind?: string;
 
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
-  #suppress "@azure-tools/typespec-azure-core/no-private-usage"
   @doc("The resource-specific properties for this resource.")
-  @Azure.ResourceManager.Private.conditionalClientFlatten
   properties?: SavingsPlanOrderAliasProperties;
 }
 

--- a/packages/typespec-go/test/tsp/BillingBenefits.Management/SavingsPlanOrderModel.tsp
+++ b/packages/typespec-go/test/tsp/BillingBenefits.Management/SavingsPlanOrderModel.tsp
@@ -33,9 +33,7 @@ model SavingsPlanOrderModel extends Foundations.ProxyResource {
   sku: ResourceSku;
 
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
-  #suppress "@azure-tools/typespec-azure-core/no-private-usage"
   @doc("The resource-specific properties for this resource.")
-  @Azure.ResourceManager.Private.conditionalClientFlatten
   properties?: SavingsPlanOrderModelProperties;
 }
 

--- a/packages/typespec-go/test/tsp/BillingBenefits.Management/models.tsp
+++ b/packages/typespec-go/test/tsp/BillingBenefits.Management/models.tsp
@@ -645,8 +645,6 @@ model RoleAssignmentEntity {
   /**
    * Role assignment entity properties
    */
-  #suppress "@azure-tools/typespec-azure-core/no-private-usage" "For backward compatibility"
-  @Azure.ResourceManager.Private.conditionalClientFlatten
   properties?: RoleAssignmentEntityProperties;
 }
 
@@ -883,9 +881,7 @@ model PurchaseRequest {
    */
   sku?: ResourceSku;
 
-  #suppress "@azure-tools/typespec-azure-core/no-private-usage" "For backward compatibility"
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  @Azure.ResourceManager.Private.conditionalClientFlatten
   properties?: PurchaseRequestProperties;
 }
 
@@ -1115,8 +1111,6 @@ model ReservationOrderAliasRequest extends Azure.ResourceManager.CommonTypes.Res
   /**
    * Reservation order alias request properties
    */
-  #suppress "@azure-tools/typespec-azure-core/no-private-usage" "For backward compatibility"
-  @Azure.ResourceManager.Private.conditionalClientFlatten
   properties?: ReservationOrderAliasRequestProperties;
 }
 
@@ -1467,8 +1461,6 @@ model DiscountPatchRequest {
   /**
    * Discounts patch request properties
    */
-  #suppress "@azure-tools/typespec-azure-core/no-private-usage" "For backward compatibility"
-  @Azure.ResourceManager.Private.conditionalClientFlatten
   properties?: DiscountPatchRequestProperties;
 
   /**
@@ -1824,7 +1816,5 @@ model AppliedDiscount extends Azure.ResourceManager.Foundations.ProxyResource {
   /**
    * Discount properties
    */
-  #suppress "@azure-tools/typespec-azure-core/no-private-usage" "For backward compatibility"
-  @Azure.ResourceManager.Private.conditionalClientFlatten
   properties?: DiscountProperties;
 }

--- a/packages/typespec-go/test/tsp/HardwareSecurityModules.Management/DedicatedHsm.tsp
+++ b/packages/typespec-go/test/tsp/HardwareSecurityModules.Management/DedicatedHsm.tsp
@@ -36,7 +36,6 @@ model DedicatedHsm extends Foundations.TrackedResource {
    * Properties of the dedicated HSM
    */
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property"
-  @Azure.ResourceManager.Private.conditionalClientFlatten
   @Azure.ResourceManager.Private.armResourcePropertiesOptionality(false)
   properties: DedicatedHsmProperties;
 }

--- a/packages/typespec-go/test/tsp/HardwareSecurityModules.Management/models.tsp
+++ b/packages/typespec-go/test/tsp/HardwareSecurityModules.Management/models.tsp
@@ -446,8 +446,6 @@ model PrivateLinkResource extends Resource {
   /**
    * Resource properties.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-private-usage" "For backward compatibility"
-  @Azure.ResourceManager.Private.conditionalClientFlatten
   properties?: PrivateLinkResourceProperties;
 }
 
@@ -503,8 +501,6 @@ model BackupResult {
   /**
    * Properties of the Cloud HSM Cluster
    */
-  #suppress "@azure-tools/typespec-azure-core/no-private-usage" "For backward compatibility"
-  @Azure.ResourceManager.Private.conditionalClientFlatten
   properties?: BackupResultProperties;
 }
 

--- a/packages/typespec-go/test/tsp/Healthbot.Management/HealthBot.tsp
+++ b/packages/typespec-go/test/tsp/Healthbot.Management/HealthBot.tsp
@@ -40,9 +40,7 @@ model HealthBot extends Foundations.TrackedResource {
   identity?: Identity;
 
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" ""
-  #suppress "@azure-tools/typespec-azure-core/no-private-usage" ""
   @doc("The set of properties specific to Azure Health Bot resource.")
-  @Azure.ResourceManager.Private.conditionalClientFlatten
   @Azure.ResourceManager.Private.armResourcePropertiesOptionality(true)
   properties?: HealthBotProperties;
 }


### PR DESCRIPTION
TypeSpec new version removed `@conditionalClientFlatten`. So Go need to update build-in test spec to remove that. It is the root cause of nightly build failure. This PR only changes test files, not codegen logic impact.