### PR TITLE
Don't force streaming bodies to be required

### DIFF
--- a/packages/autorest.go/CHANGELOG.md
+++ b/packages/autorest.go/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.0.0-preview.76 (unreleased)
 
+### Breaking Changes
+
+* Optional streaming bodies are no longer forced to be required.
+
 ### Other Changes
 
 * Updated the minimum version of Go to `v1.24.0`.

--- a/packages/autorest.go/src/transform/namer.ts
+++ b/packages/autorest.go/src/transform/namer.ts
@@ -8,7 +8,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
 import { Session } from '@autorest/extension-base';
-import { ChoiceSchema, CodeModel, HttpHeader, HttpMethod, Language, SealedChoiceSchema } from '@autorest/codemodel';
+import { ChoiceSchema, CodeModel, HttpHeader, HttpMethod, Language, SchemaType, SealedChoiceSchema } from '@autorest/codemodel';
 import { visitor, clone, values } from '@azure-tools/linq';
 import { createPolymorphicInterfaceName, ensureNameCase, getEscapedReservedName, packageNameFromOutputFolder, trimPackagePrefix, uncapitalize } from '../../../naming.go/src/naming.js';
 import { aggregateParameters, hasAdditionalProperties } from './helpers.js';
@@ -251,8 +251,8 @@ export async function namer(session: Session<CodeModel>) {
         }
         if (!honorBodyPlacement) {
           const opMethod = op.requests![0].protocol.http!.method;
-          if (param.protocol.http?.in === 'body' && (opMethod === HttpMethod.Patch || opMethod === HttpMethod.Put)) {
-            // we enforce PATCH/PUT body parameters to be required.  do this before fixing up the parameter name
+          if (param.protocol.http?.in === 'body' && param.schema.type !== SchemaType.Binary && (opMethod === HttpMethod.Patch || opMethod === HttpMethod.Put)) {
+            // we enforce PATCH/PUT body parameters that aren't raw binary payloads to be required.  do this before fixing up the parameter name
             param.required = true;
           }
         }

--- a/packages/autorest.go/test/acr/azacr/fake/zz_containerregistryblob_server.go
+++ b/packages/autorest.go/test/acr/azacr/fake/zz_containerregistryblob_server.go
@@ -36,7 +36,7 @@ type ContainerRegistryBlobServer struct {
 
 	// CompleteUpload is the fake for method ContainerRegistryBlobClient.CompleteUpload
 	// HTTP status codes to indicate success: http.StatusCreated
-	CompleteUpload func(ctx context.Context, digest string, location string, value io.ReadSeekCloser, options *azacr.ContainerRegistryBlobClientCompleteUploadOptions) (resp azfake.Responder[azacr.ContainerRegistryBlobClientCompleteUploadResponse], errResp azfake.ErrorResponder)
+	CompleteUpload func(ctx context.Context, digest string, location string, options *azacr.ContainerRegistryBlobClientCompleteUploadOptions) (resp azfake.Responder[azacr.ContainerRegistryBlobClientCompleteUploadResponse], errResp azfake.ErrorResponder)
 
 	// DeleteBlob is the fake for method ContainerRegistryBlobClient.DeleteBlob
 	// HTTP status codes to indicate success: http.StatusAccepted
@@ -270,7 +270,13 @@ func (c *ContainerRegistryBlobServerTransport) dispatchCompleteUpload(req *http.
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := c.srv.CompleteUpload(req.Context(), digestParam, locationParam, req.Body.(io.ReadSeekCloser), nil)
+	var options *azacr.ContainerRegistryBlobClientCompleteUploadOptions
+	if req.Body != nil {
+		options = &azacr.ContainerRegistryBlobClientCompleteUploadOptions{
+			Value: req.Body.(io.ReadSeekCloser),
+		}
+	}
+	respr, errRespr := c.srv.CompleteUpload(req.Context(), digestParam, locationParam, options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/autorest.go/test/acr/azacr/zz_options.go
+++ b/packages/autorest.go/test/acr/azacr/zz_options.go
@@ -5,6 +5,8 @@
 
 package azacr
 
+import "io"
+
 // AuthenticationClientExchangeAADAccessTokenForAcrRefreshTokenOptions contains the optional parameters for the AuthenticationClient.ExchangeAADAccessTokenForAcrRefreshToken
 // method.
 type AuthenticationClientExchangeAADAccessTokenForAcrRefreshTokenOptions struct {
@@ -52,7 +54,8 @@ type ContainerRegistryBlobClientCheckChunkExistsOptions struct {
 // ContainerRegistryBlobClientCompleteUploadOptions contains the optional parameters for the ContainerRegistryBlobClient.CompleteUpload
 // method.
 type ContainerRegistryBlobClientCompleteUploadOptions struct {
-	// placeholder for future optional parameters
+	// Optional raw data of blob
+	Value io.ReadSeekCloser
 }
 
 // ContainerRegistryBlobClientDeleteBlobOptions contains the optional parameters for the ContainerRegistryBlobClient.DeleteBlob

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release History
 
-## 0.8.9 (unreleased)
+## 0.9.0 (unreleased)
+
+### Breaking Changes
+
+* Optional streaming bodies are no longer forced to be required.
 
 ### Features Added
 

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-go",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "description": "TypeSpec emitter for Go SDKs",
   "type": "module",
   "exports": {

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -908,8 +908,12 @@ export class ClientAdapter {
     const methodParam = opParam.correspondingMethodParams[0];
 
     let paramStyle = this.adaptParameterStyle(methodParam);
-    if (opParam.kind === 'body' && (verb === 'patch' || verb === 'put')) {
-      paramStyle = 'required';
+    if (opParam.kind === 'body') {
+      const contentType = this.adaptContentType(opParam.defaultContentType);
+      // only force modeled body params to be required (binary payloads can be optional)
+      if (contentType !== 'binary' && (verb === 'patch' || verb === 'put')) {
+        paramStyle = 'required';
+      }
     }
 
     const paramName = getEscapedReservedName(ensureNameCase(methodParam.name, paramStyle === 'required'), 'Param');

--- a/packages/typespec-go/test/local/azregressions/zz_client.go
+++ b/packages/typespec-go/test/local/azregressions/zz_client.go
@@ -43,6 +43,164 @@ func NewClientWithNoCredential(endpoint string, options *ClientOptions) (*Client
 	return client, nil
 }
 
+// ForceRequiredBodyPatch -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ClientForceRequiredBodyPatchOptions contains the optional parameters for the Client.ForceRequiredBodyPatch method.
+func (client *Client) ForceRequiredBodyPatch(ctx context.Context, body SomeModel, options *ClientForceRequiredBodyPatchOptions) (ClientForceRequiredBodyPatchResponse, error) {
+	var err error
+	const operationName = "Client.ForceRequiredBodyPatch"
+	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
+	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
+	req, err := client.forceRequiredBodyPatchCreateRequest(ctx, body, options)
+	if err != nil {
+		return ClientForceRequiredBodyPatchResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return ClientForceRequiredBodyPatchResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
+		err = runtime.NewResponseError(httpResp)
+		return ClientForceRequiredBodyPatchResponse{}, err
+	}
+	return ClientForceRequiredBodyPatchResponse{}, nil
+}
+
+// forceRequiredBodyPatchCreateRequest creates the ForceRequiredBodyPatch request.
+func (client *Client) forceRequiredBodyPatchCreateRequest(ctx context.Context, body SomeModel, _ *ClientForceRequiredBodyPatchOptions) (*policy.Request, error) {
+	urlPath := "/force-required-body-patch"
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header["Content-Type"] = []string{"application/json"}
+	if err := runtime.MarshalAsJSON(req, body); err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+// ForceRequiredBodyPut -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ClientForceRequiredBodyPutOptions contains the optional parameters for the Client.ForceRequiredBodyPut method.
+func (client *Client) ForceRequiredBodyPut(ctx context.Context, body SomeModel, options *ClientForceRequiredBodyPutOptions) (ClientForceRequiredBodyPutResponse, error) {
+	var err error
+	const operationName = "Client.ForceRequiredBodyPut"
+	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
+	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
+	req, err := client.forceRequiredBodyPutCreateRequest(ctx, body, options)
+	if err != nil {
+		return ClientForceRequiredBodyPutResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return ClientForceRequiredBodyPutResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
+		err = runtime.NewResponseError(httpResp)
+		return ClientForceRequiredBodyPutResponse{}, err
+	}
+	return ClientForceRequiredBodyPutResponse{}, nil
+}
+
+// forceRequiredBodyPutCreateRequest creates the ForceRequiredBodyPut request.
+func (client *Client) forceRequiredBodyPutCreateRequest(ctx context.Context, body SomeModel, _ *ClientForceRequiredBodyPutOptions) (*policy.Request, error) {
+	urlPath := "/force-required-body-put"
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header["Content-Type"] = []string{"application/json"}
+	if err := runtime.MarshalAsJSON(req, body); err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+// OptionalBinaryBody -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ClientOptionalBinaryBodyOptions contains the optional parameters for the Client.OptionalBinaryBody method.
+func (client *Client) OptionalBinaryBody(ctx context.Context, options *ClientOptionalBinaryBodyOptions) (ClientOptionalBinaryBodyResponse, error) {
+	var err error
+	const operationName = "Client.OptionalBinaryBody"
+	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
+	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
+	req, err := client.optionalBinaryBodyCreateRequest(ctx, options)
+	if err != nil {
+		return ClientOptionalBinaryBodyResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return ClientOptionalBinaryBodyResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
+		err = runtime.NewResponseError(httpResp)
+		return ClientOptionalBinaryBodyResponse{}, err
+	}
+	return ClientOptionalBinaryBodyResponse{}, nil
+}
+
+// optionalBinaryBodyCreateRequest creates the OptionalBinaryBody request.
+func (client *Client) optionalBinaryBodyCreateRequest(ctx context.Context, options *ClientOptionalBinaryBodyOptions) (*policy.Request, error) {
+	urlPath := "/optional-binary-payload"
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	if options != nil && options.Payload != nil {
+		req.Raw().Header["Content-Type"] = []string{"application/octet-stream"}
+		if err := req.SetBody(options.Payload, "application/octet-stream"); err != nil {
+			return nil, err
+		}
+		return req, nil
+	}
+	return req, nil
+}
+
+// OptionalBodyPost -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ClientOptionalBodyPostOptions contains the optional parameters for the Client.OptionalBodyPost method.
+func (client *Client) OptionalBodyPost(ctx context.Context, options *ClientOptionalBodyPostOptions) (ClientOptionalBodyPostResponse, error) {
+	var err error
+	const operationName = "Client.OptionalBodyPost"
+	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
+	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
+	req, err := client.optionalBodyPostCreateRequest(ctx, options)
+	if err != nil {
+		return ClientOptionalBodyPostResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return ClientOptionalBodyPostResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
+		err = runtime.NewResponseError(httpResp)
+		return ClientOptionalBodyPostResponse{}, err
+	}
+	return ClientOptionalBodyPostResponse{}, nil
+}
+
+// optionalBodyPostCreateRequest creates the OptionalBodyPost request.
+func (client *Client) optionalBodyPostCreateRequest(ctx context.Context, options *ClientOptionalBodyPostOptions) (*policy.Request, error) {
+	urlPath := "/optional-body-post"
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	if options != nil && options.Body != nil {
+		req.Raw().Header["Content-Type"] = []string{"application/json"}
+		if err := runtime.MarshalAsJSON(req, *options.Body); err != nil {
+			return nil, err
+		}
+		return req, nil
+	}
+	return req, nil
+}
+
 // SpreadWithModel -
 // If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ClientSpreadWithModelOptions contains the optional parameters for the Client.SpreadWithModel method.

--- a/packages/typespec-go/test/local/azregressions/zz_models.go
+++ b/packages/typespec-go/test/local/azregressions/zz_models.go
@@ -11,3 +11,8 @@ type InnerSpreadParam struct {
 	// REQUIRED
 	Name *string
 }
+
+type SomeModel struct {
+	// REQUIRED
+	Name *string
+}

--- a/packages/typespec-go/test/local/azregressions/zz_models_serde.go
+++ b/packages/typespec-go/test/local/azregressions/zz_models_serde.go
@@ -42,6 +42,33 @@ func (i *InnerSpreadParam) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SomeModel.
+func (s SomeModel) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "name", s.Name)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type SomeModel.
+func (s *SomeModel) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", s, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "name":
+			err = unpopulate(val, "Name", &s.Name)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", s, err)
+		}
+	}
+	return nil
+}
+
 func populate(m map[string]any, k string, v any) {
 	if v == nil {
 		return

--- a/packages/typespec-go/test/local/azregressions/zz_options.go
+++ b/packages/typespec-go/test/local/azregressions/zz_options.go
@@ -4,6 +4,28 @@
 
 package azregressions
 
+import "io"
+
+// ClientForceRequiredBodyPatchOptions contains the optional parameters for the Client.ForceRequiredBodyPatch method.
+type ClientForceRequiredBodyPatchOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ClientForceRequiredBodyPutOptions contains the optional parameters for the Client.ForceRequiredBodyPut method.
+type ClientForceRequiredBodyPutOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ClientOptionalBinaryBodyOptions contains the optional parameters for the Client.OptionalBinaryBody method.
+type ClientOptionalBinaryBodyOptions struct {
+	Payload io.ReadSeekCloser
+}
+
+// ClientOptionalBodyPostOptions contains the optional parameters for the Client.OptionalBodyPost method.
+type ClientOptionalBodyPostOptions struct {
+	Body *SomeModel
+}
+
 // ClientSpreadWithModelOptions contains the optional parameters for the Client.SpreadWithModel method.
 type ClientSpreadWithModelOptions struct {
 	Color *string

--- a/packages/typespec-go/test/local/azregressions/zz_responses.go
+++ b/packages/typespec-go/test/local/azregressions/zz_responses.go
@@ -4,6 +4,26 @@
 
 package azregressions
 
+// ClientForceRequiredBodyPatchResponse contains the response from method Client.ForceRequiredBodyPatch.
+type ClientForceRequiredBodyPatchResponse struct {
+	// placeholder for future response values
+}
+
+// ClientForceRequiredBodyPutResponse contains the response from method Client.ForceRequiredBodyPut.
+type ClientForceRequiredBodyPutResponse struct {
+	// placeholder for future response values
+}
+
+// ClientOptionalBinaryBodyResponse contains the response from method Client.OptionalBinaryBody.
+type ClientOptionalBinaryBodyResponse struct {
+	// placeholder for future response values
+}
+
+// ClientOptionalBodyPostResponse contains the response from method Client.OptionalBodyPost.
+type ClientOptionalBodyPostResponse struct {
+	// placeholder for future response values
+}
+
 // ClientSpreadWithModelResponse contains the response from method Client.SpreadWithModel.
 type ClientSpreadWithModelResponse struct {
 	// placeholder for future response values

--- a/packages/typespec-go/test/tsp/Regressions/main.tsp
+++ b/packages/typespec-go/test/tsp/Regressions/main.tsp
@@ -27,5 +27,24 @@ model InnerSpreadParam {
   code: int32;
 }
 
+model SomeModel {
+  name: string;
+}
+
 @route("/spread-with-model")
 op spreadWithModel(...SpreadParams): void;
+
+@route("/optional-binary-payload")
+op optionalBinaryBody(@body payload?: bytes): void;
+
+@patch
+@route("/force-required-body-patch")
+op forceRequiredBodyPatch(@body body?: SomeModel): void;
+
+@put
+@route("/force-required-body-put")
+op forceRequiredBodyPut(@body body?: SomeModel): void;
+
+@post
+@route("/optional-body-post")
+op optionalBodyPost(@body body?: SomeModel): void;


### PR DESCRIPTION
While it makes sense for model types, it doesn't for binary payloads. It can also cause the Content-Type header to be set when there's no body which is undesirable.