### PR TITLE
Update Go and Node versions used in CI

### DIFF
--- a/eng/pipelines/sdk-regenerate.yml
+++ b/eng/pipelines/sdk-regenerate.yml
@@ -51,8 +51,11 @@ jobs:
     inputs:
       versionSpec: '$(NodeVersion)'
 
-  - script: npm install -g pnpm@9.5.0
-    displayName: Install pnpm 9.5.0
+  - script: |
+      npm i -g corepack@latest
+      corepack enable
+      corepack prepare pnpm@latest-10 --activate
+    displayName: Install pnpm
 
   - script: pnpm install
     displayName: pnpm install

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,9 +1,9 @@
 variables:
   - name: GoVersionLatest
-    value: "1.25.4"
+    value: "1.26.1"
   - name: GoVersionPrevious
-    value: "1.24.10"
+    value: "1.25.8"
   - name: NodeVersion
-    value: "20.x"
+    value: "24.x"
   - name: GoLintCLIVersion
-    value: "v2.6.2"
+    value: "v2.11.4"

--- a/packages/autorest.go/tsconfig.json
+++ b/packages/autorest.go/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "..",
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "resources", "node_modules", "**/*.d.ts", "generated"]

--- a/packages/codegen.go/tsconfig.json
+++ b/packages/codegen.go/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "..",
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "resources", "node_modules", "**/*.d.ts", "generated"]

--- a/packages/codemodel.go/tsconfig.json
+++ b/packages/codemodel.go/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "..",
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "resources", "node_modules", "**/*.d.ts", "generated"]

--- a/packages/naming.go/tsconfig.json
+++ b/packages/naming.go/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "..",
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "resources", "node_modules", "**/*.d.ts", "generated"]

--- a/packages/typespec-go/tsconfig.json
+++ b/packages/typespec-go/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "..",
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "resources", "node_modules", "**/*.d.ts", "generated"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "declaration": true,
     "declarationMap": true,
-    "downlevelIteration": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": false,


### PR DESCRIPTION
Fix up non-compliant tsconfig.json flagged with recent Node versions. Removed downlevelIteration as it's not required and being deprecated.