### PR TITLE
Include all child clients in fake server dispatch

### DIFF
--- a/packages/codegen.go/src/fake/servers.ts
+++ b/packages/codegen.go/src/fake/servers.ts
@@ -299,13 +299,34 @@ function generateServerTransportClientDispatch(serverTransport: string, subClien
     return '';
   }
 
+  /** gathers all children, not just immediate children, in breadth first order */
+  const getAllSubClientsForCase = function(client: go.Client): Array<go.Client> {
+    const subClients = new Array<go.Client>();
+    for (const clientAccessor of client.clientAccessors) {
+      if (helpers.clientHasNoExportedMethods(clientAccessor.returns)) {
+        // client has no exported methods, skip it
+        continue;
+      }
+      subClients.push(clientAccessor.returns);
+    }
+    for (const subClient of subClients) {
+      const children = getAllSubClientsForCase(subClient);
+      subClients.push(...children);
+    }
+    return subClients;
+  };
+
   const receiverName = serverTransport[0].toLowerCase();
   imports.add('strings');
   let content = `func (${receiverName} *${serverTransport}) ${dispatchToClientFake}(req *http.Request, client string) (*http.Response, error) {\n`;
   content += `${indent.get()}var resp *http.Response\n${indent.get()}var err error\n\n`;
   content += `${indent.get()}switch client {\n`;
   for (const subClient of subClients) {
-    content += `${indent.get()}case "${subClient.name}":\n`;
+    // we must include all child clients, not just the immediate children
+    const subClientsforCase = getAllSubClientsForCase(subClient);
+    const allClientNamesForCase = new Array<string>(`"${subClient.name}"`);
+    allClientNamesForCase.push(...subClientsforCase.map((each) => `"${each.name}"`));
+    content += `${indent.get()}case ${allClientNamesForCase.join()}:\n`;
     const serverName = getServerName(subClient);
     indent.push();
     content += `${indent.get()}initServer(&${receiverName}.trMu, &${receiverName}.tr${serverName}, func() *${serverName}Transport {\n`;

--- a/packages/codegen.go/src/fake/servers.ts
+++ b/packages/codegen.go/src/fake/servers.ts
@@ -300,20 +300,34 @@ function generateServerTransportClientDispatch(serverTransport: string, subClien
   }
 
   /** gathers all children, not just immediate children, in breadth first order */
-  const getAllSubClientsForCase = function(client: go.Client): Array<go.Client> {
-    const subClients = new Array<go.Client>();
+  const getAllSubClientsForCase = function (client: go.Client): Array<go.Client> {
+    const result = new Array<go.Client>();
+    const visited = new Set<go.Client>();
+    const queue = new Array<go.Client>();
     for (const clientAccessor of client.clientAccessors) {
       if (helpers.clientHasNoExportedMethods(clientAccessor.returns)) {
-        // client has no exported methods, skip it
         continue;
       }
-      subClients.push(clientAccessor.returns);
+      if (!visited.has(clientAccessor.returns)) {
+        visited.add(clientAccessor.returns);
+        queue.push(clientAccessor.returns);
+        result.push(clientAccessor.returns);
+      }
     }
-    for (const subClient of subClients) {
-      const children = getAllSubClientsForCase(subClient);
-      subClients.push(...children);
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      for (const clientAccessor of current.clientAccessors) {
+        if (helpers.clientHasNoExportedMethods(clientAccessor.returns)) {
+          continue;
+        }
+        if (!visited.has(clientAccessor.returns)) {
+          visited.add(clientAccessor.returns);
+          queue.push(clientAccessor.returns);
+          result.push(clientAccessor.returns);
+        }
+      }
     }
-    return subClients;
+    return result;
   };
 
   const receiverName = serverTransport[0].toLowerCase();
@@ -323,10 +337,10 @@ function generateServerTransportClientDispatch(serverTransport: string, subClien
   content += `${indent.get()}switch client {\n`;
   for (const subClient of subClients) {
     // we must include all child clients, not just the immediate children
-    const subClientsforCase = getAllSubClientsForCase(subClient);
+    const subClientsForCase = getAllSubClientsForCase(subClient);
     const allClientNamesForCase = new Array<string>(`"${subClient.name}"`);
-    allClientNamesForCase.push(...subClientsforCase.map((each) => `"${each.name}"`));
-    content += `${indent.get()}case ${allClientNamesForCase.join()}:\n`;
+    allClientNamesForCase.push(...subClientsForCase.map((each) => `"${each.name}"`));
+    content += `${indent.get()}case ${allClientNamesForCase.join(', ')}:\n`;
     const serverName = getServerName(subClient);
     indent.push();
     content += `${indent.get()}initServer(&${receiverName}.trMu, &${receiverName}.tr${serverName}, func() *${serverName}Transport {\n`;

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 
 * Fixed handling of `multipart/form` operations.
+* Fake servers will correctly dispatch calls to all child servers, not just immediate ones.
 
 ## 0.11.0 (2026-04-24)
 

--- a/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/fake/zz_service_server.go
+++ b/packages/typespec-go/test/azure-http-specs/client/structure/defaultgroup/fake/zz_service_server.go
@@ -84,7 +84,7 @@ func (s *ServiceServerTransport) dispatchToClientFake(req *http.Request, client 
 			return NewServiceFooServerTransport(&s.srv.ServiceFooServer)
 		})
 		resp, err = s.trServiceFooServer.Do(req)
-	case "ServiceQuxClient":
+	case "ServiceQuxClient", "ServiceQuxBarClient":
 		initServer(&s.trMu, &s.trServiceQuxServer, func() *ServiceQuxServerTransport {
 			return NewServiceQuxServerTransport(&s.srv.ServiceQuxServer)
 		})

--- a/packages/typespec-go/test/http-specs/payload/multipartgroup/fake/zz_multipart_server.go
+++ b/packages/typespec-go/test/http-specs/payload/multipartgroup/fake/zz_multipart_server.go
@@ -50,7 +50,7 @@ func (m *MultiPartServerTransport) dispatchToClientFake(req *http.Request, clien
 	var err error
 
 	switch client {
-	case "MultiPartFormDataClient":
+	case "MultiPartFormDataClient", "MultiPartFormDataFileClient", "MultiPartFormDataHTTPPartsClient", "MultiPartFormDataHTTPPartsContentTypeClient", "MultiPartFormDataHTTPPartsNonStringClient":
 		initServer(&m.trMu, &m.trMultiPartFormDataServer, func() *MultiPartFormDataServerTransport {
 			return NewMultiPartFormDataServerTransport(&m.srv.MultiPartFormDataServer)
 		})

--- a/packages/typespec-go/test/http-specs/payload/multipartgroup/fake/zz_multipartformdata_server.go
+++ b/packages/typespec-go/test/http-specs/payload/multipartgroup/fake/zz_multipartformdata_server.go
@@ -111,7 +111,7 @@ func (m *MultiPartFormDataServerTransport) dispatchToClientFake(req *http.Reques
 			return NewMultiPartFormDataFileServerTransport(&m.srv.MultiPartFormDataFileServer)
 		})
 		resp, err = m.trMultiPartFormDataFileServer.Do(req)
-	case "MultiPartFormDataHTTPPartsClient":
+	case "MultiPartFormDataHTTPPartsClient", "MultiPartFormDataHTTPPartsContentTypeClient", "MultiPartFormDataHTTPPartsNonStringClient":
 		initServer(&m.trMu, &m.trMultiPartFormDataHTTPPartsServer, func() *MultiPartFormDataHTTPPartsServerTransport {
 			return NewMultiPartFormDataHTTPPartsServerTransport(&m.srv.MultiPartFormDataHTTPPartsServer)
 		})

--- a/packages/typespec-go/test/http-specs/payload/multipartgroup/fakes_test.go
+++ b/packages/typespec-go/test/http-specs/payload/multipartgroup/fakes_test.go
@@ -59,7 +59,6 @@ func TestFakeFormDataClient_Basic(t *testing.T) {
 }
 
 func TestFakeFormDataFileClient_UploadFileRequiredFilename(t *testing.T) {
-	t.Skip("https://github.com/Azure/autorest.go/issues/1937")
 	calledUpload := false
 	srv := fake.MultiPartServer{
 		MultiPartFormDataServer: fake.MultiPartFormDataServer{
@@ -86,7 +85,6 @@ func TestFakeFormDataFileClient_UploadFileRequiredFilename(t *testing.T) {
 }
 
 func TestFakeFormDataHTTPPartsClient_JSONArrayAndFileArray(t *testing.T) {
-	t.Skip("https://github.com/Azure/autorest.go/issues/1937")
 	calledJSONArrayAndFileArray := false
 	srv := fake.MultiPartServer{
 		MultiPartFormDataServer: fake.MultiPartFormDataServer{
@@ -143,7 +141,6 @@ func TestFakeFormDataHTTPPartsClient_JSONArrayAndFileArray(t *testing.T) {
 }
 
 func TestFakeFormDataHTTPPartsContentTypeClient_RequiredContentType(t *testing.T) {
-	t.Skip("https://github.com/Azure/autorest.go/issues/1937")
 	calledRequiredContentType := false
 	srv := fake.MultiPartServer{
 		MultiPartFormDataServer: fake.MultiPartFormDataServer{
@@ -175,7 +172,6 @@ func TestFakeFormDataHTTPPartsContentTypeClient_RequiredContentType(t *testing.T
 }
 
 func TestFakeFormDataHTTPPartsNonStringClient_Float(t *testing.T) {
-	t.Skip("https://github.com/Azure/autorest.go/issues/1937")
 	calledFloat := false
 	srv := fake.MultiPartServer{
 		MultiPartFormDataServer: fake.MultiPartFormDataServer{

--- a/packages/typespec-go/test/http-specs/payload/multipartgroup/formdata_client_test.go
+++ b/packages/typespec-go/test/http-specs/payload/multipartgroup/formdata_client_test.go
@@ -156,10 +156,30 @@ func TestFormDataClient_MultiBinaryParts(t *testing.T) {
 
 func TestFormDataClient_OptionalParts(t *testing.T) {
 	client := newClient(t)
+
+	// first time with only id
+	resp, err := client.NewMultiPartFormDataClient().OptionalParts(context.Background(), multipartgroup.MultiPartOptionalRequest{
+		ID: to.Ptr("123"),
+	}, nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+
+	// second time with only profileImage
 	jpgFile, err := os.OpenFile(jpgPath, os.O_RDONLY, 0)
 	require.NoError(t, err)
 	defer func() { _ = jpgFile.Close() }()
-	resp, err := client.NewMultiPartFormDataClient().OptionalParts(context.Background(), multipartgroup.MultiPartOptionalRequest{
+	resp, err = client.NewMultiPartFormDataClient().OptionalParts(context.Background(), multipartgroup.MultiPartOptionalRequest{
+		ProfileImage: &streaming.MultipartContent{
+			Body: jpgFile,
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+
+	// third time with both id and profileImage
+	_, err = jpgFile.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	resp, err = client.NewMultiPartFormDataClient().OptionalParts(context.Background(), multipartgroup.MultiPartOptionalRequest{
 		ID: to.Ptr("123"),
 		ProfileImage: &streaming.MultipartContent{
 			Body: jpgFile,

--- a/packages/typespec-go/test/http-specs/payload/pageablegroup/fake/zz_pageable_server.go
+++ b/packages/typespec-go/test/http-specs/payload/pageablegroup/fake/zz_pageable_server.go
@@ -63,7 +63,7 @@ func (p *PageableServerTransport) dispatchToClientFake(req *http.Request, client
 			return NewPageablePageSizeServerTransport(&p.srv.PageablePageSizeServer)
 		})
 		resp, err = p.trPageablePageSizeServer.Do(req)
-	case "PageableServerDrivenPaginationClient":
+	case "PageableServerDrivenPaginationClient", "PageableServerDrivenPaginationAlternateInitialVerbClient", "PageableServerDrivenPaginationContinuationTokenClient":
 		initServer(&p.trMu, &p.trPageableServerDrivenPaginationServer, func() *PageableServerDrivenPaginationServerTransport {
 			return NewPageableServerDrivenPaginationServerTransport(&p.srv.PageableServerDrivenPaginationServer)
 		})


### PR DESCRIPTION
This fixes fake method dispatching for hierarchical clients.

Fixes https://github.com/Azure/autorest.go/issues/1937