### PR TITLE
Clean up Spector authentication tests

### DIFF
--- a/packages/typespec-go/.scripts/tspcompile.js
+++ b/packages/typespec-go/.scripts/tspcompile.js
@@ -18,10 +18,10 @@ const compiler = pkgRoot + 'node_modules/@typespec/compiler/cmd/tsp.js';
 // 'moduleName': [ 'input', 'emitter option 1', 'emitter option N...' ]
 // if no .tsp file is specified in input, it's assumed to be main.tsp
 const httpSpecsGroup = {
-  // 'apikeygroup': ['authentication/api-key'],     // ctors for API key not supported
-  // 'customgroup': ['authentication/http/custom'], // ctors for API key not supported
+  'apikeygroup': ['authentication/api-key'],
+  'customgroup': ['authentication/http/custom'],
   'oauth2group': ['authentication/oauth2'],
-  'unionauthgroup': ['authentication/union'],    // ctors for API key not supported
+  'unionauthgroup': ['authentication/union'],
   'bytesgroup': ['encode/bytes'],
   'datetimegroup': ['encode/datetime', 'slice-elements-byval=true'],
   'durationgroup': ['encode/duration'],

--- a/packages/typespec-go/test/http-specs/authentication/apikeygroup/apikey_client_test.go
+++ b/packages/typespec-go/test/http-specs/authentication/apikeygroup/apikey_client_test.go
@@ -8,11 +8,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAPIKeyClient_Invalid(t *testing.T) {
-	client, err := apikeygroup.NewAPIKeyClient("http://localhost:3000", nil)
+	client, err := apikeygroup.NewAPIKeyClient("http://localhost:3000", azcore.NewKeyCredential("invalid-key"), nil)
 	require.NoError(t, err)
 	resp, err := client.Invalid(context.Background(), nil)
 	require.Error(t, err)
@@ -21,7 +22,7 @@ func TestAPIKeyClient_Invalid(t *testing.T) {
 }
 
 func TestAPIKeyClient_Valid(t *testing.T) {
-	client, err := apikeygroup.NewAPIKeyClient("http://localhost:3000", nil)
+	client, err := apikeygroup.NewAPIKeyClient("http://localhost:3000", azcore.NewKeyCredential("valid-key"), nil)
 	require.NoError(t, err)
 	resp, err := client.Valid(context.Background(), nil)
 	require.NoError(t, err)

--- a/packages/typespec-go/test/http-specs/authentication/apikeygroup/custom_client.go
+++ b/packages/typespec-go/test/http-specs/authentication/apikeygroup/custom_client.go
@@ -5,11 +5,18 @@ package apikeygroup
 
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
-func NewAPIKeyClient(endpoint string, options *azcore.ClientOptions) (*APIKeyClient, error) {
-	internal, err := azcore.NewClient(moduleName, moduleVersion, runtime.PipelineOptions{}, options)
+func NewAPIKeyClient(endpoint string, credential *azcore.KeyCredential, options *azcore.ClientOptions) (*APIKeyClient, error) {
+	internal, err := azcore.NewClient(moduleName, moduleVersion, runtime.PipelineOptions{
+		PerRetry: []policy.Policy{
+			runtime.NewKeyCredentialPolicy(credential, "x-ms-api-key", &runtime.KeyCredentialPolicyOptions{
+				InsecureAllowCredentialWithHTTP: true,
+			}),
+		},
+	}, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/authentication/apikeygroup/zz_apikey_client.go
+++ b/packages/typespec-go/test/http-specs/authentication/apikeygroup/zz_apikey_client.go
@@ -37,7 +37,6 @@ func (client *APIKeyClient) Invalid(ctx context.Context, options *APIKeyClientIn
 	if err != nil {
 		return APIKeyClientInvalidResponse{}, err
 	}
-	req.Raw().Header.Set("x-ms-api-key", "invalid-key")
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return APIKeyClientInvalidResponse{}, err
@@ -72,7 +71,6 @@ func (client *APIKeyClient) Valid(ctx context.Context, options *APIKeyClientVali
 	if err != nil {
 		return APIKeyClientValidResponse{}, err
 	}
-	req.Raw().Header.Set("x-ms-api-key", "valid-key")
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return APIKeyClientValidResponse{}, err

--- a/packages/typespec-go/test/http-specs/authentication/http/customgroup/custom_client.go
+++ b/packages/typespec-go/test/http-specs/authentication/http/customgroup/custom_client.go
@@ -5,11 +5,19 @@ package customgroup
 
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
-func NewCustomClient(endpoint string, options *azcore.ClientOptions) (*CustomClient, error) {
-	internal, err := azcore.NewClient(moduleName, moduleVersion, runtime.PipelineOptions{}, options)
+func NewCustomClient(endpoint string, credential *azcore.KeyCredential, options *azcore.ClientOptions) (*CustomClient, error) {
+	internal, err := azcore.NewClient(moduleName, moduleVersion, runtime.PipelineOptions{
+		PerRetry: []policy.Policy{
+			runtime.NewKeyCredentialPolicy(credential, "authorization", &runtime.KeyCredentialPolicyOptions{
+				InsecureAllowCredentialWithHTTP: true,
+				Prefix:                          "SharedAccessKey ",
+			}),
+		},
+	}, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/http-specs/authentication/http/customgroup/custom_client_test.go
+++ b/packages/typespec-go/test/http-specs/authentication/http/customgroup/custom_client_test.go
@@ -8,11 +8,12 @@ import (
 	"customgroup"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCustomClient_Invalid(t *testing.T) {
-	client, err := customgroup.NewCustomClient("http://localhost:3000", nil)
+	client, err := customgroup.NewCustomClient("http://localhost:3000", azcore.NewKeyCredential("invalid-key"), nil)
 	require.NoError(t, err)
 	resp, err := client.Invalid(context.Background(), nil)
 	require.Error(t, err)
@@ -20,7 +21,7 @@ func TestCustomClient_Invalid(t *testing.T) {
 }
 
 func TestCustomClient_Valid(t *testing.T) {
-	client, err := customgroup.NewCustomClient("http://localhost:3000", nil)
+	client, err := customgroup.NewCustomClient("http://localhost:3000", azcore.NewKeyCredential("valid-key"), nil)
 	require.NoError(t, err)
 	resp, err := client.Valid(context.Background(), nil)
 	require.NoError(t, err)

--- a/packages/typespec-go/test/http-specs/authentication/http/customgroup/zz_custom_client.go
+++ b/packages/typespec-go/test/http-specs/authentication/http/customgroup/zz_custom_client.go
@@ -6,11 +6,10 @@ package customgroup
 
 import (
 	"context"
-	"net/http"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"net/http"
 )
 
 // CustomClient - Illustrates clients generated with generic HTTP auth.
@@ -38,7 +37,6 @@ func (client *CustomClient) Invalid(ctx context.Context, options *CustomClientIn
 	if err != nil {
 		return CustomClientInvalidResponse{}, err
 	}
-	req.Raw().Header.Set("authorization", "SharedAccessKey invalid-key")
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return CustomClientInvalidResponse{}, err
@@ -73,7 +71,6 @@ func (client *CustomClient) Valid(ctx context.Context, options *CustomClientVali
 	if err != nil {
 		return CustomClientValidResponse{}, err
 	}
-	req.Raw().Header.Set("authorization", "SharedAccessKey valid-key")
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return CustomClientValidResponse{}, err


### PR DESCRIPTION
Use generated code with hand-written client constructors.