### PR TITLE
Remove azure-tools/codegen dependency from tsp emitter

### DIFF
--- a/packages/autorest.go/package.json
+++ b/packages/autorest.go/package.json
@@ -55,6 +55,7 @@
     "@eslint/js": "catalog:",
     "@microsoft.azure/autorest.testserver": "3.3.50",
     "@types/node": "catalog:",
+    "@types/semver": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
     "eslint": "catalog:",
@@ -72,6 +73,7 @@
     "@types/html-to-text": "^5.1.2",
     "@types/showdown": "^1.9.4",
     "html-to-text": "^5.1.1",
+    "semver": "catalog:",
     "showdown": "^1.9.1",
     "source-map-support": "0.5.21"
   }

--- a/packages/codegen.go/package.json
+++ b/packages/codegen.go/package.json
@@ -7,9 +7,10 @@
     "build": "tsc -p ."
   },
   "dependencies": {
-    "@azure-tools/codegen": "catalog:"
+    "semver": "catalog:"
   },
   "devDependencies": {
+    "@types/semver": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/packages/codegen.go/src/core/example.ts
+++ b/packages/codegen.go/src/core/example.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { camelCase, capitalize } from '@azure-tools/codegen';
 import * as go from '../../../codemodel.go/src/index.js';
+import * as naming from '../../../naming.go/src/naming.js';
 import * as helpers from './helpers.js';
 import { ImportManager } from './imports.js';
 import { fixUpMethodName } from './operations.js';
@@ -71,7 +71,7 @@ export function generateExamples(pkg: go.TestPackage, target: go.CodeModelType, 
       for (const example of method.examples) {
         // function signature
         exampleText += `// Generated from example definition: ${example.filePath}\n`;
-        const exampleFuncNamePrefix = method.examples.length > 1 ? `_${camelCase(example.name)}` : '';
+        const exampleFuncNamePrefix = method.examples.length > 1 ? `_${helpers.camelCase(example.name)}` : '';
         exampleText += `func Example${client.name}_${fixUpMethodName(method)}${exampleFuncNamePrefix}() {\n`;
 
         // create credential
@@ -150,7 +150,7 @@ export function generateExamples(pkg: go.TestPackage, target: go.CodeModelType, 
         let methodOptionalParametersText = 'nil';
         if (methodOptionalParameters.length > 0) {
           methodOptionalParametersText = `&${go.getPackageName(method.optionalParamsGroup.pkg)}.${method.optionalParamsGroup.groupName}{\n`;
-          methodOptionalParametersText += methodOptionalParameters.map(p => `${capitalize(p.parameter.name)}: ${getExampleValue(pkg, p.value, '\t', imports, p.parameter.byValue).slice(1)}`).join(',\n');
+          methodOptionalParametersText += methodOptionalParameters.map(p => `${naming.capitalize(p.parameter.name)}: ${getExampleValue(pkg, p.value, '\t', imports, p.parameter.byValue).slice(1)}`).join(',\n');
           methodOptionalParametersText += `}`;
         }
 

--- a/packages/codegen.go/src/core/gomod.ts
+++ b/packages/codegen.go/src/core/gomod.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as go from '../../../codemodel.go/src/index.js';
-import { lt, toSemver } from '@azure-tools/codegen';
 import { CodegenError } from './errors.js';
+import * as semver from 'semver';
 
 /**
  * Creates the content for the go.mod file.
@@ -61,3 +61,34 @@ export function generateGoModFile(module: go.Module, options: go.Options, existi
   }
   return existingGoMod;
 }
+
+// the following was copied from @azure-tools/codegen as it's being deprecated
+function toSemver(apiversion: string) {
+  // strip off leading "v" or "=" character
+  apiversion = apiversion.replace(/^v|^=/gi, "");
+  // eslint-disable-next-line no-useless-escape
+  const versionedDateRegex = new RegExp(/(^\d{4}\-\d{2}\-\d{2})(\.\d+\.\d+$)/gi);
+  if (apiversion.match(versionedDateRegex)) {
+    // convert yyyy-mm-dd.x1.x2      --->     (miliseconds since 1970-01-01).x1.x2
+    const date = apiversion.replace(versionedDateRegex, "$1");
+    const miliseconds = new Date(date).getTime();
+    const lastNumbers = apiversion.replace(versionedDateRegex, "$2");
+    return `${miliseconds}${lastNumbers}`;
+  }
+  const [major, minor, revision, tag] =
+    /^(\d+)-(\d+)(?:-(\d+))?(.*)/.exec(apiversion) ||
+    /(\d*)\.(\d*)\.(\d*)(.*)/.exec(apiversion) ||
+    /(\d*)\.(\d*)()(.*)/.exec(apiversion) ||
+    /(\d*)()()(.*)/.exec(apiversion) ||
+    [];
+  return `${Number.parseInt(major || "0") || 0}.${Number.parseInt(minor || "0") || 0}.${
+    Number.parseInt(revision || "0") || 0
+  }${tag?.startsWith("-") ? tag : ""}`;
+}
+
+function lt(apiVersion1: string, apiVersion2: string) {
+  const v1 = toSemver(apiVersion1);
+  const v2 = toSemver(apiVersion2);
+  return semver.lt(v1, v2);
+}
+// end ports from @azure-tools/codegen

--- a/packages/codegen.go/src/core/interfaces.ts
+++ b/packages/codegen.go/src/core/interfaces.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as go from '../../../codemodel.go/src/index.js';
-import { comment } from '@azure-tools/codegen';
-import { contentPreamble, sortAscending } from './helpers.js';
+import * as helpers from './helpers.js';
 
 /**
  * Creates the content for the interfaces.go file.
@@ -19,7 +18,7 @@ export function generateInterfaces(pkg: go.PackageContent): string {
     return '';
   }
 
-  let text = contentPreamble(pkg);
+  let text = helpers.contentPreamble(pkg);
 
   for (const iface of pkg.interfaces) {
     const methodName = `Get${iface.rootType.name}`;
@@ -31,8 +30,8 @@ export function generateInterfaces(pkg: go.PackageContent): string {
     for (const possibleType of iface.possibleTypes) {
       possibleTypeNames.push(`*${possibleType.name}`);
     }
-    possibleTypeNames.sort(sortAscending);
-    text += comment(possibleTypeNames.join(', '), '// - ');
+    possibleTypeNames.sort(helpers.sortAscending);
+    text += helpers.comment(possibleTypeNames.join(', '), '// - ');
     text += `\ntype ${iface.name} interface {\n`;
     if (iface.parent) {
       text += `\t${iface.parent.name}\n`;

--- a/packages/codegen.go/src/core/models.ts
+++ b/packages/codegen.go/src/core/models.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as go from '../../../codemodel.go/src/index.js';
-import { comment } from '@azure-tools/codegen';
 import * as helpers from './helpers.js';
 import { ImportManager } from './imports.js';
 
@@ -53,7 +52,7 @@ export function generateModels(pkg: go.PackageContent, options: go.Options): Mod
     modelDef.Methods.sort((a: ModelMethod, b: ModelMethod) => { return helpers.sortAscending(a.name, b.name); });
     for (const method of modelDef.Methods) {
       if (method.desc.length > 0) {
-        modelText += `${comment(method.desc, '// ', undefined, helpers.commentLength)}\n`;
+        modelText += `${helpers.comment(method.desc, '// ', undefined, helpers.commentLength)}\n`;
       }
       modelText += method.text;
     }
@@ -61,7 +60,7 @@ export function generateModels(pkg: go.PackageContent, options: go.Options): Mod
     modelDef.SerDe.methods.sort((a: ModelMethod, b: ModelMethod) => { return helpers.sortAscending(a.name, b.name); });
     for (const method of modelDef.SerDe.methods) {
       if (method.desc.length > 0) {
-        serdeTextBody += `${comment(method.desc, '// ', undefined, helpers.commentLength)}\n`;
+        serdeTextBody += `${helpers.comment(method.desc, '// ', undefined, helpers.commentLength)}\n`;
       }
       serdeTextBody += method.text;
     }

--- a/packages/codegen.go/src/core/operations.ts
+++ b/packages/codegen.go/src/core/operations.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as go from '../../../codemodel.go/src/index.js';
-import { ensureNameCase } from '../../../naming.go/src/naming.js';
-import { capitalize, comment, uncapitalize } from '@azure-tools/codegen';
+import * as naming from '../../../naming.go/src/naming.js';
 import * as helpers from './helpers.js';
 import { ImportManager } from './imports.js';
 import { CodegenError } from './errors.js';
@@ -91,7 +90,7 @@ export function generateOperations(pkg: go.PackageContent, target: go.CodeModelT
         }
         if (clientParam.group) {
           if (!addedGroups.has(clientParam.group.groupName)) {
-            clientText += `\t${uncapitalize(clientParam.group.groupName)} ${!isParamPointer(clientParam) ? '' : '*'}${clientParam.group.groupName}\n`;
+            clientText += `\t${naming.uncapitalize(clientParam.group.groupName)} ${!isParamPointer(clientParam) ? '' : '*'}${clientParam.group.groupName}\n`;
             addedGroups.add(clientParam.group.groupName);
           }
           continue;
@@ -205,14 +204,14 @@ function generateConstructors(client: go.Client, type: go.CodeModelType, imports
         // we use azcore.ClientOptions.APIVersion
         continue;
       }
-      ctorText += helpers.formatDocCommentWithPrefix(ensureNameCase(param.name), param.docs);
+      ctorText += helpers.formatDocCommentWithPrefix(naming.ensureNameCase(param.name), param.docs);
       if (go.isClientSideDefault(param.style)) {
         if (!param.docs.description && !param.docs.summary) {
           ctorText += '\n';
         }
-        ctorText += `\t${comment(`The default value is ${helpers.formatLiteralValue(param.style.defaultValue, false)}`, '// ')}.\n`;
+        ctorText += `\t${helpers.comment(`The default value is ${helpers.formatLiteralValue(param.style.defaultValue, false)}`, '// ')}.\n`;
       }
-      ctorText += `\t${ensureNameCase(param.name)} *${go.getTypeDeclaration(param.type, client.pkg)}\n`;
+      ctorText += `\t${naming.ensureNameCase(param.name)} *${go.getTypeDeclaration(param.type, client.pkg)}\n`;
     }
     ctorText += '}\n\n';
   }
@@ -372,7 +371,7 @@ function generateConstructors(client: go.Client, type: go.CodeModelType, imports
           if (go.isAPIVersionParameter(param)) {
             name = 'APIVersion';
           } else {
-            name = ensureNameCase(param.name);
+            name = naming.ensureNameCase(param.name);
           }
           ctorText += `\t${param.name} := ${helpers.formatLiteralValue(param.style.defaultValue, false)}\n`;
           ctorText += `\tif options.${name} != ${helpers.zeroValue(param)} {\n\t\t${param.name} = ${helpers.star(param.byValue)}options.${name}\n\t}\n`;
@@ -402,7 +401,7 @@ function generateConstructors(client: go.Client, type: go.CodeModelType, imports
     // ensure clientVar doesn't collide with any params
     for (const param of consolidatedCtorParams) {
       if (param.name === clientVar) {
-        clientVar = ensureNameCase(client.name, true);
+        clientVar = naming.ensureNameCase(client.name, true);
         break;
       }
     }
@@ -446,7 +445,7 @@ function formatHeaderResponseValue(headerResp: go.HeaderScalarResponse | go.Head
   }
 
   let text = `\tif val := resp.Header.Get("${headerResp.headerName}"); val != "" {\n`;
-  let name = uncapitalize(headerResp.fieldName);
+  let name = naming.uncapitalize(headerResp.fieldName);
   let byRef = '&';
   switch (headerResp.type.kind) {
     case 'constant':
@@ -595,7 +594,7 @@ function emitPagerDefinition(method: go.LROPageableMethod | go.PageableMethod, i
       text += '&runtime.FetcherForNextLinkOptions{\n\t\t\t\tNextReq: func(ctx context.Context, encodedNextLink string) (*policy.Request, error) {\n';
       text += `\t\t\t\t\treturn client.${method.nextPageMethod.name}(${nextOpParams.join(', ')})\n\t\t\t\t},\n\t\t\t})\n`;
     } else if (method.nextLinkVerb !== 'get') {
-      text += `&runtime.FetcherForNextLinkOptions{\n\t\t\t\tHTTPVerb: http.Method${capitalize(method.nextLinkVerb)},\n\t\t\t})\n`;
+      text += `&runtime.FetcherForNextLinkOptions{\n\t\t\t\tHTTPVerb: http.Method${naming.capitalize(method.nextLinkVerb)},\n\t\t\t})\n`;
     } else {
       text += 'nil)\n';
     }
@@ -746,7 +745,7 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
   }
 
   const returns = ['*policy.Request', 'error'];
-  let text = `${comment(name, '// ')} creates the ${method.name} request.\n`;
+  let text = `${helpers.comment(name, '// ')} creates the ${method.name} request.\n`;
   text += `func ${getClientReceiverDefinition(method.receiver)} ${name}(${helpers.getCreateRequestParametersSig(method)}) (${returns.join(', ')}) {\n`;
 
   const hostParams = new Array<go.URIParameter>();
@@ -806,12 +805,12 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
     if (param.location === 'client') {
       client = 'client.';
     }
-    const paramGroupName = uncapitalize(param.group.name);
+    const paramGroupName = naming.uncapitalize(param.group.name);
     let optionalParamGroupCheck = `${client}${paramGroupName} != nil && `;
     if (param.group.required) {
       optionalParamGroupCheck = '';
     }
-    return `\tif ${optionalParamGroupCheck}${client}${paramGroupName}.${capitalize(param.name)} != nil {\n`;
+    return `\tif ${optionalParamGroupCheck}${client}${paramGroupName}.${naming.capitalize(param.name)} != nil {\n`;
   };
 
   if (hasPathParams) {
@@ -856,7 +855,7 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
         // param isn't required, so emit a local var with
         // the correct default value, then populate it with
         // the optional value when set.
-        paramValue = `optional${capitalize(pp.name)}`;
+        paramValue = `optional${naming.capitalize(pp.name)}`;
         text += `\t${paramValue} := ""\n`;
         text += emitParamGroupCheck(pp);
         text += `\t${paramValue} = ${helpers.formatParamValue(pp, imports)}\n\t}\n`;
@@ -890,7 +889,7 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
     }
   }
 
-  text += `\treq, err := runtime.NewRequest(ctx, http.Method${capitalize(method.httpMethod)}, ${hostParam})\n`;
+  text += `\treq, err := runtime.NewRequest(ctx, http.Method${naming.capitalize(method.httpMethod)}, ${hostParam})\n`;
   text += '\tif err != nil {\n';
   text += '\t\treturn nil, err\n';
   text += '\t}\n';
@@ -1061,7 +1060,7 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
           tagName = bodyParam.xml.name;
         }
         text += `\t\tXMLName xml.Name \`xml:"${tagName}"\`\n`;
-        const fieldName = capitalize(bodyParam.name);
+        const fieldName = naming.capitalize(bodyParam.name);
         let tag = go.getTypeDeclaration(bodyParam.type.elementType, method.receiver.type.pkg);
         if (bodyParam.type.elementType.kind === 'model' && bodyParam.type.elementType.xml?.name) {
           tag = bodyParam.type.elementType.xml.name;
@@ -1147,13 +1146,13 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
     // define and instantiate an instance of the wire type, using the values from each param.
     text += '\tbody := struct {\n';
     for (const partialBodyParam of partialBodyParams) {
-      text += `\t\t${capitalize(partialBodyParam.serializedName)} ${helpers.star(partialBodyParam.byValue)}${go.getTypeDeclaration(partialBodyParam.type, method.receiver.type.pkg)} \`${partialBodyParam.format.toLowerCase()}:"${partialBodyParam.serializedName}"\`\n`;
+      text += `\t\t${naming.capitalize(partialBodyParam.serializedName)} ${helpers.star(partialBodyParam.byValue)}${go.getTypeDeclaration(partialBodyParam.type, method.receiver.type.pkg)} \`${partialBodyParam.format.toLowerCase()}:"${partialBodyParam.serializedName}"\`\n`;
     }
     text += '\t}{\n';
     // required params are emitted as initializers in the struct literal
     for (const partialBodyParam of partialBodyParams) {
       if (go.isRequiredParameter(partialBodyParam.style)) {
-        text += `\t\t${capitalize(partialBodyParam.serializedName)}: ${uncapitalize(partialBodyParam.name)},\n`;
+        text += `\t\t${naming.capitalize(partialBodyParam.serializedName)}: ${naming.uncapitalize(partialBodyParam.name)},\n`;
       }
     }
     text += '\t}\n';
@@ -1161,7 +1160,7 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
     for (const partialBodyParam of partialBodyParams) {
       if (!go.isRequiredParameter(partialBodyParam.style)) {
         text += emitParamGroupCheck(partialBodyParam);
-        text += `\t\tbody.${capitalize(partialBodyParam.serializedName)} = options.${capitalize(partialBodyParam.name)}\n\t}\n`;
+        text += `\t\tbody.${naming.capitalize(partialBodyParam.serializedName)} = options.${naming.capitalize(partialBodyParam.name)}\n\t}\n`;
       }
     }
     // TODO: spread params are JSON only https://github.com/Azure/autorest.go/issues/1455
@@ -1218,10 +1217,10 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
 }
 
 function emitClientSideDefault(param: go.HeaderCollectionParameter | go.HeaderScalarParameter | go.QueryParameter, csd: go.ClientSideDefault, setterFormat: (name: string, val: string) => string, imports: ImportManager): string {
-  const defaultVar = uncapitalize(param.name) + 'Default';
+  const defaultVar = naming.uncapitalize(param.name) + 'Default';
   let text = `\t${defaultVar} := ${helpers.formatLiteralValue(csd.defaultValue, true)}\n`;
-  text += `\tif options != nil && options.${capitalize(param.name)} != nil {\n`;
-  text += `\t\t${defaultVar} = *options.${capitalize(param.name)}\n`;
+  text += `\tif options != nil && options.${naming.capitalize(param.name)} != nil {\n`;
+  text += `\t\t${defaultVar} = *options.${naming.capitalize(param.name)}\n`;
   text += '}\n';
 
   let serializedName: string;
@@ -1353,7 +1352,7 @@ function createProtocolResponse(method: go.SyncMethod | go.LROPageableMethod | g
     return '';
   }
   const name = method.naming.responseMethod;
-  let text = `${comment(name, '// ')} handles the ${method.name} response.\n`;
+  let text = `${helpers.comment(name, '// ')} handles the ${method.name} response.\n`;
   text += `func ${getClientReceiverDefinition(method.receiver)} ${name}(resp *http.Response) (${generateReturnsInfo(method, 'handler').join(', ')}) {\n`;
 
   const addHeaders = function (headers: Array<go.HeaderScalarResponse | go.HeaderMapResponse>) {
@@ -1477,7 +1476,7 @@ function getAPIParametersSig(method: go.ClientAccessor | go.MethodType, imports:
       if (methodParam.kind !== 'paramGroup') {
         imports.addForType(methodParam.type);
       }
-      params.push(`${uncapitalize(methodParam.name)} ${helpers.formatParameterTypeName(method.receiver.type.pkg, methodParam)}`);
+      params.push(`${naming.uncapitalize(methodParam.name)} ${helpers.formatParameterTypeName(method.receiver.type.pkg, methodParam)}`);
     }
   }
   return params.join(', ');

--- a/packages/codegen.go/src/core/options.ts
+++ b/packages/codegen.go/src/core/options.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { capitalize } from '@azure-tools/codegen';
 import * as go from '../../../codemodel.go/src/index.js';
+import * as naming from '../../../naming.go/src/naming.js';
 import * as helpers from './helpers.js';
 import { ImportManager } from './imports.js';
 
@@ -72,7 +72,7 @@ function emit(pkg: go.PackageContent, struct: go.Struct, imports: ImportManager)
       if (field.byValue) {
         pointer = '';
       }
-      text += `\t${capitalize(field.name)} ${pointer}${typeName}\n`;
+      text += `\t${naming.capitalize(field.name)} ${pointer}${typeName}\n`;
       first = false;
     }
   }

--- a/packages/codegen.go/src/core/responses.ts
+++ b/packages/codegen.go/src/core/responses.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { comment } from '@azure-tools/codegen';
 import * as go from '../../../codemodel.go/src/index.js';
 import * as helpers from './helpers.js';
 import { ImportManager } from './imports.js';
@@ -74,7 +73,7 @@ function generateMarshaller(respEnv: go.ResponseEnvelope, imports: ImportManager
     // without it, the response envelope type name is the outer type which is incorrect.
     imports.add('encoding/json');
     const receiver = respEnv.name[0].toLowerCase();
-    text += `${comment(`MarshalJSON implements the json.Marshaller interface for type ${respEnv.name}.`, '// ', undefined, helpers.commentLength)}\n`;
+    text += `${helpers.comment(`MarshalJSON implements the json.Marshaller interface for type ${respEnv.name}.`, '// ', undefined, helpers.commentLength)}\n`;
     text += `func (${receiver} ${respEnv.name}) MarshalJSON() ([]byte, error) {\n`;
     // TODO: this doesn't include any headers. however, LROs with header responses are currently broken :(
     text += `\treturn json.Marshal(${receiver}.${go.getTypeDeclaration(respEnv.result.interface, respEnv.method.receiver.type.pkg)})\n}\n\n`;
@@ -107,7 +106,7 @@ function generateUnmarshaller(respEnv: go.ResponseEnvelope, imports: ImportManag
   }
 
   const receiver = respEnv.name[0].toLowerCase();
-  let unmarshaller = `${comment(`UnmarshalJSON implements the json.Unmarshaller interface for type ${respEnv.name}.`, '// ', undefined, helpers.commentLength)}\n`;
+  let unmarshaller = `${helpers.comment(`UnmarshalJSON implements the json.Unmarshaller interface for type ${respEnv.name}.`, '// ', undefined, helpers.commentLength)}\n`;
   unmarshaller += `func (${receiver} *${respEnv.name}) UnmarshalJSON(data []byte) error {\n`;
 
   // add a custom unmarshaller to the response envelope

--- a/packages/codegen.go/src/fake/servers.ts
+++ b/packages/codegen.go/src/fake/servers.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { camelCase, capitalize, uncapitalize } from '@azure-tools/codegen';
 import * as go from '../../../codemodel.go/src/index.js';
+import * as naming from '../../../naming.go/src/naming.js';
 import * as helpers from '../core/helpers.js';
 import { ImportManager } from '../core/imports.js';
 import { fixUpMethodName } from '../core/operations.js';
@@ -38,7 +38,7 @@ const requiredHelpers = new RequiredHelpers();
 
 export function getServerName(client: go.Client): string {
   // for the fake server, we use the suffix Server instead of Client
-  return capitalize(client.name.replace(/[C|c]lient$/, 'Server'));
+  return naming.capitalize(client.name.replace(/[C|c]lient$/, 'Server'));
 }
 
 /**
@@ -173,11 +173,11 @@ export function generateServers(pkg: go.FakePackage): ServerContent {
               respType = `azfake.PagerResponder[${go.getTypeDeclaration(method.returns, pkg)}]`;
             }
             requiredHelpers.tracker = true;
-            content += `\t\t${uncapitalize(fixUpMethodName(method))}: newTracker[azfake.PollerResponder[${respType}]](),\n`;
+            content += `\t\t${naming.uncapitalize(fixUpMethodName(method))}: newTracker[azfake.PollerResponder[${respType}]](),\n`;
             break;
           case 'pageableMethod':
             requiredHelpers.tracker = true;
-            content += `\t\t${uncapitalize(fixUpMethodName(method))}: newTracker[azfake.PagerResponder[${respType}]](),\n`;
+            content += `\t\t${naming.uncapitalize(fixUpMethodName(method))}: newTracker[azfake.PagerResponder[${respType}]](),\n`;
             break;
         }
       }
@@ -210,11 +210,11 @@ export function generateServers(pkg: go.FakePackage): ServerContent {
             respType = `azfake.PagerResponder[${go.getTypeDeclaration(method.returns, pkg)}]`;
           }
           requiredHelpers.tracker = true;
-          content += `\t${uncapitalize(fixUpMethodName(method))} *tracker[azfake.PollerResponder[${respType}]]\n`;
+          content += `\t${naming.uncapitalize(fixUpMethodName(method))} *tracker[azfake.PollerResponder[${respType}]]\n`;
           break;
         case 'pageableMethod':
           requiredHelpers.tracker = true;
-          content += `\t${uncapitalize(fixUpMethodName(method))} *tracker[azfake.PagerResponder[${go.getTypeDeclaration(method.returns, pkg)}]]\n`;
+          content += `\t${naming.uncapitalize(fixUpMethodName(method))} *tracker[azfake.PagerResponder[${go.getTypeDeclaration(method.returns, pkg)}]]\n`;
           break;
       }
     }
@@ -242,7 +242,7 @@ export function generateServers(pkg: go.FakePackage): ServerContent {
 }
 
 function getTransportInterceptorVarName(client: go.Client): string {
-  return `${camelCase(getServerName(client))}TransportInterceptor`;
+  return `${helpers.camelCase(getServerName(client))}TransportInterceptor`;
 }
 
 // method names for fakes dispatching
@@ -707,7 +707,7 @@ function dispatchForOperationBody(pkg: go.FakePackage, receiverName: string, met
     // construct the partial body params type and unmarshal it
     content += '\ttype partialBodyParams struct {\n';
     for (const partialBodyParam of partialBodyParams) {
-      content += `\t\t${capitalize(partialBodyParam.name)} ${helpers.star(partialBodyParam.byValue)}${go.getTypeDeclaration(partialBodyParam.type, pkg)} \`json:"${partialBodyParam.serializedName}"\`\n`;
+      content += `\t\t${naming.capitalize(partialBodyParam.name)} ${helpers.star(partialBodyParam.byValue)}${go.getTypeDeclaration(partialBodyParam.type, pkg)} \`json:"${partialBodyParam.serializedName}"\`\n`;
     }
     content += '\t}\n';
     content += `\tbody, err := server.UnmarshalRequestAs${partialBodyParams[0].format}[partialBodyParams](req)\n`;
@@ -719,7 +719,7 @@ function dispatchForOperationBody(pkg: go.FakePackage, receiverName: string, met
 
   // translate each partial body param to its field within the unmarshalled body
   for (const partialBodyParam of partialBodyParams) {
-    result.params.set(partialBodyParam.name, `${helpers.star(partialBodyParam.byValue)}body.${capitalize(partialBodyParam.name)}`);
+    result.params.set(partialBodyParam.name, `${helpers.star(partialBodyParam.byValue)}body.${naming.capitalize(partialBodyParam.name)}`);
   }
 
   const apiCall = `:= ${receiverName}.srv.${fixUpMethodName(method)}(${populateApiParams(pkg, method, result.params, imports)})`;
@@ -763,8 +763,8 @@ function getMethodStatusCodes(method: go.MethodType): Array<number> {
  */
 function dispatchForLROBody(pkg: go.FakePackage, receiverName: string, method: go.LROMethod | go.LROPageableMethod, imports: ImportManager): string {
   const operationName = fixUpMethodName(method);
-  const localVarName = uncapitalize(operationName);
-  const operationStateMachine = `${receiverName}.${uncapitalize(operationName)}`;
+  const localVarName = naming.uncapitalize(operationName);
+  const operationStateMachine = `${receiverName}.${naming.uncapitalize(operationName)}`;
   let content = `\t${localVarName} := ${operationStateMachine}.get(req)\n`;
   content += `\tif ${localVarName} == nil {\n`;
   content += dispatchForOperationBody(pkg, receiverName, method, imports);
@@ -797,8 +797,8 @@ function dispatchForLROBody(pkg: go.FakePackage, receiverName: string, method: g
  */
 function dispatchForPagerBody(pkg: go.FakePackage, receiverName: string, method: go.PageableMethod, imports: ImportManager): string {
   const operationName = fixUpMethodName(method);
-  const localVarName = uncapitalize(operationName);
-  const operationStateMachine = `${receiverName}.${uncapitalize(operationName)}`;
+  const localVarName = naming.uncapitalize(operationName);
+  const operationStateMachine = `${receiverName}.${naming.uncapitalize(operationName)}`;
   let content = `\t${localVarName} := ${operationStateMachine}.get(req)\n`;
   content += `\tif ${localVarName} == nil {\n`;
   content += dispatchForOperationBody(pkg, receiverName, method, imports);
@@ -872,7 +872,7 @@ function parseHeaderPathQueryParams(pkg: go.FakePackage, method: go.MethodType, 
   const paramValues = new Map<string, string>();
 
   const createLocalVariableName = function (param: go.MethodParameter, suffix: string): string {
-    const paramName = `${uncapitalize(param.name)}${suffix}`;
+    const paramName = `${naming.uncapitalize(param.name)}${suffix}`;
     paramValues.set(param.name, paramName);
     return paramName;
   };
@@ -1024,7 +1024,7 @@ function parseHeaderPathQueryParams(pkg: go.FakePackage, method: go.MethodType, 
           content += `\t\t${fromVar}, parseErr := strconv.ParseBool(${paramValue}[i])\n`;
           content += '\t\tif parseErr != nil {\n\t\t\treturn nil, parseErr\n\t\t}\n';
         } else if (elementFormat === 'float32' || elementFormat === 'float64' || elementFormat === 'int32' || elementFormat === 'int64') {
-          fromVar = `parsed${capitalize(elementFormat)}`;
+          fromVar = `parsed${naming.capitalize(elementFormat)}`;
           content += `\t\t${fromVar}, parseErr := ${emitNumericConversion(`${paramValue}[i]`, elementFormat)}\n`;
           content += '\t\tif parseErr != nil {\n\t\t\treturn nil, parseErr\n\t\t}\n';
         } else if (elementFormat === 'string') {
@@ -1033,12 +1033,12 @@ function parseHeaderPathQueryParams(pkg: go.FakePackage, method: go.MethodType, 
           fromVar = `${paramValue}[i]`;
         } else if (elementFormat === 'Std' || elementFormat === 'URL') {
           imports.add('encoding/base64');
-          fromVar = `parsed${capitalize(elementFormat)}`;
+          fromVar = `parsed${naming.capitalize(elementFormat)}`;
           content += `\t\t${fromVar}, parseErr := base64.${elementFormat}Encoding.DecodeString(${paramValue}[i])\n`;
           content += '\t\tif parseErr != nil {\n\t\t\treturn nil, parseErr\n\t\t}\n';
         } else if (elementFormat === 'RFC1123' || elementFormat === 'RFC3339' || elementFormat === 'Unix') {
           imports.add('time');
-          fromVar = `parsed${capitalize(elementFormat)}`;
+          fromVar = `parsed${naming.capitalize(elementFormat)}`;
           if (elementFormat === 'Unix') {
             imports.add('strconv');
             content += `\t\tp, parseErr := strconv.ParseInt(${paramValue}[i], 10, 64)\n`;
@@ -1183,16 +1183,16 @@ function parseHeaderPathQueryParams(pkg: go.FakePackage, method: go.MethodType, 
   // create the param groups and populate their values
   for (const paramGroup of paramGroups.keys()) {
     if (paramGroup.required) {
-      content += `\t${uncapitalize(paramGroup.name)} := ${go.getTypeDeclaration(paramGroup, pkg)}{\n`;
+      content += `\t${naming.uncapitalize(paramGroup.name)} := ${go.getTypeDeclaration(paramGroup, pkg)}{\n`;
       const params = paramGroups.get(paramGroup);
       if (params) {
         for (const param of params) {
-          content += `\t\t${capitalize(param.name)}: ${getFinalParamValue(pkg, param, paramValues)},\n`;
+          content += `\t\t${naming.capitalize(param.name)}: ${getFinalParamValue(pkg, param, paramValues)},\n`;
         }
       }
       content += '\t}\n';
     } else {
-      content += `\tvar ${uncapitalize(paramGroup.name)} *${go.getTypeDeclaration(paramGroup, pkg)}\n`;
+      content += `\tvar ${naming.uncapitalize(paramGroup.name)} *${go.getTypeDeclaration(paramGroup, pkg)}\n`;
       const params = paramGroups.get(paramGroup);
       const paramNilCheck = new Array<string>();
       if (params) {
@@ -1217,14 +1217,14 @@ function parseHeaderPathQueryParams(pkg: go.FakePackage, method: go.MethodType, 
         }
       }
       content += `\tif ${paramNilCheck.join(' || ')} {\n`;
-      content += `\t\t${uncapitalize(paramGroup.name)} = &${go.getTypeDeclaration(paramGroup, pkg)}{\n`;
+      content += `\t\t${naming.uncapitalize(paramGroup.name)} = &${go.getTypeDeclaration(paramGroup, pkg)}{\n`;
       if (params) {
         for (const param of params) {
           let byRef = '&';
           if (param.byValue || (!go.isRequiredParameter(param.style) && param.kind !== 'bodyParam' && !go.isFormBodyParameter(param) && param.kind !== 'multipartFormBodyParam')) {
             byRef = '';
           }
-          content += `\t\t\t${capitalize(param.name)}: ${byRef}${getFinalParamValue(pkg, param, paramValues)},\n`;
+          content += `\t\t\t${naming.capitalize(param.name)}: ${byRef}${getFinalParamValue(pkg, param, paramValues)},\n`;
         }
       }
       content += '\t\t}\n';
@@ -1272,7 +1272,7 @@ function populateApiParams(pkg: go.FakePackage, method: go.MethodType, paramValu
       }
       // by convention, for param groups, the param parsing code
       // creates a local var with the name of the param
-      params.push(uncapitalize(param.name));
+      params.push(naming.uncapitalize(param.name));
       continue;
     }
     imports.addForType(param.type);
@@ -1361,7 +1361,7 @@ function getFinalParamValue(pkg: go.FakePackage, param: go.MethodParameter, para
     }
   } else if (param.kind === 'partialBodyParam') {
     // use the value from the unmarshaled, intermediate struct type
-    return `body.${capitalize(param.name)}`;
+    return `body.${naming.capitalize(param.name)}`;
   }
 
   return paramValue;
@@ -1409,7 +1409,7 @@ function getAPIParametersSig(pkg: go.FakePackage, method: go.MethodType, imports
     params.push('ctx context.Context');
   }
   for (const methodParam of methodParams) {
-    let paramName = uncapitalize(methodParam.name);
+    let paramName = naming.uncapitalize(methodParam.name);
     if (methodParam.kind === 'uriParam') {
       paramName = 'host';
     }

--- a/packages/naming.go/src/naming.ts
+++ b/packages/naming.go/src/naming.ts
@@ -96,7 +96,7 @@ export function trimPackagePrefix(pkg: string, val: string): string {
   return val.substring(pkg.length);
 }
 
-// the following was copied from @azure-tools/codegen to keep compat without dragging in YAD
+// the following was copied from @azure-tools/codegen as it's being deprecated
 const acronyms = new Set([
   'ip',
   'os',
@@ -114,6 +114,7 @@ export function capitalize(str: string): string {
 export function uncapitalize(str: string): string {
   return str ? `${str.charAt(0).toLowerCase()}${str.slice(1)}` : str;
 }
+// end ports from @azure-tools/codegen
 
 export function createPolymorphicInterfaceName(base: string): string {
   return base + 'Classification';

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -56,6 +56,7 @@
     "@azure-tools/typespec-azure-rulesets": "0.64.0",
     "@azure-tools/typespec-client-generator-core": "0.64.3",
     "@types/node": "catalog:",
+    "@types/semver": "catalog:",
     "@typespec/compiler": "1.8.0",
     "@typespec/events": "0.78.0",
     "@typespec/http": "1.8.0",
@@ -81,7 +82,7 @@
     "@typespec/http": "^1.8.0"
   },
   "dependencies": {
-    "@azure-tools/codegen": "catalog:",
+    "semver": "catalog:",
     "source-map-support": "0.5.21"
   }
 }

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { uncapitalize } from '@azure-tools/codegen';
 import * as tcgc from '@azure-tools/typespec-client-generator-core';
 import * as tsp from '@typespec/compiler';
 import * as http from '@typespec/http';
@@ -446,7 +445,7 @@ export class TypeAdapter {
   private getConstantType(enumType: tcgc.SdkEnumType): go.Constant {
     let constTypeName = naming.ensureNameCase(enumType.name);
     if (enumType.access === 'internal') {
-      constTypeName = naming.getEscapedReservedName(uncapitalize(constTypeName), 'Type');
+      constTypeName = naming.getEscapedReservedName(naming.uncapitalize(constTypeName), 'Type');
     }
     let constType = this.types.get(constTypeName);
     if (constType) {
@@ -470,7 +469,7 @@ export class TypeAdapter {
     }
     let ifaceName = naming.createPolymorphicInterfaceName(naming.ensureNameCase(model.name));
     if (model.access === 'internal') {
-      ifaceName = uncapitalize(ifaceName);
+      ifaceName = naming.uncapitalize(ifaceName);
     }
     let iface = this.types.get(ifaceName);
     if (iface) {
@@ -500,7 +499,7 @@ export class TypeAdapter {
   private getModel(model: tcgc.SdkModelType): go.Model | go.PolymorphicModel {
     let modelName = naming.ensureNameCase(model.name);
     if (model.access === 'internal') {
-      modelName = naming.getEscapedReservedName(uncapitalize(modelName), 'Model');
+      modelName = naming.getEscapedReservedName(naming.uncapitalize(modelName), 'Model');
     }
     let modelType = this.types.get(modelName);
     if (modelType) {
@@ -626,7 +625,7 @@ export class TypeAdapter {
     for (const valueType of valueTypes) {
       let valueTypeName = `${type.name}${naming.ensureNameCase(valueType.name)}`;
       if (valueType.enumType.access === 'internal') {
-        valueTypeName = naming.getEscapedReservedName(uncapitalize(valueTypeName), 'Type');
+        valueTypeName = naming.getEscapedReservedName(naming.uncapitalize(valueTypeName), 'Type');
       }
 
       if (this.constValues.has(valueTypeName)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@types/node':
       specifier: ^20.19.25
       version: 20.19.27
+    '@types/semver':
+      specifier: ^7.7.1
+      version: 7.7.1
     '@vitest/coverage-v8':
       specifier: ^3.1.1
       version: 3.1.3
@@ -30,6 +33,9 @@ catalogs:
     eslint:
       specifier: ^9.39.1
       version: 9.39.2
+    semver:
+      specifier: ^7.7.1
+      version: 7.7.2
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
@@ -83,6 +89,9 @@ importers:
       html-to-text:
         specifier: ^5.1.1
         version: 5.1.1
+      semver:
+        specifier: 'catalog:'
+        version: 7.7.2
       showdown:
         specifier: ^1.9.1
         version: 1.9.1
@@ -99,6 +108,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.27
+      '@types/semver':
+        specifier: 'catalog:'
+        version: 7.7.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 3.1.3(vitest@3.1.3)
@@ -211,10 +223,13 @@ importers:
 
   packages/codegen.go:
     dependencies:
-      '@azure-tools/codegen':
+      semver:
         specifier: 'catalog:'
-        version: 2.10.0
+        version: 7.7.2
     devDependencies:
+      '@types/semver':
+        specifier: 'catalog:'
+        version: 7.7.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -233,9 +248,9 @@ importers:
 
   packages/typespec-go:
     dependencies:
-      '@azure-tools/codegen':
+      semver:
         specifier: 'catalog:'
-        version: 2.10.0
+        version: 7.7.2
       source-map-support:
         specifier: 0.5.21
         version: 0.5.21
@@ -261,6 +276,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.27
+      '@types/semver':
+        specifier: 'catalog:'
+        version: 7.7.1
       '@typespec/compiler':
         specifier: 1.8.0
         version: 1.8.0(@types/node@20.19.27)
@@ -1608,6 +1626,9 @@ packages:
 
   '@types/nunjucks@3.2.6':
     resolution: {integrity: sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/showdown@1.9.4':
     resolution: {integrity: sha512-50ehC3IAijfkvoNqmQ+VL73S7orOxmAK8ljQAFBv8o7G66lAZyxQj1L3BAv2dD86myLXI+sgKP1kcxAaxW356w==}
@@ -7256,6 +7277,8 @@ snapshots:
       undici-types: 7.16.0
 
   '@types/nunjucks@3.2.6': {}
+
+  '@types/semver@7.7.1': {}
 
   '@types/showdown@1.9.4': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,9 +12,11 @@ catalog:
   "@azure-tools/linq": ^3.1.263
   "@eslint/js": ^9.39.1
   "@types/node": ^20.19.25
+  "@types/semver": "^7.7.1"
   "@vitest/coverage-v8": ^3.1.1
   "@vitest/ui": ^3.1.1
   eslint: ^9.39.1
+  semver: "^7.7.1"
   typescript: ^5.9.3
   typescript-eslint: ^8.47.0
   vitest: ^3.1.1


### PR DESCRIPTION
Copied required exports.  This includes some camel and pascal casing helpers, and some helpers for parsing/comparing semver values.

Fixes https://github.com/Azure/autorest.go/issues/1837