### PR TITLE
Some imports cleanup

### DIFF
--- a/packages/codegen.go/src/core/imports.ts
+++ b/packages/codegen.go/src/core/imports.ts
@@ -97,7 +97,7 @@ export class ImportManager {
    * 
    * @param type the type for which to add the import
    */
-  addForType(type: go.Type): void {
+  addForType(type: go.Client | go.Type): void {
     switch (type.kind) {
       case 'map':
         this.addForType(type.valueType);
@@ -105,6 +105,7 @@ export class ImportManager {
       case 'slice':
         this.addForType(type.elementType);
         break;
+      case 'client':
       case 'constant':
       case 'interface':
       case 'model':

--- a/packages/codegen.go/src/core/operations.ts
+++ b/packages/codegen.go/src/core/operations.ts
@@ -117,9 +117,11 @@ export function generateOperations(pkg: go.PackageContent, target: go.CodeModelT
     // generate client accessors and operations
     let opText = '';
     for (const clientAccessor of client.clientAccessors) {
-      opText += `// ${clientAccessor.name} creates a new instance of [${clientAccessor.subClient.name}].\n`;
-      opText += `func (client *${client.name}) ${clientAccessor.name}() *${clientAccessor.subClient.name} {\n`;
-      opText += `\treturn &${clientAccessor.subClient.name}{\n`;
+      imports.addForType(clientAccessor.subClient);
+      const subClientDecl = go.getTypeDeclaration(clientAccessor.subClient, pkg);
+      opText += `// ${clientAccessor.name} creates a new instance of [${subClientDecl}].\n`;
+      opText += `func (client *${client.name}) ${clientAccessor.name}() *${subClientDecl} {\n`;
+      opText += `\treturn &${subClientDecl}{\n`;
       opText += '\t\tinternal: client.internal,\n';
       // propagate all client params
       for (const param of client.parameters) {

--- a/packages/codegen.go/src/core/responses.ts
+++ b/packages/codegen.go/src/core/responses.ts
@@ -153,15 +153,14 @@ function emit(respEnv: go.ResponseEnvelope, imports: ImportManager): string {
     let first = true;
 
     if (respEnv.result) {
+      const respType = go.getResultType(respEnv.result);
+      imports.addForType(respType);
       if (respEnv.result.kind === 'modelResult' || respEnv.result.kind === 'polymorphicResult') {
         // anonymously embedded type always goes first
         text += helpers.formatDocComment(respEnv.result.docs);
-        text += `\t${go.getTypeDeclaration(go.getResultType(respEnv.result), respEnv.method.receiver.type.pkg)}\n`;
+        text += `\t${go.getTypeDeclaration(respType, respEnv.method.receiver.type.pkg)}\n`;
         first = false;
       } else {
-        const type = go.getResultType(respEnv.result);
-        imports.addForType(type);
-
         let tag = '';
         if (respEnv.result.kind === 'monomorphicResult' && respEnv.result.format === 'XML') {
           // only emit tags for XML; JSON uses custom marshallers/unmarshallers
@@ -177,7 +176,7 @@ function emit(respEnv: go.ResponseEnvelope, imports: ImportManager): string {
           byValue = respEnv.result.byValue;
         }
 
-        fields.push({docs: respEnv.result.docs, field: `\t${respEnv.result.fieldName} ${helpers.star(byValue)}${go.getTypeDeclaration(type, respEnv.method.receiver.type.pkg)}${tag}\n`});
+        fields.push({docs: respEnv.result.docs, field: `\t${respEnv.result.fieldName} ${helpers.star(byValue)}${go.getTypeDeclaration(respType, respEnv.method.receiver.type.pkg)}${tag}\n`});
       }
     }
 

--- a/packages/codegen.go/src/emitter.ts
+++ b/packages/codegen.go/src/emitter.ts
@@ -145,29 +145,29 @@ export class Emitter {
       }
 
       if (this.codeModel.options.generateFakes) {
-        const serverContent = generateServers(new go.FakePackage(pkg));
+        const fakePkg = new go.FakePackage(pkg);
+        const serverContent = generateServers(fakePkg);
         if (serverContent.servers.length > 0) {
-          const fakesDir = 'fake';
           for (const op of serverContent.servers) {
             const fileName = `${snakeClientFileName(op.name, 'server')}.go`;
-            await write(fileName, op.content, fakesDir);
+            await write(fileName, op.content, fakePkg.kind);
           }
 
-          const serverFactory = generateServerFactory(new go.FakePackage(pkg), this.codeModel.type);
+          const serverFactory = generateServerFactory(fakePkg, this.codeModel.type);
           if (serverFactory.length > 0) {
-            await write('server_factory.go', serverFactory, fakesDir);
+            await write('server_factory.go', serverFactory, fakePkg.kind);
           }
 
-          await write('internal.go', serverContent.internals, fakesDir);
+          await write('internal.go', serverContent.internals, fakePkg.kind);
 
-          const timeHelpers = generateTimeHelpers(new go.FakePackage(pkg));
+          const timeHelpers = generateTimeHelpers(fakePkg);
           for (const helper of timeHelpers) {
-            await write(`${helper.name.toLowerCase()}.go`, helper.content, fakesDir);
+            await write(`${helper.name.toLowerCase()}.go`, helper.content, fakePkg.kind);
           }
 
-          const polymorphics = generatePolymorphicHelpers(new go.FakePackage(pkg));
+          const polymorphics = generatePolymorphicHelpers(fakePkg);
           if (polymorphics.length > 0) {
-            await write('polymorphic_helpers.go', polymorphics, fakesDir);
+            await write('polymorphic_helpers.go', polymorphics, fakePkg.kind);
           }
         }
       }

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -21,8 +21,8 @@ export class TypeAdapter {
   readonly codeModel: go.CodeModel;
 
   // cache of previously created types/constant values
-  private types: Map<string, go.WireType>;
-  private constValues: Map<string, go.ConstantValue>;
+  private readonly types: Map<string, go.WireType>;
+  private readonly constValues: Map<string, go.ConstantValue>;
 
   constructor(ctx: tcgc.SdkContext, codeModel: go.CodeModel) {
     this.ctx = ctx;
@@ -37,7 +37,7 @@ export class TypeAdapter {
    * NOTE: this is temporary and will go away with namespaces.
    * @returns the module or package to contain the adapted tcgc model
    */
-  private getPkg(): go.PackageContent {
+  getPkg(): go.PackageContent {
     return this.codeModel.root.kind === 'containingModule' ? this.codeModel.root.package : this.codeModel.root;
   }
 


### PR DESCRIPTION
Add import and use getTypeDeclaration for client accessors. Consolidated some duplicate code handling response envelopes and creating the fake package.
Add some missing readonly annotations and removed duplicate implementations of getPkg().