### PR TITLE
Refine modeling of body param content types

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -381,13 +381,14 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter, pkg: go.Pac
       if (!op.requests![0].protocol.http!.mediaTypes) {
         throw new Error(`no media types defined for operation ${op.operationId}`);
       }
-      let contentType = `"${op.requests![0].protocol.http!.mediaTypes[0]}"`;
+      const contentTypeLiteral = <string>op.requests![0].protocol.http!.mediaTypes[0];
+      let contentType: go.BodyParameterContentTypeKind = new go.Literal(new go.String, contentTypeLiteral);
       if (op.requests![0].protocol.http!.mediaTypes.length > 1) {
         for (const param of values(op.requests![0].parameters)) {
           // If a request defined more than one possible media type, then the param is expected to be synthesized from modelerfour
           // and should be a SealedChoice schema type that account for the acceptable media types defined in the swagger.
           if (param.origin === 'modelerfour:synthesized/content-type' && param.schema.type === m4.SchemaType.SealedChoice) {
-            contentType = `string(${param.language.go!.name})`;
+            contentType = new go.ParameterRef(param.language.go!.name);
           }
         }
       }

--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -382,7 +382,7 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter, pkg: go.Pac
         throw new Error(`no media types defined for operation ${op.operationId}`);
       }
       const contentTypeLiteral = <string>op.requests![0].protocol.http!.mediaTypes[0];
-      let contentType: go.BodyParameterContentTypeKind = new go.Literal(new go.String, contentTypeLiteral);
+      let contentType: go.BodyParameterContentTypeKind = new go.Literal(new go.String(), contentTypeLiteral);
       if (op.requests![0].protocol.http!.mediaTypes.length > 1) {
         for (const param of values(op.requests![0].parameters)) {
           // If a request defined more than one possible media type, then the param is expected to be synthesized from modelerfour

--- a/packages/codegen.go/src/core/example.ts
+++ b/packages/codegen.go/src/core/example.ts
@@ -265,7 +265,7 @@ function getExampleValue(pkg: go.TestPackage, example: go.ExampleType, indent: s
       } else if (example.type.kind === 'encodedBytes') {
         exampleText = `[]byte("${escapeString(example.value)}")`;
       } else if (example.type.kind === 'literal' && example.type.type.kind === 'constant') {
-        exampleText = getConstantValue(pkg, example.type.type, example.type.literal.value);
+        exampleText = getConstantValue(pkg, example.type.type, (<go.ConstantValue>example.type.literal).value);
       } else if (example.type.kind === 'etag') {
         imports?.add(example.type.module);
         exampleText = `${go.getTypeDeclaration(example.type, pkg)}("${escapeString(example.value)}")`;
@@ -475,7 +475,7 @@ function generateFakeExample(goType: go.Type, name?: string): go.ExampleType {
           return new go.NumberExample(goType.values[0].value as number, goType);
       }
     case 'literal':
-      return new go.StringExample(goType.literal, goType);
+      return new go.StringExample(<string>goType.literal, goType);
     case 'scalar':
       switch (goType.type) {
         case 'bool':

--- a/packages/codegen.go/src/core/helpers.ts
+++ b/packages/codegen.go/src/core/helpers.ts
@@ -397,7 +397,7 @@ export function formatLiteralValue(value: go.Literal, withCast: boolean): string
     case 'constant':
       return (<go.ConstantValue>value.literal).name;
     case 'encodedBytes':
-      return value.literal;
+      return <string>value.literal;
     case 'scalar':
       if (!withCast) {
         return `${value.literal}`;
@@ -412,12 +412,12 @@ export function formatLiteralValue(value: go.Literal, withCast: boolean): string
         case 'int64':
           return `int64(${value.literal})`;
         default:
-          return value.literal;
+          return <string>value.literal;
       }
     case 'string':
-      if (value.literal[0] === '"') {
+      if ((<string>value.literal)[0] === '"') {
         // string is already quoted
-        return value.literal;
+        return <string>value.literal;
       }
       return `"${value.literal}"`;
     case 'time':

--- a/packages/codegen.go/src/core/operations.ts
+++ b/packages/codegen.go/src/core/operations.ts
@@ -1291,6 +1291,27 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
   };
 
   if (bodyParam) {
+    /** returns the source value for the content type */
+    const getContentTypeValue = function (src: go.BodyParameterContentTypeKind): string {
+      switch (src.kind) {
+        case 'literal':
+          return helpers.formatLiteralValue(src, false);
+        case 'parameterRef': {
+          // find the param
+          for (const param of method.parameters) {
+            if (param.kind === 'headerScalarParam' && param.name === src.name) {
+              let paramName = param.name;
+              if (param.type.kind === 'constant') {
+                paramName = `string(${paramName})`;
+              }
+              return paramName;
+            }
+          }
+          throw new CodegenError('InternalError', `didn't find parameter reference ${src.name}`);
+        }
+      }
+    };
+
     if (bodyParam.bodyFormat === 'JSON' || bodyParam.bodyFormat === 'XML') {
       // default to the body param name
       let body = helpers.getParamName(bodyParam);
@@ -1367,12 +1388,12 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
       }
     } else if (bodyParam.bodyFormat === 'binary') {
       if (go.isRequiredParameter(bodyParam.style)) {
-        text += emitSetBodyWithErrCheck(`req.SetBody(${bodyParam.name}, ${bodyParam.contentType})`, contentType);
+        text += emitSetBodyWithErrCheck(`req.SetBody(${bodyParam.name}, ${getContentTypeValue(bodyParam.contentType)})`, contentType);
         text += `${indent.get()}return req, nil\n`;
       } else {
         text += emitParamGroupCheck(bodyParam);
         indent.push();
-        text += emitSetBodyWithErrCheck(`req.SetBody(${helpers.getParamName(bodyParam)}, ${bodyParam.contentType})`, contentType);
+        text += emitSetBodyWithErrCheck(`req.SetBody(${helpers.getParamName(bodyParam)}, ${getContentTypeValue(bodyParam.contentType)})`, contentType);
         text += `${indent.get()}return req, nil\n`;
         indent.pop();
         text += `${indent.get()}}\n`;
@@ -1383,13 +1404,13 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
       if (go.isRequiredParameter(bodyParam.style)) {
         text += `${indent.get()}body := streaming.NopCloser(strings.NewReader(${bodyParam.name}))\n`;
-        text += emitSetBodyWithErrCheck(`req.SetBody(body, ${bodyParam.contentType})`, contentType);
+        text += emitSetBodyWithErrCheck(`req.SetBody(body, ${getContentTypeValue(bodyParam.contentType)})`, contentType);
         text += `${indent.get()}return req, nil\n`;
       } else {
         text += emitParamGroupCheck(bodyParam);
         indent.push();
         text += `${indent.get()}body := streaming.NopCloser(strings.NewReader(${helpers.getParamName(bodyParam)}))\n`;
-        text += emitSetBodyWithErrCheck(`req.SetBody(body, ${bodyParam.contentType})`, contentType);
+        text += emitSetBodyWithErrCheck(`req.SetBody(body, ${getContentTypeValue(bodyParam.contentType)})`, contentType);
         text += `${indent.get()}return req, nil\n`;
         indent.pop();
         text += `${indent.get()}}\n`;

--- a/packages/codegen.go/src/core/operations.ts
+++ b/packages/codegen.go/src/core/operations.ts
@@ -1300,7 +1300,7 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
           // find the param
           for (const param of method.parameters) {
             if (param.kind === 'headerScalarParam' && param.name === src.name) {
-              let paramName = param.name;
+              let paramName = helpers.getParamName(param);
               if (param.type.kind === 'constant') {
                 paramName = `string(${paramName})`;
               }

--- a/packages/codegen.go/src/emitter.ts
+++ b/packages/codegen.go/src/emitter.ts
@@ -300,7 +300,9 @@ function sortContent(pkg: go.PackageContent): void {
     // we sort by literal value so that the switch/case statements in polymorphic_helpers.go
     // are ordered by the literal value which can be somewhat different from the model name.
     iface.possibleTypes.sort((a: go.PolymorphicModel, b: go.PolymorphicModel) => {
-      return sortAscending(a.discriminatorValue!.literal, b.discriminatorValue!.literal);
+      const aValue = a.discriminatorValue!.type.kind === 'constant' ? (<go.ConstantValue>a.discriminatorValue!.literal).name : <string>a.discriminatorValue!.literal;
+      const bValue = b.discriminatorValue!.type.kind === 'constant' ? (<go.ConstantValue>b.discriminatorValue!.literal).name : <string>b.discriminatorValue!.literal;
+      return sortAscending(aValue, bValue);
     });
   }
 

--- a/packages/codegen.go/src/emitter.ts
+++ b/packages/codegen.go/src/emitter.ts
@@ -299,6 +299,7 @@ function sortContent(pkg: go.PackageContent): void {
   for (const iface of pkg.interfaces) {
     // we sort by literal value so that the switch/case statements in polymorphic_helpers.go
     // are ordered by the literal value which can be somewhat different from the model name.
+    // when constant values are used, we sort by the Go identifier instead.
     iface.possibleTypes.sort((a: go.PolymorphicModel, b: go.PolymorphicModel) => {
       const aValue = a.discriminatorValue!.type.kind === 'constant' ? (<go.ConstantValue>a.discriminatorValue!.literal).name : <string>a.discriminatorValue!.literal;
       const bValue = b.discriminatorValue!.type.kind === 'constant' ? (<go.ConstantValue>b.discriminatorValue!.literal).name : <string>b.discriminatorValue!.literal;

--- a/packages/codemodel.go/src/param.ts
+++ b/packages/codemodel.go/src/param.ts
@@ -42,11 +42,14 @@ export interface BodyParameter extends HttpParameterBase {
   bodyFormat: BodyFormat;
 
   /** value used for the Content-Type header */
-  contentType: string;
+  contentType: BodyParameterContentTypeKind;
 
   /** optional XML schema metadata */
   xml?: type.XMLInfo;
 }
+
+/** describes how the body param's content type is set */
+export type BodyParameterContentTypeKind = type.Literal<type.String> | ParameterRef;
 
 /** represents parameters that have a default value on the client side */
 export interface ClientSideDefault {
@@ -234,6 +237,14 @@ export interface PathScalarParameter extends HttpParameterBase {
 
 /** defines the possible types for a PathScalarParameter */
 export type PathScalarParameterType = type.Constant | type.EncodedBytes | type.Literal | type.Scalar | type.String | type.Time;
+
+/** a reference to an existing parameter */
+export interface ParameterRef {
+  kind: 'parameterRef';
+
+  /** the name of the parameter */
+  name: string;
+}
 
 /** a collection of values that go in the HTTP query string */
 export interface QueryCollectionParameter extends HttpParameterBase {
@@ -434,7 +445,7 @@ class HttpParameterBase extends method.Parameter implements HttpParameterBase {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 export class BodyParameter extends HttpParameterBase implements BodyParameter {
-  constructor(name: string, bodyFormat: BodyFormat, contentType: string, type: type.WireType, style: ParameterStyle, byValue: boolean) {
+  constructor(name: string, bodyFormat: BodyFormat, contentType: BodyParameterContentTypeKind, type: type.WireType, style: ParameterStyle, byValue: boolean) {
     super(name, type, style, byValue, 'method');
     this.kind = 'bodyParam';
     this.bodyFormat = bodyFormat;
@@ -509,6 +520,13 @@ export class ParameterGroup implements ParameterGroup {
     this.required = required;
     this.docs = {};
     this.pkg = pkg;
+  }
+}
+
+export class ParameterRef implements ParameterRef {
+  constructor(name: string) {
+    this.kind = 'parameterRef';
+    this.name = name;
   }
 }
 

--- a/packages/codemodel.go/src/type.ts
+++ b/packages/codemodel.go/src/type.ts
@@ -144,15 +144,22 @@ export interface Interface {
 }
 
 /** a literal value (e.g. "foo", 123, true) */
-export interface Literal {
+export interface Literal<T extends LiteralType = LiteralType> {
   kind: 'literal';
 
-  /** the literal's underlying type */
-  type: LiteralType;
+  /**
+   * the literal's underlying type.
+   * note that when T is a Constant type,
+   * literal will contain a ConstantValue
+   */
+  type: T;
 
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  /** the value for this literal */
-  literal: any;
+  /**
+   * the value for this literal.
+   * usually a boolean, number, or string
+   * but it can also be a ConstantValue
+   */
+  literal: unknown;
 }
 
 /** the possible types of literals */
@@ -227,7 +234,7 @@ export interface MultipartContent extends QualifiedType {
   kind: 'multipartContent';
 
   /** optional, explicit content-type for the payload */
-  contentType?: Literal;
+  contentType?: Literal<String>;
 }
 
 /** a model that's a discriminated type */
@@ -620,12 +627,10 @@ export class Interface implements Interface {
   }
 }
 
-export class Literal implements Literal {
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  constructor(type: LiteralType, literal: any) {
+export class Literal<T> implements Literal<T> {
+  constructor(type: T, literal: unknown) {
     this.kind = 'literal';
     this.type = type;
-    /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */
     this.literal = literal;
   }
 }
@@ -672,7 +677,7 @@ export class Model extends ModelBase implements Model {
 }
 
 export class MultipartContent extends QualifiedType implements MultipartContent {
-  constructor(contentType?: Literal) {
+  constructor(contentType?: Literal<String>) {
     super('MultipartContent', 'github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
     this.kind = 'multipartContent';
     this.contentType = contentType;

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Fixed handling of `multipart/form` operations.
 * Fake servers will correctly dispatch calls to all child servers, not just immediate ones.
 
+### Other Changes
+
+* Fixed sorting of case statements in polymorphic helpers.
+
 ## 0.11.0 (2026-04-24)
 
 ### Breaking Changes

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -424,7 +424,7 @@ export class ClientAdapter {
   private adaptURIParam(sdkParam: tcgc.SdkPathParameter, forceRequired: boolean): go.URIParameter {
     let paramType: go.WireType;
     if (sdkParam.isApiVersionParam) {
-      paramType = new go.String();
+      paramType = this.ta.getStringType();
     } else {
       paramType = this.ta.getWireType(sdkParam.type, true, false);
     }
@@ -802,7 +802,8 @@ export class ClientAdapter {
             if (opParam.defaultContentType.match(/multipart/i)) {
               adaptedParam = this.adaptMultipartFormParameter(param, paramStyle, byVal);
             } else {
-              adaptedParam = new go.BodyParameter(paramName, contentType, `"${opParam.defaultContentType}"`, this.ta.getReadSeekCloser(false), paramStyle, byVal);
+              const contentTypeLiteral = this.ta.getLiteral(this.ta.getStringType(), opParam.defaultContentType);
+              adaptedParam = new go.BodyParameter(paramName, contentType, contentTypeLiteral, this.ta.getReadSeekCloser(false), paramStyle, byVal);
             }
             break;
           default:
@@ -1007,7 +1008,7 @@ export class ClientAdapter {
     if (opParam.isApiVersionParam) {
       // we emit the api version param inline as a literal, never as a param.
       // the ClientOptions.APIVersion setting is used to change the version.
-      const paramType = opParam.clientDefaultValue ? new go.Literal(new go.String(), opParam.clientDefaultValue) : new go.String();
+      const paramType = opParam.clientDefaultValue ? new go.Literal(this.ta.getStringType(), opParam.clientDefaultValue) : this.ta.getStringType();
       const paramStyle = opParam.clientDefaultValue ? 'literal' : opParam.optional ? 'optional' : 'required';
       const paramLoc = opParam.onClient ? 'client' : 'method';
       let apiVersionParam: go.HeaderScalarParameter | go.PathScalarParameter | go.QueryScalarParameter;
@@ -1086,7 +1087,8 @@ export class ClientAdapter {
             // tcgc models binary params as 'bytes' but we want an io.ReadSeekCloser
             bodyType = this.ta.getReadSeekCloser(methodParam.type.kind === 'array');
           }
-          adaptedParam = new go.BodyParameter(paramName, contentType, `"${opParam.defaultContentType}"`, bodyType, paramStyle, byVal);
+          const contentTypeLiteral = this.ta.getLiteral(this.ta.getStringType(), opParam.defaultContentType);
+          adaptedParam = new go.BodyParameter(paramName, contentType, contentTypeLiteral, bodyType, paramStyle, byVal);
           if (contentType === 'XML' && methodParam.type.kind === 'array') {
             // this is for compat with autorest.go
             adaptedParam.xml = new go.XMLInfo();
@@ -1569,7 +1571,7 @@ export class ClientAdapter {
       if (param.isApiVersionParam) {
         // we force the API version param type to a string
         // so it matches the ClientOptions.APIVersion type
-        adaptedType = new go.String();
+        adaptedType = this.ta.getStringType();
       } else {
         const adaptedWireType = this.ta.getWireType(param.type, false, false);
         if (!go.isLiteralValueType(adaptedWireType)) {
@@ -1753,8 +1755,7 @@ export class ClientAdapter {
           let concreteType: go.Model | go.PolymorphicModel | undefined;
           if (goType.kind === 'interface') {
             concreteType = goType.possibleTypes.find(
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              (t) => t.discriminatorValue?.literal === exampleType.type.discriminatorValue || t.discriminatorValue?.literal.value === exampleType.type.discriminatorValue,
+              (t) => t.discriminatorValue?.literal === exampleType.type.discriminatorValue || (<go.ConstantValue>t.discriminatorValue?.literal).value === exampleType.type.discriminatorValue,
             );
             if (concreteType === undefined) {
               // can't find the sub type of a discriminated type, fallback to the base type

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -1755,7 +1755,9 @@ export class ClientAdapter {
           let concreteType: go.Model | go.PolymorphicModel | undefined;
           if (goType.kind === 'interface') {
             concreteType = goType.possibleTypes.find(
-              (t) => t.discriminatorValue?.literal === exampleType.type.discriminatorValue || (<go.ConstantValue>t.discriminatorValue?.literal).value === exampleType.type.discriminatorValue,
+              (t) =>
+                t.discriminatorValue?.literal === exampleType.type.discriminatorValue ||
+                (<go.ConstantValue>t.discriminatorValue?.literal).value === exampleType.type.discriminatorValue,
             );
             if (concreteType === undefined) {
               // can't find the sub type of a discriminated type, fallback to the base type

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -209,14 +209,7 @@ export class TypeAdapter {
         return arrayType;
       }
       case 'endpoint': {
-        const stringKey = 'string';
-        let stringType = this.types.get(stringKey);
-        if (stringType) {
-          return stringType;
-        }
-        stringType = new go.String();
-        this.types.set(stringKey, stringType);
-        return stringType;
+        return this.getStringType();
       }
       case 'enum':
         return this.getConstantType(type);
@@ -313,7 +306,7 @@ export class TypeAdapter {
     }
     let mpc = this.types.get(keyName);
     if (!mpc) {
-      const ct = contentType ? new go.Literal(new go.String(), `"${contentType}"`) : undefined;
+      const ct = contentType ? new go.Literal(this.getStringType(), `"${contentType}"`) : undefined;
       mpc = new go.MultipartContent(ct);
       if (sliceOf) {
         mpc = new go.Slice(mpc, true);
@@ -430,15 +423,7 @@ export class TypeAdapter {
         if (type.crossLanguageDefinitionId === 'Azure.Core.eTag') {
           return this.getETagType();
         }
-
-        const stringKey = 'string';
-        let stringType = this.types.get(stringKey);
-        if (stringType) {
-          return stringType;
-        }
-        stringType = new go.String();
-        this.types.set(stringKey, stringType);
-        return stringType;
+        return this.getStringType();
       }
       case 'plainTime': {
         const encoding = 'PlainTime';
@@ -483,6 +468,34 @@ export class TypeAdapter {
     etag = new go.ETag();
     this.types.set(etagKey, etag);
     return etag;
+  }
+
+  /**
+   * returns a Go literal for the specified values
+   *
+   * @param type the underlying type of the literal
+   * @param value the literal value
+   * @returns a Go literal
+   */
+  getLiteral<T extends go.LiteralType = go.LiteralType>(type: T, value: boolean | number | string): go.Literal<T> {
+    const literalKey = `literal-${type.kind}-${value}`;
+    let literalType = this.types.get(literalKey);
+    if (!literalType) {
+      literalType = new go.Literal(type, value);
+      this.types.set(literalKey, literalType);
+    }
+    return <go.Literal<T>>literalType;
+  }
+
+  /** returns a Go string type */
+  getStringType(): go.String {
+    const stringKey = 'string';
+    let stringType = this.types.get(stringKey);
+    if (!stringType) {
+      stringType = new go.String();
+      this.types.set(stringKey, stringType);
+    }
+    return <go.String>stringType;
   }
 
   private getInterfaceType(model: tcgc.SdkModelType): go.Interface {
@@ -878,7 +891,7 @@ export class TypeAdapter {
         if (literalString) {
           return <go.Literal>literalString;
         }
-        literalString = new go.Literal(new go.String(), constType.value);
+        literalString = new go.Literal(this.getStringType(), constType.value);
         this.types.set(keyName, literalString);
         return literalString;
       }

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -478,7 +478,21 @@ export class TypeAdapter {
    * @returns a Go literal
    */
   getLiteral<T extends go.LiteralType = go.LiteralType>(type: T, value: boolean | number | string): go.Literal<T> {
-    const literalKey = `literal-${type.kind}-${value}`;
+    let literalKey = `literal-${type.kind}`;
+    switch (type.kind) {
+      case 'constant':
+        literalKey = `${literalKey}-${type.name}`;
+        break;
+      case 'encodedBytes':
+        literalKey = `${literalKey}-${type.encoding}`;
+        break;
+      case 'scalar':
+        literalKey = `${literalKey}-${type.type}`;
+        break;
+      case 'time':
+        literalKey = `${literalKey}-${type.format}-${type.utc}`;
+    }
+    literalKey = `${literalKey}-${value}`;
     let literalType = this.types.get(literalKey);
     if (!literalType) {
       literalType = new go.Literal(type, value);

--- a/packages/typespec-go/test/local/armbillingbenefits/zz_polymorphic_helpers.go
+++ b/packages/typespec-go/test/local/armbillingbenefits/zz_polymorphic_helpers.go
@@ -39,10 +39,10 @@ func unmarshalDiscountTypePropertiesClassification(rawMsg json.RawMessage) (Disc
 	}
 	var b DiscountTypePropertiesClassification
 	switch m["discountType"] {
-	case string(DiscountTypeProductFamily):
-		b = &ProductFamilyDiscountTypeProperties{}
 	case string(DiscountTypeProduct):
 		b = &ProductDiscountTypeProperties{}
+	case string(DiscountTypeProductFamily):
+		b = &ProductFamilyDiscountTypeProperties{}
 	case string(DiscountTypeSKU):
 		b = &ProductSKUDiscountTypeProperties{}
 	default:

--- a/packages/typespec-go/test/local/armcognitiveservices/zz_polymorphic_helpers.go
+++ b/packages/typespec-go/test/local/armcognitiveservices/zz_polymorphic_helpers.go
@@ -16,10 +16,10 @@ func unmarshalAgentDeploymentPropertiesClassification(rawMsg json.RawMessage) (A
 	}
 	var b AgentDeploymentPropertiesClassification
 	switch m["deploymentType"] {
-	case string(AgentDeploymentTypeManaged):
-		b = &ManagedAgentDeployment{}
 	case string(AgentDeploymentTypeHosted):
 		b = &HostedAgentDeployment{}
+	case string(AgentDeploymentTypeManaged):
+		b = &ManagedAgentDeployment{}
 	default:
 		b = &AgentDeploymentProperties{}
 	}
@@ -39,12 +39,12 @@ func unmarshalApplicationAuthorizationPolicyClassification(rawMsg json.RawMessag
 	}
 	var b ApplicationAuthorizationPolicyClassification
 	switch m["type"] {
+	case string(BuiltInAuthorizationSchemeChannels):
+		b = &ChannelsBuiltInAuthorizationPolicy{}
 	case string(BuiltInAuthorizationSchemeDefault):
 		b = &RoleBasedBuiltInAuthorizationPolicy{}
 	case string(BuiltInAuthorizationSchemeOrganizationScope):
 		b = &OrganizationSharedBuiltInAuthorizationPolicy{}
-	case string(BuiltInAuthorizationSchemeChannels):
-		b = &ChannelsBuiltInAuthorizationPolicy{}
 	default:
 		b = &ApplicationAuthorizationPolicy{}
 	}
@@ -64,30 +64,30 @@ func unmarshalConnectionPropertiesV2Classification(rawMsg json.RawMessage) (Conn
 	}
 	var b ConnectionPropertiesV2Classification
 	switch m["authType"] {
-	case string(ConnectionAuthTypePAT):
-		b = &PATAuthTypeConnectionProperties{}
-	case string(ConnectionAuthTypeManagedIdentity):
-		b = &ManagedIdentityAuthTypeConnectionProperties{}
-	case string(ConnectionAuthTypeUsernamePassword):
-		b = &UsernamePasswordAuthTypeConnectionProperties{}
-	case string(ConnectionAuthTypeNone):
-		b = &NoneAuthTypeConnectionProperties{}
-	case string(ConnectionAuthTypeSAS):
-		b = &SASAuthTypeConnectionProperties{}
-	case string(ConnectionAuthTypeAccountKey):
-		b = &AccountKeyAuthTypeConnectionProperties{}
-	case string(ConnectionAuthTypeServicePrincipal):
-		b = &ServicePrincipalAuthTypeConnectionProperties{}
-	case string(ConnectionAuthTypeAccessKey):
-		b = &AccessKeyAuthTypeConnectionProperties{}
-	case string(ConnectionAuthTypeAPIKey):
-		b = &APIKeyAuthConnectionProperties{}
-	case string(ConnectionAuthTypeCustomKeys):
-		b = &CustomKeysConnectionProperties{}
-	case string(ConnectionAuthTypeOAuth2):
-		b = &OAuth2AuthTypeConnectionProperties{}
 	case string(ConnectionAuthTypeAAD):
 		b = &AADAuthTypeConnectionProperties{}
+	case string(ConnectionAuthTypeAPIKey):
+		b = &APIKeyAuthConnectionProperties{}
+	case string(ConnectionAuthTypeAccessKey):
+		b = &AccessKeyAuthTypeConnectionProperties{}
+	case string(ConnectionAuthTypeAccountKey):
+		b = &AccountKeyAuthTypeConnectionProperties{}
+	case string(ConnectionAuthTypeCustomKeys):
+		b = &CustomKeysConnectionProperties{}
+	case string(ConnectionAuthTypeManagedIdentity):
+		b = &ManagedIdentityAuthTypeConnectionProperties{}
+	case string(ConnectionAuthTypeNone):
+		b = &NoneAuthTypeConnectionProperties{}
+	case string(ConnectionAuthTypeOAuth2):
+		b = &OAuth2AuthTypeConnectionProperties{}
+	case string(ConnectionAuthTypePAT):
+		b = &PATAuthTypeConnectionProperties{}
+	case string(ConnectionAuthTypeSAS):
+		b = &SASAuthTypeConnectionProperties{}
+	case string(ConnectionAuthTypeServicePrincipal):
+		b = &ServicePrincipalAuthTypeConnectionProperties{}
+	case string(ConnectionAuthTypeUsernamePassword):
+		b = &UsernamePasswordAuthTypeConnectionProperties{}
 	default:
 		b = &ConnectionPropertiesV2{}
 	}

--- a/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_polymorphic_helpers.go
+++ b/packages/typespec-go/test/local/armcontainerorchestratorruntime/zz_polymorphic_helpers.go
@@ -16,14 +16,14 @@ func unmarshalStorageClassTypePropertiesClassification(rawMsg json.RawMessage) (
 	}
 	var b StorageClassTypePropertiesClassification
 	switch m["type"] {
-	case string(SCTypeNative):
-		b = &NativeStorageClassTypeProperties{}
-	case string(SCTypeRWX):
-		b = &RwxStorageClassTypeProperties{}
 	case string(SCTypeBlob):
 		b = &BlobStorageClassTypeProperties{}
 	case string(SCTypeNFS):
 		b = &NfsStorageClassTypeProperties{}
+	case string(SCTypeNative):
+		b = &NativeStorageClassTypeProperties{}
+	case string(SCTypeRWX):
+		b = &RwxStorageClassTypeProperties{}
 	case string(SCTypeSMB):
 		b = &SmbStorageClassTypeProperties{}
 	default:

--- a/packages/typespec-go/test/local/armdevopsinfrastructure/zz_polymorphic_helpers.go
+++ b/packages/typespec-go/test/local/armdevopsinfrastructure/zz_polymorphic_helpers.go
@@ -83,10 +83,10 @@ func unmarshalResourcePredictionsProfileClassification(rawMsg json.RawMessage) (
 	}
 	var b ResourcePredictionsProfileClassification
 	switch m["kind"] {
-	case string(ResourcePredictionsProfileTypeManual):
-		b = &ManualResourcePredictionsProfile{}
 	case string(ResourcePredictionsProfileTypeAutomatic):
 		b = &AutomaticResourcePredictionsProfile{}
+	case string(ResourcePredictionsProfileTypeManual):
+		b = &ManualResourcePredictionsProfile{}
 	default:
 		b = &ResourcePredictionsProfile{}
 	}


### PR DESCRIPTION
The value for content type can either be a literal or a parameter; this is now accurately reflected in the code model.
Added a generic type param to Literal so its underlying type can be narrowed where applicable.  This allows us to model the content type as a string literal.
Changed the Literal's value from any to unknown which forces stricter type checking when reading the value.  This uncovered a bug when sorting discriminator values that are ConstantValues.  It also allowed us to remove some lint suppressions due to unsafe use of any.
Consolidated some duplicate code for creating String instances.