### PR TITLE
Fix detection of streaming responses

### DIFF
--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 
 * Fixed incorrect example generation for unknown type.
+* Fixed detection logic for streaming responses.
 
 ### Other Changes
 

--- a/packages/typespec-go/test/local/azregressions/zz_client.go
+++ b/packages/typespec-go/test/local/azregressions/zz_client.go
@@ -43,6 +43,53 @@ func NewClientWithNoCredential(endpoint string, options *ClientOptions) (*Client
 	return client, nil
 }
 
+// BinaryResponseWithXMLContentType -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ClientBinaryResponseWithXMLContentTypeOptions contains the optional parameters for the Client.BinaryResponseWithXMLContentType
+//     method.
+func (client *Client) BinaryResponseWithXMLContentType(ctx context.Context, options *ClientBinaryResponseWithXMLContentTypeOptions) (ClientBinaryResponseWithXMLContentTypeResponse, error) {
+	var err error
+	const operationName = "Client.BinaryResponseWithXMLContentType"
+	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
+	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
+	req, err := client.binaryResponseWithXMLContentTypeCreateRequest(ctx, options)
+	if err != nil {
+		return ClientBinaryResponseWithXMLContentTypeResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return ClientBinaryResponseWithXMLContentTypeResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
+		err = runtime.NewResponseError(httpResp)
+		return ClientBinaryResponseWithXMLContentTypeResponse{}, err
+	}
+	resp, err := client.binaryResponseWithXMLContentTypeHandleResponse(httpResp)
+	return resp, err
+}
+
+// binaryResponseWithXMLContentTypeCreateRequest creates the BinaryResponseWithXMLContentType request.
+func (client *Client) binaryResponseWithXMLContentTypeCreateRequest(ctx context.Context, _ *ClientBinaryResponseWithXMLContentTypeOptions) (*policy.Request, error) {
+	urlPath := "/binary-response-with-xml-content-type"
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	runtime.SkipBodyDownload(req)
+	req.Raw().Header["Accept"] = []string{"application/xml"}
+	return req, nil
+}
+
+// binaryResponseWithXMLContentTypeHandleResponse handles the BinaryResponseWithXMLContentType response.
+func (client *Client) binaryResponseWithXMLContentTypeHandleResponse(resp *http.Response) (ClientBinaryResponseWithXMLContentTypeResponse, error) {
+	result := ClientBinaryResponseWithXMLContentTypeResponse{Body: resp.Body}
+	if val := resp.Header.Get("Content-Type"); val != "" {
+		result.ContentType = &val
+	}
+	return result, nil
+}
+
 // ForceRequiredBodyPatch -
 // If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ClientForceRequiredBodyPatchOptions contains the optional parameters for the Client.ForceRequiredBodyPatch method.

--- a/packages/typespec-go/test/local/azregressions/zz_options.go
+++ b/packages/typespec-go/test/local/azregressions/zz_options.go
@@ -6,6 +6,12 @@ package azregressions
 
 import "io"
 
+// ClientBinaryResponseWithXMLContentTypeOptions contains the optional parameters for the Client.BinaryResponseWithXMLContentType
+// method.
+type ClientBinaryResponseWithXMLContentTypeOptions struct {
+	// placeholder for future optional parameters
+}
+
 // ClientForceRequiredBodyPatchOptions contains the optional parameters for the Client.ForceRequiredBodyPatch method.
 type ClientForceRequiredBodyPatchOptions struct {
 	// placeholder for future optional parameters

--- a/packages/typespec-go/test/local/azregressions/zz_responses.go
+++ b/packages/typespec-go/test/local/azregressions/zz_responses.go
@@ -4,6 +4,15 @@
 
 package azregressions
 
+import "io"
+
+// ClientBinaryResponseWithXMLContentTypeResponse contains the response from method Client.BinaryResponseWithXMLContentType.
+type ClientBinaryResponseWithXMLContentTypeResponse struct {
+	// Body contains the streaming response.
+	Body        io.ReadCloser
+	ContentType *string
+}
+
 // ClientForceRequiredBodyPatchResponse contains the response from method Client.ForceRequiredBodyPatch.
 type ClientForceRequiredBodyPatchResponse struct {
 	// placeholder for future response values

--- a/packages/typespec-go/test/tsp/Regressions/main.tsp
+++ b/packages/typespec-go/test/tsp/Regressions/main.tsp
@@ -48,3 +48,14 @@ op forceRequiredBodyPut(@body body?: SomeModel): void;
 @post
 @route("/optional-body-post")
 op optionalBodyPost(@body body?: SomeModel): void;
+
+@get
+@route("/binary-response-with-xml-content-type")
+op binaryResponseWithXmlContentType():     {
+  @header("Content-Type")
+  contentType: "application/xml";
+
+  @bodyRoot
+  @encode("bytes")
+  body: bytes;
+};


### PR DESCRIPTION
Bytes type with bytes encoding indicates a streaming response.

Fixes https://github.com/Azure/autorest.go/issues/1845