### PR TITLE
Improved handling of Content-Type parameters

### DIFF
--- a/packages/autorest.go/test/autorest/mediatypesgroup/zz_mediatypes_client.go
+++ b/packages/autorest.go/test/autorest/mediatypesgroup/zz_mediatypes_client.go
@@ -57,7 +57,6 @@ func (client *MediaTypesClient) analyzeBodyCreateRequest(ctx context.Context, co
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	req.Raw().Header["Content-Type"] = []string{string(contentType)}
 	if options != nil && options.Input != nil {
 		if err := req.SetBody(options.Input, string(contentType)); err != nil {
 			return nil, err
@@ -110,7 +109,6 @@ func (client *MediaTypesClient) analyzeBodyNoAcceptHeaderCreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["Content-Type"] = []string{string(contentType)}
 	if options != nil && options.Input != nil {
 		if err := req.SetBody(options.Input, string(contentType)); err != nil {
 			return nil, err
@@ -252,7 +250,6 @@ func (client *MediaTypesClient) binaryBodyWithThreeContentTypesCreateRequest(ctx
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"text/plain"}
-	req.Raw().Header["Content-Type"] = []string{string(contentType)}
 	if err := req.SetBody(message, string(contentType)); err != nil {
 		return nil, err
 	}
@@ -308,7 +305,6 @@ func (client *MediaTypesClient) binaryBodyWithTwoContentTypesCreateRequest(ctx c
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"text/plain"}
-	req.Raw().Header["Content-Type"] = []string{string(contentType)}
 	if err := req.SetBody(message, string(contentType)); err != nil {
 		return nil, err
 	}
@@ -582,7 +578,6 @@ func (client *MediaTypesClient) putTextAndJSONBodyCreateRequest(ctx context.Cont
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"text/plain"}
-	req.Raw().Header["Content-Type"] = []string{string(contentType)}
 	body := streaming.NopCloser(strings.NewReader(message))
 	if err := req.SetBody(body, string(contentType)); err != nil {
 		return nil, err

--- a/packages/autorest.go/test/autorest/mediatypesgroupwithnormailzedoperationname/zz_mediatypes_client.go
+++ b/packages/autorest.go/test/autorest/mediatypesgroupwithnormailzedoperationname/zz_mediatypes_client.go
@@ -150,7 +150,6 @@ func (client *MediaTypesClient) analyzeBodyNoAcceptHeaderWithBinaryCreateRequest
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["Content-Type"] = []string{string(contentType)}
 	if options != nil && options.Input != nil {
 		if err := req.SetBody(options.Input, string(contentType)); err != nil {
 			return nil, err
@@ -195,7 +194,6 @@ func (client *MediaTypesClient) analyzeBodyWithBinaryCreateRequest(ctx context.C
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	req.Raw().Header["Content-Type"] = []string{string(contentType)}
 	if options != nil && options.Input != nil {
 		if err := req.SetBody(options.Input, string(contentType)); err != nil {
 			return nil, err
@@ -252,7 +250,6 @@ func (client *MediaTypesClient) binaryBodyWithThreeContentTypesWithBinaryCreateR
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"text/plain"}
-	req.Raw().Header["Content-Type"] = []string{string(contentType)}
 	if err := req.SetBody(message, string(contentType)); err != nil {
 		return nil, err
 	}
@@ -308,7 +305,6 @@ func (client *MediaTypesClient) binaryBodyWithTwoContentTypesWithBinaryCreateReq
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"text/plain"}
-	req.Raw().Header["Content-Type"] = []string{string(contentType)}
 	if err := req.SetBody(message, string(contentType)); err != nil {
 		return nil, err
 	}
@@ -583,7 +579,6 @@ func (client *MediaTypesClient) putTextAndJSONBodyWithTextCreateRequest(ctx cont
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"text/plain"}
-	req.Raw().Header["Content-Type"] = []string{string(contentType)}
 	body := streaming.NopCloser(strings.NewReader(message))
 	if err := req.SetBody(body, string(contentType)); err != nil {
 		return nil, err

--- a/packages/autorest.go/test/storage/azblob/zz_container_client.go
+++ b/packages/autorest.go/test/storage/azblob/zz_container_client.go
@@ -1726,7 +1726,6 @@ func (client *ContainerClient) submitBatchCreateRequest(ctx context.Context, con
 	runtime.SkipBodyDownload(req)
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	req.Raw().Header["Content-Length"] = []string{strconv.FormatInt(contentLength, 10)}
-	req.Raw().Header["Content-Type"] = []string{multipartContentType}
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}

--- a/packages/autorest.go/test/storage/azblob/zz_service_client.go
+++ b/packages/autorest.go/test/storage/azblob/zz_service_client.go
@@ -584,7 +584,6 @@ func (client *ServiceClient) submitBatchCreateRequest(ctx context.Context, comp 
 	runtime.SkipBodyDownload(req)
 	req.Raw().Header["Accept"] = []string{"application/xml"}
 	req.Raw().Header["Content-Length"] = []string{strconv.FormatInt(contentLength, 10)}
-	req.Raw().Header["Content-Type"] = []string{multipartContentType}
 	if options != nil && options.RequestID != nil {
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.RequestID}
 	}

--- a/packages/codegen.go/src/core/operations.ts
+++ b/packages/codegen.go/src/core/operations.ts
@@ -1252,9 +1252,18 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
   for (const param of methodParamGroups.headerParams.sort((a: go.HeaderParameter, b: go.HeaderParameter) => {
     return helpers.sortAscending(a.headerName, b.headerName);
   })) {
-    if (param.headerName.match(/^content-type$/)) {
+    if (param.headerName.match(/^content-type$/i)) {
       // canonicalize content-type as req.SetBody checks for it via its canonicalized name :(
       param.headerName = 'Content-Type';
+
+      // if the content-type is from a param, then the param will be passed
+      // explicitly to runtime.SetBody() so don't emit code to set it inline
+      if (go.isClientSideDefault(param.style)) {
+        text += emitClientSideDefault(param as go.HeaderScalarParameter, param.style, () => '', imports, indent);
+        continue;
+      } else if (param.style === 'required') {
+        continue;
+      }
     }
 
     if (param.headerName === 'Content-Type' && param.style === 'literal') {
@@ -1308,6 +1317,9 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
           // find the param
           for (const param of method.parameters) {
             if (param.kind === 'headerScalarParam' && param.name === src.name) {
+              if (go.isClientSideDefault(param.style)) {
+                return getClientSideDefaultVarName(param);
+              }
               let paramName = helpers.getParamName(param);
               if (param.type.kind === 'constant') {
                 paramName = `string(${paramName})`;
@@ -1524,6 +1536,16 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
   return text;
 }
 
+/**
+ * returns the var name to use for a param's client-side default value
+ *
+ * @param param the param for which to name the var
+ * @returns the var name
+ */
+function getClientSideDefaultVarName(param: go.HeaderCollectionParameter | go.HeaderScalarParameter | go.QueryParameter): string {
+  return naming.uncapitalize(param.name) + 'Default';
+}
+
 function emitClientSideDefault(
   param: go.HeaderCollectionParameter | go.HeaderScalarParameter | go.QueryParameter,
   csd: go.ClientSideDefault,
@@ -1531,7 +1553,7 @@ function emitClientSideDefault(
   imports: ImportManager,
   indent: helpers.Indentation,
 ): string {
-  const defaultVar = naming.uncapitalize(param.name) + 'Default';
+  const defaultVar = getClientSideDefaultVarName(param);
   let text = `${indent.get()}${defaultVar} := ${helpers.formatLiteralValue(csd.defaultValue, true)}\n`;
   text += `${indent.get()}if options != nil && options.${naming.capitalize(param.name)} != nil {\n`;
   text += `${indent.push().get()}${defaultVar} = *options.${naming.capitalize(param.name)}\n`;
@@ -1549,7 +1571,13 @@ function emitClientSideDefault(
       break;
   }
 
-  text += setterFormat(`"${serializedName}"`, helpers.formatValue(defaultVar, param.type, imports)) + '\n';
+  const setterFormatText = setterFormat(`"${serializedName}"`, helpers.formatValue(defaultVar, param.type, imports));
+  text += setterFormatText;
+  // setterFormat can return the empty string in some cases.
+  // if it does, there's no need for an extra new-line char.
+  if (setterFormatText.length > 0) {
+    text += '\n';
+  }
   return text;
 }
 

--- a/packages/codegen.go/src/core/operations.ts
+++ b/packages/codegen.go/src/core/operations.ts
@@ -1256,13 +1256,17 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
       // canonicalize content-type as req.SetBody checks for it via its canonicalized name :(
       param.headerName = 'Content-Type';
 
-      // if the content-type is from a param, then the param will be passed
-      // explicitly to runtime.SetBody() so don't emit code to set it inline
-      if (go.isClientSideDefault(param.style)) {
-        text += emitClientSideDefault(param as go.HeaderScalarParameter, param.style, () => '', imports, indent);
-        continue;
-      } else if (param.style === 'required') {
-        continue;
+      // there's a corner case where we have a content-type param with no body
+      // param. for this case we still need to set the header inline.
+      if (methodParamGroups.bodyParam) {
+        // if the content-type is from a param, then the param will be passed
+        // explicitly to runtime.SetBody() so don't emit code to set it inline
+        if (go.isClientSideDefault(param.style)) {
+          text += emitClientSideDefault(param as go.HeaderScalarParameter, param.style, () => '', imports, indent);
+          continue;
+        } else if (param.style === 'required') {
+          continue;
+        }
       }
     }
 

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -666,6 +666,33 @@ export class ClientAdapter {
 
     const paramMapping = this.adaptMethodParameters(sdkMethod, method);
 
+    // check if the method takes a binary body with an explicit content-type param.
+    // if it does, then we need to fix up the body param to reference it. we must
+    // do this after adapting all of the method parameters.
+    const binaryBodyParam = method.parameters.find((param) => param.kind === 'bodyParam' && param.bodyFormat === 'binary');
+    const contentTypeParam = method.parameters.find((param) => param.kind === 'headerScalarParam' && param.headerName.match(/^content-type$/i) && param.style !== 'literal');
+    if (binaryBodyParam && contentTypeParam) {
+      // note that when content-type is a param, the defaultContentType on
+      // the body param will be a '*/*' literal. we want to replace that
+      // with the discrete param. if the param is optional, then we'll treat
+      // it as a client-side default.
+      const bodyParam = <go.BodyParameter>binaryBodyParam;
+      switch (contentTypeParam.style) {
+        case 'optional':
+          // convert the literal to a client-side default
+          contentTypeParam.style = new go.ClientSideDefault(bodyParam.contentType as go.Literal);
+          bodyParam.contentType = new go.ParameterRef(contentTypeParam.name);
+          break;
+        case 'required':
+          bodyParam.contentType = new go.ParameterRef(contentTypeParam.name);
+          break;
+        default: {
+          const style = go.isClientSideDefault(contentTypeParam.style) ? 'client-side default' : contentTypeParam.style;
+          throw new AdapterError('UnsupportedTsp', `unexpected content-type style ${style}`, sdkMethod.__raw?.node);
+        }
+      }
+    }
+
     // we must do this after adapting method params as it can add optional params
     this.ta.getPkg().paramGroups.push(this.adaptParameterGroup(method.optionalParamsGroup));
 
@@ -1605,6 +1632,10 @@ export class ClientAdapter {
           for (const param of example.parameters) {
             if (param.parameter.isApiVersionParam && param.parameter.clientDefaultValue) {
               // skip the api-version param as it's not a formal parameter
+              continue;
+            } else if (param.parameter.type.kind === 'constant') {
+              // if the param's type is a constant then it's embedded
+              // in the code and not a formal parameter so skip it
               continue;
             }
             const goParams = paramMapping.get(param.parameter);

--- a/packages/typespec-go/test/local/azregressions/fake/zz_internal.go
+++ b/packages/typespec-go/test/local/azregressions/fake/zz_internal.go
@@ -22,6 +22,14 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
+func getHeaderValue(h http.Header, k string) string {
+	v := h[k]
+	if len(v) == 0 {
+		return ""
+	}
+	return v[0]
+}
+
 func getOptional[T any](v T) *T {
 	if reflect.ValueOf(v).IsZero() {
 		return nil

--- a/packages/typespec-go/test/local/azregressions/fake/zz_server.go
+++ b/packages/typespec-go/test/local/azregressions/fake/zz_server.go
@@ -24,6 +24,10 @@ import (
 
 // Server is a fake server for instances of the azregressions.Client type.
 type Server struct {
+	// BinaryBodyWithContentType is the fake for method Client.BinaryBodyWithContentType
+	// HTTP status codes to indicate success: http.StatusNoContent
+	BinaryBodyWithContentType func(ctx context.Context, payload io.ReadSeekCloser, contentType string, options *azregressions.ClientBinaryBodyWithContentTypeOptions) (resp azfake.Responder[azregressions.ClientBinaryBodyWithContentTypeResponse], errResp azfake.ErrorResponder)
+
 	// BinaryResponseWithXMLContentType is the fake for method Client.BinaryResponseWithXMLContentType
 	// HTTP status codes to indicate success: http.StatusOK
 	BinaryResponseWithXMLContentType func(ctx context.Context, options *azregressions.ClientBinaryResponseWithXMLContentTypeOptions) (resp azfake.Responder[azregressions.ClientBinaryResponseWithXMLContentTypeResponse], errResp azfake.ErrorResponder)
@@ -71,6 +75,10 @@ type Server struct {
 	// OptionalBinaryBody is the fake for method Client.OptionalBinaryBody
 	// HTTP status codes to indicate success: http.StatusNoContent
 	OptionalBinaryBody func(ctx context.Context, options *azregressions.ClientOptionalBinaryBodyOptions) (resp azfake.Responder[azregressions.ClientOptionalBinaryBodyResponse], errResp azfake.ErrorResponder)
+
+	// OptionalBinaryBodyWithContentType is the fake for method Client.OptionalBinaryBodyWithContentType
+	// HTTP status codes to indicate success: http.StatusNoContent
+	OptionalBinaryBodyWithContentType func(ctx context.Context, options *azregressions.ClientOptionalBinaryBodyWithContentTypeOptions) (resp azfake.Responder[azregressions.ClientOptionalBinaryBodyWithContentTypeResponse], errResp azfake.ErrorResponder)
 
 	// OptionalBodyPost is the fake for method Client.OptionalBodyPost
 	// HTTP status codes to indicate success: http.StatusNoContent
@@ -127,6 +135,8 @@ func (s *ServerTransport) dispatchToMethodFake(req *http.Request, method string)
 		}
 		if !intercepted {
 			switch method {
+			case "Client.BinaryBodyWithContentType":
+				res.resp, res.err = s.dispatchBinaryBodyWithContentType(req)
 			case "Client.BinaryResponseWithXMLContentType":
 				res.resp, res.err = s.dispatchBinaryResponseWithXMLContentType(req)
 			case "Client.DoubleDecode":
@@ -151,6 +161,8 @@ func (s *ServerTransport) dispatchToMethodFake(req *http.Request, method string)
 				res.resp, res.err = s.dispatchGetXMLTwo(req)
 			case "Client.OptionalBinaryBody":
 				res.resp, res.err = s.dispatchOptionalBinaryBody(req)
+			case "Client.OptionalBinaryBodyWithContentType":
+				res.resp, res.err = s.dispatchOptionalBinaryBodyWithContentType(req)
 			case "Client.OptionalBodyPost":
 				res.resp, res.err = s.dispatchOptionalBodyPost(req)
 			case "Client.SpreadWithModel":
@@ -175,6 +187,25 @@ func (s *ServerTransport) dispatchToMethodFake(req *http.Request, method string)
 	case res := <-resultChan:
 		return res.resp, res.err
 	}
+}
+
+func (s *ServerTransport) dispatchBinaryBodyWithContentType(req *http.Request) (*http.Response, error) {
+	if s.srv.BinaryBodyWithContentType == nil {
+		return nil, &nonRetriableError{errors.New("fake for method BinaryBodyWithContentType not implemented")}
+	}
+	respr, errRespr := s.srv.BinaryBodyWithContentType(req.Context(), req.Body.(io.ReadSeekCloser), getHeaderValue(req.Header, "Content-Type"), nil)
+	if respErr := server.GetError(errRespr, req); respErr != nil {
+		return nil, respErr
+	}
+	respContent := server.GetResponseContent(respr)
+	if !slices.Contains([]int{http.StatusNoContent}, respContent.HTTPStatus) {
+		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusNoContent", respContent.HTTPStatus)}
+	}
+	resp, err := server.NewResponse(respContent, req, nil)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func (s *ServerTransport) dispatchBinaryResponseWithXMLContentType(req *http.Request) (*http.Response, error) {
@@ -452,6 +483,33 @@ func (s *ServerTransport) dispatchOptionalBinaryBody(req *http.Request) (*http.R
 		}
 	}
 	respr, errRespr := s.srv.OptionalBinaryBody(req.Context(), options)
+	if respErr := server.GetError(errRespr, req); respErr != nil {
+		return nil, respErr
+	}
+	respContent := server.GetResponseContent(respr)
+	if !slices.Contains([]int{http.StatusNoContent}, respContent.HTTPStatus) {
+		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusNoContent", respContent.HTTPStatus)}
+	}
+	resp, err := server.NewResponse(respContent, req, nil)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (s *ServerTransport) dispatchOptionalBinaryBodyWithContentType(req *http.Request) (*http.Response, error) {
+	if s.srv.OptionalBinaryBodyWithContentType == nil {
+		return nil, &nonRetriableError{errors.New("fake for method OptionalBinaryBodyWithContentType not implemented")}
+	}
+	contentTypeParam := getOptional(getHeaderValue(req.Header, "Content-Type"))
+	var options *azregressions.ClientOptionalBinaryBodyWithContentTypeOptions
+	if req.Body != nil || contentTypeParam != nil {
+		options = &azregressions.ClientOptionalBinaryBodyWithContentTypeOptions{
+			Payload:     req.Body.(io.ReadSeekCloser),
+			ContentType: contentTypeParam,
+		}
+	}
+	respr, errRespr := s.srv.OptionalBinaryBodyWithContentType(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/typespec-go/test/local/azregressions/zz_client.go
+++ b/packages/typespec-go/test/local/azregressions/zz_client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -45,6 +46,44 @@ func NewClientWithNoCredential(endpoint string, options *ClientOptions) (*Client
 		internal: cl,
 	}
 	return client, nil
+}
+
+// BinaryBodyWithContentType - required contentType parameter is passed to req.SetBody()
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ClientBinaryBodyWithContentTypeOptions contains the optional parameters for the Client.BinaryBodyWithContentType
+//     method.
+func (client *Client) BinaryBodyWithContentType(ctx context.Context, payload io.ReadSeekCloser, contentType string, options *ClientBinaryBodyWithContentTypeOptions) (ClientBinaryBodyWithContentTypeResponse, error) {
+	var err error
+	const operationName = "Client.BinaryBodyWithContentType"
+	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
+	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
+	req, err := client.binaryBodyWithContentTypeCreateRequest(ctx, payload, contentType, options)
+	if err != nil {
+		return ClientBinaryBodyWithContentTypeResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return ClientBinaryBodyWithContentTypeResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
+		err = runtime.NewResponseError(httpResp)
+		return ClientBinaryBodyWithContentTypeResponse{}, err
+	}
+	return ClientBinaryBodyWithContentTypeResponse{}, nil
+}
+
+// binaryBodyWithContentTypeCreateRequest creates the BinaryBodyWithContentType request.
+func (client *Client) binaryBodyWithContentTypeCreateRequest(ctx context.Context, payload io.ReadSeekCloser, contentType string, _ *ClientBinaryBodyWithContentTypeOptions) (*policy.Request, error) {
+	urlPath := "/binary-payload-with-content-type"
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	if err := req.SetBody(payload, contentType); err != nil {
+		return nil, err
+	}
+	return req, nil
 }
 
 // BinaryResponseWithXMLContentType -
@@ -598,6 +637,51 @@ func (client *Client) optionalBinaryBodyCreateRequest(ctx context.Context, optio
 	if options != nil && options.Payload != nil {
 		req.Raw().Header["Content-Type"] = []string{"application/octet-stream"}
 		if err := req.SetBody(options.Payload, "application/octet-stream"); err != nil {
+			return nil, err
+		}
+		return req, nil
+	}
+	return req, nil
+}
+
+// OptionalBinaryBodyWithContentType - optional contentType parameter is passed to req.SetBody() IFF body is not nil
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ClientOptionalBinaryBodyWithContentTypeOptions contains the optional parameters for the Client.OptionalBinaryBodyWithContentType
+//     method.
+func (client *Client) OptionalBinaryBodyWithContentType(ctx context.Context, options *ClientOptionalBinaryBodyWithContentTypeOptions) (ClientOptionalBinaryBodyWithContentTypeResponse, error) {
+	var err error
+	const operationName = "Client.OptionalBinaryBodyWithContentType"
+	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
+	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
+	req, err := client.optionalBinaryBodyWithContentTypeCreateRequest(ctx, options)
+	if err != nil {
+		return ClientOptionalBinaryBodyWithContentTypeResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return ClientOptionalBinaryBodyWithContentTypeResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
+		err = runtime.NewResponseError(httpResp)
+		return ClientOptionalBinaryBodyWithContentTypeResponse{}, err
+	}
+	return ClientOptionalBinaryBodyWithContentTypeResponse{}, nil
+}
+
+// optionalBinaryBodyWithContentTypeCreateRequest creates the OptionalBinaryBodyWithContentType request.
+func (client *Client) optionalBinaryBodyWithContentTypeCreateRequest(ctx context.Context, options *ClientOptionalBinaryBodyWithContentTypeOptions) (*policy.Request, error) {
+	urlPath := "/optional-binary-payload-with-content-type"
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	contentTypeDefault := "*/*"
+	if options != nil && options.ContentType != nil {
+		contentTypeDefault = *options.ContentType
+	}
+	if options != nil && options.Payload != nil {
+		if err := req.SetBody(options.Payload, contentTypeDefault); err != nil {
 			return nil, err
 		}
 		return req, nil

--- a/packages/typespec-go/test/local/azregressions/zz_options.go
+++ b/packages/typespec-go/test/local/azregressions/zz_options.go
@@ -6,6 +6,11 @@ package azregressions
 
 import "io"
 
+// ClientBinaryBodyWithContentTypeOptions contains the optional parameters for the Client.BinaryBodyWithContentType method.
+type ClientBinaryBodyWithContentTypeOptions struct {
+	// placeholder for future optional parameters
+}
+
 // ClientBinaryResponseWithXMLContentTypeOptions contains the optional parameters for the Client.BinaryResponseWithXMLContentType
 // method.
 type ClientBinaryResponseWithXMLContentTypeOptions struct {
@@ -65,6 +70,13 @@ type ClientGetXMLTwoOptions struct {
 // ClientOptionalBinaryBodyOptions contains the optional parameters for the Client.OptionalBinaryBody method.
 type ClientOptionalBinaryBodyOptions struct {
 	Payload io.ReadSeekCloser
+}
+
+// ClientOptionalBinaryBodyWithContentTypeOptions contains the optional parameters for the Client.OptionalBinaryBodyWithContentType
+// method.
+type ClientOptionalBinaryBodyWithContentTypeOptions struct {
+	ContentType *string
+	Payload     io.ReadSeekCloser
 }
 
 // ClientOptionalBodyPostOptions contains the optional parameters for the Client.OptionalBodyPost method.

--- a/packages/typespec-go/test/local/azregressions/zz_responses.go
+++ b/packages/typespec-go/test/local/azregressions/zz_responses.go
@@ -6,6 +6,11 @@ package azregressions
 
 import "io"
 
+// ClientBinaryBodyWithContentTypeResponse contains the response from method Client.BinaryBodyWithContentType.
+type ClientBinaryBodyWithContentTypeResponse struct {
+	// placeholder for future response values
+}
+
 // ClientBinaryResponseWithXMLContentTypeResponse contains the response from method Client.BinaryResponseWithXMLContentType.
 type ClientBinaryResponseWithXMLContentTypeResponse struct {
 	// Body contains the streaming response.
@@ -72,6 +77,11 @@ type ClientGetXMLTwoResponse struct {
 
 // ClientOptionalBinaryBodyResponse contains the response from method Client.OptionalBinaryBody.
 type ClientOptionalBinaryBodyResponse struct {
+	// placeholder for future response values
+}
+
+// ClientOptionalBinaryBodyWithContentTypeResponse contains the response from method Client.OptionalBinaryBodyWithContentType.
+type ClientOptionalBinaryBodyWithContentTypeResponse struct {
 	// placeholder for future response values
 }
 

--- a/packages/typespec-go/test/tsp/Regressions/main.tsp
+++ b/packages/typespec-go/test/tsp/Regressions/main.tsp
@@ -217,3 +217,15 @@ op getInteger(): {
   @header contentType: "text/plain; charset=utf-8";
   @body body: int64;
 };
+
+/**
+ * optional contentType parameter is passed to req.SetBody() IFF body is not nil
+ */
+@route("/optional-binary-payload-with-content-type")
+op optionalBinaryBodyWithContentType(@body payload?: bytes, @header("content-type") contentType?: string): void;
+
+/**
+ * required contentType parameter is passed to req.SetBody()
+ */
+@route("/binary-payload-with-content-type")
+op binaryBodyWithContentType(@body payload: bytes, @header("content-type") contentType: string): void;


### PR DESCRIPTION
For a binary body parameter with a parameterized content type, pass the content type param to runtime.SetBody().