### PR TITLE
Small change to enable `preview` release with newest `npm`/`pnpm`

### DIFF
--- a/eng/pipelines/templates/steps/publish-release.yaml
+++ b/eng/pipelines/templates/steps/publish-release.yaml
@@ -45,5 +45,9 @@ steps:
     - script: |
         cd packages/${{ parameters.PackagePath }}
         echo "//registry.npmjs.org/:_authToken=$(azure-sdk-npm-token)" > ./.npmrc
-        pnpm publish --access public --no-git-checks
+        TAG_ARG=""
+        if node -e "process.exit(require('semver').prerelease(require('./package.json').version) ? 0 : 1)"; then
+          TAG_ARG="--tag next"
+        fi
+        pnpm publish --access public --no-git-checks $TAG_ARG
       displayName: "Publish to npm ${{ parameters.PackagePath }}"

--- a/eng/pipelines/templates/steps/publish-release.yaml
+++ b/eng/pipelines/templates/steps/publish-release.yaml
@@ -45,9 +45,5 @@ steps:
     - script: |
         cd packages/${{ parameters.PackagePath }}
         echo "//registry.npmjs.org/:_authToken=$(azure-sdk-npm-token)" > ./.npmrc
-        TAG_ARG=""
-        if node -e "process.exit(require('semver').prerelease(require('./package.json').version) ? 0 : 1)"; then
-          TAG_ARG="--tag next"
-        fi
-        pnpm publish --access public --no-git-checks $TAG_ARG
+        pnpm publish --access public --no-git-checks --tag latest
       displayName: "Publish to npm ${{ parameters.PackagePath }}"


### PR DESCRIPTION
A recent [release](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6188770) failed due to requiring a `--tag` argument for a preview package version.

I believe the semver usage that I originally added is wrong an unstable. Going to add a follow-up commit that simplifies a bit.