### PR TITLE
Improved multipart body param detection

### DIFF
--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## 0.11.2 (unreleased)
+
+### Bug Fixes
+
+* Operations with a binary body and parameterized `Content-Type` correctly utilize the parameterized value.
+* Improved detection for operations that consume `multipart` content.
+
 ## 0.11.1 (2026-04-29)
 
 ### Bugs Fixed

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.11.2 (unreleased)
 
-### Bug Fixes
+### Bugs Fixed
 
 * Operations with a binary body and parameterized `Content-Type` correctly utilize the parameterized value.
 * Improved detection for operations that consume `multipart` content.

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-go",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "TypeSpec emitter for Go SDKs",
   "type": "module",
   "packageManager": "pnpm@10.33.2",

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -816,8 +816,8 @@ export class ClientAdapter {
             break;
           }
           case 'binary':
-            if (isMultipartBody(opParam)) {
-              adaptedParam = this.adaptMultipartFormParameter(param, paramStyle, byVal);
+            if (isMultipartBodyType(opParam.type)) {
+              adaptedParam = this.adaptMultipartFormParameter(param.name, opParam.type, paramStyle, byVal);
             } else {
               const contentTypeLiteral = this.ta.getLiteral(this.ta.getStringType(), opParam.defaultContentType);
               adaptedParam = new go.BodyParameter(paramName, contentType, contentTypeLiteral, this.ta.getReadSeekCloser(false), paramStyle, byVal);
@@ -1108,8 +1108,8 @@ export class ClientAdapter {
     let adaptedParam: go.MethodParameter;
     switch (opParam.kind) {
       case 'body':
-        if (isMultipartBody(opParam)) {
-          adaptedParam = this.adaptMultipartFormParameter(methodParam, paramStyle, byVal);
+        if (isMultipartBodyType(opParam.type)) {
+          adaptedParam = this.adaptMultipartFormParameter(methodParam.name, opParam.type, paramStyle, byVal);
         } else {
           const contentType = this.adaptContentType(opParam.defaultContentType);
           let bodyType = this.ta.getWireType(methodParam.type, false, true);
@@ -1207,13 +1207,8 @@ export class ClientAdapter {
    * for file parts with a fixed content type (e.g. HttpPart<File<"image/png">>),
    * uses a MultipartContent type with the content type baked in.
    */
-  private adaptMultipartFormParameter(param: tcgc.SdkMethodParameter | tcgc.SdkModelPropertyType, paramStyle: go.ParameterStyle, byVal: boolean): go.MultipartFormBodyParameter {
-    let paramName = param.name;
-    if (param.type.kind !== 'model') {
-      throw new AdapterError('InternalError', `unexpected kind ${param.type.kind}`, param.__raw?.node);
-    }
-
-    let paramType: tcgc.SdkType = param.type;
+  private adaptMultipartFormParameter(paramName: string, paramType: tcgc.SdkModelType, paramStyle: go.ParameterStyle, byVal: boolean): go.MultipartFormBodyParameter {
+    let paramAsSdkType: tcgc.SdkType = paramType;
     let multipartOptions: tcgc.MultipartOptions | undefined;
     if (paramType.isGeneratedName) {
       // tcgc wraps inline multipart params in a generated model with a single property.
@@ -1224,7 +1219,7 @@ export class ClientAdapter {
       const prop = paramType.properties[0];
       paramName = prop.name;
       multipartOptions = prop.serializationOptions.multipart;
-      paramType = prop.type;
+      paramAsSdkType = prop.type;
     }
 
     let type: go.WireType;
@@ -1232,11 +1227,11 @@ export class ClientAdapter {
     // non-file parts (e.g. HttpPart<{ @body body: float64; @header contentType: "text/plain" }>)
     // should retain their underlying type (e.g. float64).
     if (multipartOptions?.isFilePart && multipartOptions.contentType?.type.kind === 'constant' && multipartOptions.defaultContentTypes.length === 1) {
-      type = this.ta.getMultipartContent(paramType.kind === 'array', multipartOptions.defaultContentTypes[0]);
-    } else if (paramType.kind === 'bytes' && paramType.encode === 'bytes') {
+      type = this.ta.getMultipartContent(paramAsSdkType.kind === 'array', multipartOptions.defaultContentTypes[0]);
+    } else if (paramAsSdkType.kind === 'bytes' && paramAsSdkType.encode === 'bytes') {
       type = this.ta.getReadSeekCloser(false);
     } else {
-      type = this.ta.getWireType(paramType, true, true);
+      type = this.ta.getWireType(paramAsSdkType, true, true);
     }
 
     paramName = getEscapedReservedName(ensureNameCase(paramName, paramStyle === 'required'), 'Param');
@@ -1862,18 +1857,18 @@ type RespHeadersMapForPageable = Map<tcgc.SdkServiceResponseHeader, go.HeaderSca
  * @param body the body param to check
  * @returns true if body is multipart
  */
-function isMultipartBody(body: tcgc.SdkBodyParameter): boolean {
+function isMultipartBodyType(type: tcgc.SdkType): type is tcgc.SdkModelType {
   // multipart body params are always a model type.
   // note that it's legal for models to have zero
   // properties, so they would never be multipart.
-  if (body.type.kind !== 'model' || body.type.properties.length === 0) {
+  if (type.kind !== 'model' || type.properties.length === 0) {
     return false;
   }
 
   // check for multipart serialization options.
   // it's never just some of the properties, i.e.
   // either they all have it or none of them do
-  for (const prop of body.type.properties) {
+  for (const prop of type.properties) {
     if (!prop.serializationOptions.multipart) {
       return false;
     }

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -816,7 +816,7 @@ export class ClientAdapter {
             break;
           }
           case 'binary':
-            if (opParam.defaultContentType.match(/multipart/i)) {
+            if (isMultipartBody(opParam)) {
               adaptedParam = this.adaptMultipartFormParameter(param, paramStyle, byVal);
             } else {
               const contentTypeLiteral = this.ta.getLiteral(this.ta.getStringType(), opParam.defaultContentType);
@@ -1108,8 +1108,7 @@ export class ClientAdapter {
     let adaptedParam: go.MethodParameter;
     switch (opParam.kind) {
       case 'body':
-        // TODO: form data? (non-multipart)
-        if (opParam.defaultContentType.match(/multipart/i)) {
+        if (isMultipartBody(opParam)) {
           adaptedParam = this.adaptMultipartFormParameter(methodParam, paramStyle, byVal);
         } else {
           const contentType = this.adaptContentType(opParam.defaultContentType);
@@ -1856,3 +1855,28 @@ type ParamsMapForPageable = Map<tcgc.SdkMethodParameter, go.HeaderScalarParamete
  * this is used when creating certain pageable method strategies.
  */
 type RespHeadersMapForPageable = Map<tcgc.SdkServiceResponseHeader, go.HeaderScalarResponse>;
+
+/**
+ * returns true if the provided body parameter is multipart
+ *
+ * @param body the body param to check
+ * @returns true if body is multipart
+ */
+function isMultipartBody(body: tcgc.SdkBodyParameter): boolean {
+  // multipart body params are always a model type.
+  // note that it's legal for models to have zero
+  // properties, so they would never be multipart.
+  if (body.type.kind !== 'model' || body.type.properties.length === 0) {
+    return false;
+  }
+
+  // check for multipart serialization options.
+  // it's never just some of the properties, i.e.
+  // either they all have it or none of them do
+  for (const prop of body.type.properties) {
+    if (!prop.serializationOptions.multipart) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/typespec-go/test/local/azblob/zz_container_client.go
+++ b/packages/typespec-go/test/local/azblob/zz_container_client.go
@@ -1510,12 +1510,14 @@ func (client *ContainerClient) setMetadataHandleResponse(resp *http.Response) (C
 
 // SubmitBatch - The Batch operation allows multiple API calls to be embedded into a single HTTP request.
 // If the operation fails it returns an *azcore.ResponseError type.
+//   - contentType - Required. The value of this header must be multipart/mixed with a batch boundary. Example header value: multipart/mixed;
+//     boundary=batch_<GUID>
 //   - contentLength - The length of the request.
 //   - body - The body of the request.
 //   - options - ContainerClientSubmitBatchOptions contains the optional parameters for the ContainerClient.SubmitBatch method.
-func (client *ContainerClient) SubmitBatch(ctx context.Context, contentLength int64, body io.ReadSeekCloser, options *ContainerClientSubmitBatchOptions) (ContainerClientSubmitBatchResponse, error) {
+func (client *ContainerClient) SubmitBatch(ctx context.Context, contentType string, contentLength int64, body io.ReadSeekCloser, options *ContainerClientSubmitBatchOptions) (ContainerClientSubmitBatchResponse, error) {
 	var err error
-	req, err := client.submitBatchCreateRequest(ctx, contentLength, body, options)
+	req, err := client.submitBatchCreateRequest(ctx, contentType, contentLength, body, options)
 	if err != nil {
 		return ContainerClientSubmitBatchResponse{}, err
 	}
@@ -1532,7 +1534,7 @@ func (client *ContainerClient) SubmitBatch(ctx context.Context, contentLength in
 }
 
 // submitBatchCreateRequest creates the SubmitBatch request.
-func (client *ContainerClient) submitBatchCreateRequest(ctx context.Context, contentLength int64, body io.ReadSeekCloser, options *ContainerClientSubmitBatchOptions) (*policy.Request, error) {
+func (client *ContainerClient) submitBatchCreateRequest(ctx context.Context, contentType string, contentLength int64, body io.ReadSeekCloser, options *ContainerClientSubmitBatchOptions) (*policy.Request, error) {
 	urlPath := "?restype=container&comp=batch"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.url, urlPath))
 	if err != nil {
@@ -1550,9 +1552,7 @@ func (client *ContainerClient) submitBatchCreateRequest(ctx context.Context, con
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.ClientRequestID}
 	}
 	req.Raw().Header["x-ms-version"] = []string{defaultContainerClientVersion}
-	formData := map[string]any{}
-	formData["body"] = body
-	if err := runtime.SetMultipartFormData(req, formData); err != nil {
+	if err := req.SetBody(body, contentType); err != nil {
 		return nil, err
 	}
 	return req, nil

--- a/packages/typespec-go/test/local/azblob/zz_service_client.go
+++ b/packages/typespec-go/test/local/azblob/zz_service_client.go
@@ -563,12 +563,14 @@ func (client *ServiceClient) setPropertiesHandleResponse(resp *http.Response) (S
 
 // SubmitBatch - The Batch operation allows multiple API calls to be embedded into a single HTTP request.
 // If the operation fails it returns an *azcore.ResponseError type.
+//   - contentType - Required. The value of this header must be multipart/mixed with a batch boundary. Example header value: multipart/mixed;
+//     boundary=batch_<GUID>
 //   - contentLength - The length of the request.
 //   - body - The body of the request.
 //   - options - ServiceClientSubmitBatchOptions contains the optional parameters for the ServiceClient.SubmitBatch method.
-func (client *ServiceClient) SubmitBatch(ctx context.Context, contentLength int64, body io.ReadSeekCloser, options *ServiceClientSubmitBatchOptions) (ServiceClientSubmitBatchResponse, error) {
+func (client *ServiceClient) SubmitBatch(ctx context.Context, contentType string, contentLength int64, body io.ReadSeekCloser, options *ServiceClientSubmitBatchOptions) (ServiceClientSubmitBatchResponse, error) {
 	var err error
-	req, err := client.submitBatchCreateRequest(ctx, contentLength, body, options)
+	req, err := client.submitBatchCreateRequest(ctx, contentType, contentLength, body, options)
 	if err != nil {
 		return ServiceClientSubmitBatchResponse{}, err
 	}
@@ -585,7 +587,7 @@ func (client *ServiceClient) SubmitBatch(ctx context.Context, contentLength int6
 }
 
 // submitBatchCreateRequest creates the SubmitBatch request.
-func (client *ServiceClient) submitBatchCreateRequest(ctx context.Context, contentLength int64, body io.ReadSeekCloser, options *ServiceClientSubmitBatchOptions) (*policy.Request, error) {
+func (client *ServiceClient) submitBatchCreateRequest(ctx context.Context, contentType string, contentLength int64, body io.ReadSeekCloser, options *ServiceClientSubmitBatchOptions) (*policy.Request, error) {
 	urlPath := "?comp=batch"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.url, urlPath))
 	if err != nil {
@@ -603,9 +605,7 @@ func (client *ServiceClient) submitBatchCreateRequest(ctx context.Context, conte
 		req.Raw().Header["x-ms-client-request-id"] = []string{*options.ClientRequestID}
 	}
 	req.Raw().Header["x-ms-version"] = []string{defaultServiceClientVersion}
-	formData := map[string]any{}
-	formData["body"] = body
-	if err := runtime.SetMultipartFormData(req, formData); err != nil {
+	if err := req.SetBody(body, contentType); err != nil {
 		return nil, err
 	}
 	return req, nil

--- a/packages/typespec-go/test/tsp/Microsoft.BlobStorage/client.tsp
+++ b/packages/typespec-go/test/tsp/Microsoft.BlobStorage/client.tsp
@@ -603,7 +603,17 @@ model SignedIdentifiersGo is Array<SignedIdentifier>;
   "BlobClientDownloadResponseInternal",
   "go"
 );
-
+/** The multipart body parameter. */
+alias MultipartBodyParameterGo = {
+  /** The body of the request. */
+  @body
+  @encode("bytes")
+  body: bytes;
+};
+@@alternateType(MultipartBodyParameter.body,
+  MultipartBodyParameterGo.body,
+  "go"
+);
 @@clientName(QueryType, "QueryFormatType", "python");
 @@clientName(Storage.Blob.BlockBlob.uploadBlobFromUrl,
   "putBlobFromUrl",

--- a/packages/typespec-go/test/tsp/Microsoft.BlobStorage/routes.tsp
+++ b/packages/typespec-go/test/tsp/Microsoft.BlobStorage/routes.tsp
@@ -202,7 +202,7 @@ interface Service {
   submitBatch(
     /** Required. The value of this header must be multipart/mixed with a batch boundary. Example header value: multipart/mixed; boundary=batch_<GUID> */
     @header("Content-Type")
-    @alternateType(string, "javascript,csharp")
+    @alternateType(string, "javascript,csharp,go")
     contentType: "multipart/mixed",
 
     ...ApiVersionHeader,
@@ -447,7 +447,7 @@ interface Container {
   submitBatch(
     /** Required. The value of this header must be multipart/mixed with a batch boundary. Example header value: multipart/mixed; boundary=batch_<GUID> */
     @header("Content-Type")
-    @alternateType(string, "javascript")
+    @alternateType(string, "javascript,go")
     contentType: "multipart/mixed",
 
     ...ApiVersionHeader,


### PR DESCRIPTION
Inspect the body param's serialization data instead of matching on the defaultContentType which might not always be accurate. Updated storage's client.tsp to verify expected codegen changes.
Add changelog entry for db10ab8.