### PR TITLE
Fix incorrect XML tag for arrays

### DIFF
--- a/packages/autorest.go/.scripts/regeneration.js
+++ b/packages/autorest.go/.scripts/regeneration.js
@@ -108,7 +108,7 @@ for (const namespace in goMappings) {
 }
 
 const blobStorage = repoRoot + 'swagger/specification/storage/data-plane/Microsoft.BlobStorage/readme.md';
-generateFromReadme("azblob", blobStorage, 'package-2021-12', 'test/storage/azblob', '--inject-spans');
+generateFromReadme("azblob", blobStorage, 'package-2021-12', 'test/storage/azblob', '--inject-spans --stutter=dont');
 
 const network = repoRoot + 'swagger/specification/network/resource-manager/readme.md';
 generateFromReadme("armnetwork", network, 'package-2022-09', 'test/network/armnetwork', '--module=armnetwork --azure-arm=true --remove-unreferenced-types');

--- a/packages/autorest.go/CHANGELOG.md
+++ b/packages/autorest.go/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 4.0.0-preview.80 (2026-05-21)
+
+### Bugs Fixed
+
+* Fixed an issue where the wrong XML tag was emitted for certain types of arrays.
+
 ## 4.0.0-preview.79 (2026-05-14)
 
 ### Bugs Fixed

--- a/packages/autorest.go/package.json
+++ b/packages/autorest.go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/go",
-  "version": "4.0.0-preview.79",
+  "version": "4.0.0-preview.80",
   "description": "AutoRest Go Generator",
   "main": "dist/autorest.go/src/main.js",
   "type": "module",

--- a/packages/autorest.go/src/m4togocodemodel/types.ts
+++ b/packages/autorest.go/src/m4togocodemodel/types.ts
@@ -237,12 +237,12 @@ export function adaptModelField(prop: m4.Property, obj: m4.ObjectSchema, pkg: go
     }
   }
 
-  field.xml = adaptXMLInfo(prop.schema);
+  field.xml = adaptXMLInfo(prop.schema, prop.serializedName);
 
   return field;
 }
 
-export function adaptXMLInfo(obj: m4.Schema): go.XMLInfo | undefined {
+export function adaptXMLInfo(obj: m4.Schema, serializedName?: string): go.XMLInfo | undefined {
   const xmlInfo = new go.XMLInfo();
   let includeXMLField = false;
   if (obj.serialization?.xml?.name && obj.serialization.xml.name !== obj.language.go!.name) {
@@ -271,6 +271,12 @@ export function adaptXMLInfo(obj: m4.Schema): go.XMLInfo | undefined {
       includeXMLField = true;
     } else if (asArray.elementType.language.default.name !== asArray.elementType.language.go!.name) {
       // we can land here if the Go-specific type name was renamed to remove stuttering
+      xmlInfo.name = asArray.elementType.language.default.name;
+      includeXMLField = true;
+    } else if (serializedName && serializedName !== asArray.elementType.language.default.name) {
+      // the serializedName defaults to the property name in swagger which
+      // might not match the XML element type name. for XML arrays in Go,
+      // we need to use the element type name in the XML tag.
       xmlInfo.name = asArray.elementType.language.default.name;
       includeXMLField = true;
     }

--- a/packages/autorest.go/test/storage/azblob/models_serde_test.go
+++ b/packages/autorest.go/test/storage/azblob/models_serde_test.go
@@ -762,7 +762,7 @@ func TestTagsRoundTrip(t *testing.T) {
   </TagSet>
 </Tags>`
 
-	var tags Tags
+	var tags BlobTags
 	if err := xml.Unmarshal([]byte(xmlData), &tags); err != nil {
 		t.Fatal(err)
 	}
@@ -780,7 +780,7 @@ func TestTagsRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var tags2 Tags
+	var tags2 BlobTags
 	if err := xml.Unmarshal(out, &tags2); err != nil {
 		t.Fatal(err)
 	}
@@ -928,7 +928,7 @@ func TestPropertiesInternalTimeFieldsRoundTrip(t *testing.T) {
   <LeaseState>available</LeaseState>
 </Properties>`
 
-	var props PropertiesInternal
+	var props BlobPropertiesInternal
 	if err := xml.Unmarshal([]byte(xmlData), &props); err != nil {
 		t.Fatal(err)
 	}
@@ -955,7 +955,7 @@ func TestPropertiesInternalTimeFieldsRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var props2 PropertiesInternal
+	var props2 BlobPropertiesInternal
 	if err := xml.Unmarshal(out, &props2); err != nil {
 		t.Fatal(err)
 	}

--- a/packages/autorest.go/test/storage/azblob/zz_appendblob_client.go
+++ b/packages/autorest.go/test/storage/azblob/zz_appendblob_client.go
@@ -42,8 +42,8 @@ type AppendBlobClient struct {
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
 //   - AppendPositionAccessConditions - AppendPositionAccessConditions contains a group of parameters for the AppendBlobClient.AppendBlock
 //     method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
 func (client *AppendBlobClient) AppendBlock(ctx context.Context, containerName string, blob string, comp Enum35, contentLength int64, body io.ReadSeekCloser, options *AppendBlobClientAppendBlockOptions, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (AppendBlobClientAppendBlockResponse, error) {
 	var err error
@@ -221,13 +221,13 @@ func (client *AppendBlobClient) appendBlockHandleResponse(resp *http.Response) (
 //   - contentLength - The length of the request.
 //   - options - AppendBlobClientAppendBlockFromURLOptions contains the optional parameters for the AppendBlobClient.AppendBlockFromURL
 //     method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
 //   - AppendPositionAccessConditions - AppendPositionAccessConditions contains a group of parameters for the AppendBlobClient.AppendBlock
 //     method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the Client.StartCopyFromURL
+//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the BlobClient.StartCopyFromURL
 //     method.
 func (client *AppendBlobClient) AppendBlockFromURL(ctx context.Context, containerName string, blob string, comp Enum35, sourceURL string, contentLength int64, options *AppendBlobClientAppendBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (AppendBlobClientAppendBlockFromURLResponse, error) {
 	var err error
@@ -416,10 +416,10 @@ func (client *AppendBlobClient) appendBlockFromURLHandleResponse(resp *http.Resp
 //   - blob - The blob name.
 //   - contentLength - The length of the request.
 //   - options - AppendBlobClientCreateOptions contains the optional parameters for the AppendBlobClient.Create method.
-//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the Client.SetHTTPHeaders method.
+//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the BlobClient.SetHTTPHeaders method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
 func (client *AppendBlobClient) Create(ctx context.Context, containerName string, blob string, contentLength int64, options *AppendBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (AppendBlobClientCreateResponse, error) {
 	var err error

--- a/packages/autorest.go/test/storage/azblob/zz_blob_client.go
+++ b/packages/autorest.go/test/storage/azblob/zz_blob_client.go
@@ -21,9 +21,9 @@ import (
 	"time"
 )
 
-// Client contains the methods for the Blob group.
+// BlobClient contains the methods for the Blob group.
 // Don't use this type directly, use a constructor function instead.
-type Client struct {
+type BlobClient struct {
 	internal *azcore.Client
 	endpoint string
 	version  Enum2
@@ -37,30 +37,30 @@ type Client struct {
 //   - comp - comp
 //   - copyActionAbortConstant - Copy action.
 //   - copyID - The copy identifier provided in the x-ms-copy-id header of the original Copy Blob operation.
-//   - options - ClientAbortCopyFromURLOptions contains the optional parameters for the Client.AbortCopyFromURL method.
+//   - options - BlobClientAbortCopyFromURLOptions contains the optional parameters for the BlobClient.AbortCopyFromURL method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-func (client *Client) AbortCopyFromURL(ctx context.Context, containerName string, blob string, comp Enum27, copyActionAbortConstant Enum28, copyID string, options *ClientAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (ClientAbortCopyFromURLResponse, error) {
+func (client *BlobClient) AbortCopyFromURL(ctx context.Context, containerName string, blob string, comp Enum27, copyActionAbortConstant Enum28, copyID string, options *BlobClientAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (BlobClientAbortCopyFromURLResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.AbortCopyFromURL", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.AbortCopyFromURL", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.abortCopyFromURLCreateRequest(ctx, containerName, blob, comp, copyActionAbortConstant, copyID, options, leaseAccessConditions)
 	if err != nil {
-		return ClientAbortCopyFromURLResponse{}, err
+		return BlobClientAbortCopyFromURLResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientAbortCopyFromURLResponse{}, err
+		return BlobClientAbortCopyFromURLResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientAbortCopyFromURLResponse{}, err
+		return BlobClientAbortCopyFromURLResponse{}, err
 	}
 	resp, err := client.abortCopyFromURLHandleResponse(httpResp)
 	return resp, err
 }
 
 // abortCopyFromURLCreateRequest creates the AbortCopyFromURL request.
-func (client *Client) abortCopyFromURLCreateRequest(ctx context.Context, containerName string, blob string, comp Enum27, copyActionAbortConstant Enum28, copyID string, options *ClientAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) abortCopyFromURLCreateRequest(ctx context.Context, containerName string, blob string, comp Enum27, copyActionAbortConstant Enum28, copyID string, options *BlobClientAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -94,15 +94,15 @@ func (client *Client) abortCopyFromURLCreateRequest(ctx context.Context, contain
 }
 
 // abortCopyFromURLHandleResponse handles the AbortCopyFromURL response.
-func (client *Client) abortCopyFromURLHandleResponse(resp *http.Response) (ClientAbortCopyFromURLResponse, error) {
-	result := ClientAbortCopyFromURLResponse{}
+func (client *BlobClient) abortCopyFromURLHandleResponse(resp *http.Response) (BlobClientAbortCopyFromURLResponse, error) {
+	result := BlobClientAbortCopyFromURLResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientAbortCopyFromURLResponse{}, err
+			return BlobClientAbortCopyFromURLResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -120,30 +120,30 @@ func (client *Client) abortCopyFromURLHandleResponse(resp *http.Response) (Clien
 //   - containerName - The container name.
 //   - blob - The blob name.
 //   - comp - comp
-//   - options - ClientAcquireLeaseOptions contains the optional parameters for the Client.AcquireLease method.
+//   - options - BlobClientAcquireLeaseOptions contains the optional parameters for the BlobClient.AcquireLease method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-func (client *Client) AcquireLease(ctx context.Context, containerName string, blob string, comp Enum16, options *ClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientAcquireLeaseResponse, error) {
+func (client *BlobClient) AcquireLease(ctx context.Context, containerName string, blob string, comp Enum16, options *BlobClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobClientAcquireLeaseResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.AcquireLease", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.AcquireLease", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.acquireLeaseCreateRequest(ctx, containerName, blob, comp, options, modifiedAccessConditions)
 	if err != nil {
-		return ClientAcquireLeaseResponse{}, err
+		return BlobClientAcquireLeaseResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientAcquireLeaseResponse{}, err
+		return BlobClientAcquireLeaseResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusCreated) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientAcquireLeaseResponse{}, err
+		return BlobClientAcquireLeaseResponse{}, err
 	}
 	resp, err := client.acquireLeaseHandleResponse(httpResp)
 	return resp, err
 }
 
 // acquireLeaseCreateRequest creates the AcquireLease request.
-func (client *Client) acquireLeaseCreateRequest(ctx context.Context, containerName string, blob string, comp Enum16, options *ClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) acquireLeaseCreateRequest(ctx context.Context, containerName string, blob string, comp Enum16, options *BlobClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -194,15 +194,15 @@ func (client *Client) acquireLeaseCreateRequest(ctx context.Context, containerNa
 }
 
 // acquireLeaseHandleResponse handles the AcquireLease response.
-func (client *Client) acquireLeaseHandleResponse(resp *http.Response) (ClientAcquireLeaseResponse, error) {
-	result := ClientAcquireLeaseResponse{}
+func (client *BlobClient) acquireLeaseHandleResponse(resp *http.Response) (BlobClientAcquireLeaseResponse, error) {
+	result := BlobClientAcquireLeaseResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientAcquireLeaseResponse{}, err
+			return BlobClientAcquireLeaseResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -212,7 +212,7 @@ func (client *Client) acquireLeaseHandleResponse(resp *http.Response) (ClientAcq
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientAcquireLeaseResponse{}, err
+			return BlobClientAcquireLeaseResponse{}, err
 		}
 		result.LastModified = &lastModified
 	}
@@ -233,30 +233,30 @@ func (client *Client) acquireLeaseHandleResponse(resp *http.Response) (ClientAcq
 //   - containerName - The container name.
 //   - blob - The blob name.
 //   - comp - comp
-//   - options - ClientBreakLeaseOptions contains the optional parameters for the Client.BreakLease method.
+//   - options - BlobClientBreakLeaseOptions contains the optional parameters for the BlobClient.BreakLease method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-func (client *Client) BreakLease(ctx context.Context, containerName string, blob string, comp Enum16, options *ClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientBreakLeaseResponse, error) {
+func (client *BlobClient) BreakLease(ctx context.Context, containerName string, blob string, comp Enum16, options *BlobClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobClientBreakLeaseResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.BreakLease", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.BreakLease", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.breakLeaseCreateRequest(ctx, containerName, blob, comp, options, modifiedAccessConditions)
 	if err != nil {
-		return ClientBreakLeaseResponse{}, err
+		return BlobClientBreakLeaseResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientBreakLeaseResponse{}, err
+		return BlobClientBreakLeaseResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientBreakLeaseResponse{}, err
+		return BlobClientBreakLeaseResponse{}, err
 	}
 	resp, err := client.breakLeaseHandleResponse(httpResp)
 	return resp, err
 }
 
 // breakLeaseCreateRequest creates the BreakLease request.
-func (client *Client) breakLeaseCreateRequest(ctx context.Context, containerName string, blob string, comp Enum16, options *ClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) breakLeaseCreateRequest(ctx context.Context, containerName string, blob string, comp Enum16, options *BlobClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -304,15 +304,15 @@ func (client *Client) breakLeaseCreateRequest(ctx context.Context, containerName
 }
 
 // breakLeaseHandleResponse handles the BreakLease response.
-func (client *Client) breakLeaseHandleResponse(resp *http.Response) (ClientBreakLeaseResponse, error) {
-	result := ClientBreakLeaseResponse{}
+func (client *BlobClient) breakLeaseHandleResponse(resp *http.Response) (BlobClientBreakLeaseResponse, error) {
+	result := BlobClientBreakLeaseResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientBreakLeaseResponse{}, err
+			return BlobClientBreakLeaseResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -322,7 +322,7 @@ func (client *Client) breakLeaseHandleResponse(resp *http.Response) (ClientBreak
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientBreakLeaseResponse{}, err
+			return BlobClientBreakLeaseResponse{}, err
 		}
 		result.LastModified = &lastModified
 	}
@@ -330,7 +330,7 @@ func (client *Client) breakLeaseHandleResponse(resp *http.Response) (ClientBreak
 		leaseTime32, err := strconv.ParseInt(val, 10, 32)
 		leaseTime := int32(leaseTime32)
 		if err != nil {
-			return ClientBreakLeaseResponse{}, err
+			return BlobClientBreakLeaseResponse{}, err
 		}
 		result.LeaseTime = &leaseTime
 	}
@@ -352,30 +352,30 @@ func (client *Client) breakLeaseHandleResponse(resp *http.Response) (ClientBreak
 //   - proposedLeaseID - Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed
 //     lease ID is not in the correct format. See Guid Constructor (String) for a list of valid GUID
 //     string formats.
-//   - options - ClientChangeLeaseOptions contains the optional parameters for the Client.ChangeLease method.
+//   - options - BlobClientChangeLeaseOptions contains the optional parameters for the BlobClient.ChangeLease method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-func (client *Client) ChangeLease(ctx context.Context, containerName string, blob string, comp Enum16, leaseID string, proposedLeaseID string, options *ClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientChangeLeaseResponse, error) {
+func (client *BlobClient) ChangeLease(ctx context.Context, containerName string, blob string, comp Enum16, leaseID string, proposedLeaseID string, options *BlobClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobClientChangeLeaseResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.ChangeLease", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.ChangeLease", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.changeLeaseCreateRequest(ctx, containerName, blob, comp, leaseID, proposedLeaseID, options, modifiedAccessConditions)
 	if err != nil {
-		return ClientChangeLeaseResponse{}, err
+		return BlobClientChangeLeaseResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientChangeLeaseResponse{}, err
+		return BlobClientChangeLeaseResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientChangeLeaseResponse{}, err
+		return BlobClientChangeLeaseResponse{}, err
 	}
 	resp, err := client.changeLeaseHandleResponse(httpResp)
 	return resp, err
 }
 
 // changeLeaseCreateRequest creates the ChangeLease request.
-func (client *Client) changeLeaseCreateRequest(ctx context.Context, containerName string, blob string, comp Enum16, leaseID string, proposedLeaseID string, options *ClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) changeLeaseCreateRequest(ctx context.Context, containerName string, blob string, comp Enum16, leaseID string, proposedLeaseID string, options *BlobClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -422,15 +422,15 @@ func (client *Client) changeLeaseCreateRequest(ctx context.Context, containerNam
 }
 
 // changeLeaseHandleResponse handles the ChangeLease response.
-func (client *Client) changeLeaseHandleResponse(resp *http.Response) (ClientChangeLeaseResponse, error) {
-	result := ClientChangeLeaseResponse{}
+func (client *BlobClient) changeLeaseHandleResponse(resp *http.Response) (BlobClientChangeLeaseResponse, error) {
+	result := BlobClientChangeLeaseResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientChangeLeaseResponse{}, err
+			return BlobClientChangeLeaseResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -440,7 +440,7 @@ func (client *Client) changeLeaseHandleResponse(resp *http.Response) (ClientChan
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientChangeLeaseResponse{}, err
+			return BlobClientChangeLeaseResponse{}, err
 		}
 		result.LastModified = &lastModified
 	}
@@ -465,34 +465,34 @@ func (client *Client) changeLeaseHandleResponse(resp *http.Response) (ClientChan
 //   - copySource - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies
 //     a page blob snapshot. The value should be URL-encoded as it would appear in a request
 //     URI. The source blob must either be public or must be authenticated via a shared access signature.
-//   - options - ClientCopyFromURLOptions contains the optional parameters for the Client.CopyFromURL method.
-//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the Client.StartCopyFromURL
+//   - options - BlobClientCopyFromURLOptions contains the optional parameters for the BlobClient.CopyFromURL method.
+//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the BlobClient.StartCopyFromURL
 //     method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
-func (client *Client) CopyFromURL(ctx context.Context, containerName string, blob string, xmsRequiresSync Enum26, copySource string, options *ClientCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions, cpkScopeInfo *CpkScopeInfo) (ClientCopyFromURLResponse, error) {
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
+func (client *BlobClient) CopyFromURL(ctx context.Context, containerName string, blob string, xmsRequiresSync Enum26, copySource string, options *BlobClientCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions, cpkScopeInfo *CpkScopeInfo) (BlobClientCopyFromURLResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.CopyFromURL", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.CopyFromURL", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.copyFromURLCreateRequest(ctx, containerName, blob, xmsRequiresSync, copySource, options, sourceModifiedAccessConditions, modifiedAccessConditions, leaseAccessConditions, cpkScopeInfo)
 	if err != nil {
-		return ClientCopyFromURLResponse{}, err
+		return BlobClientCopyFromURLResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientCopyFromURLResponse{}, err
+		return BlobClientCopyFromURLResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientCopyFromURLResponse{}, err
+		return BlobClientCopyFromURLResponse{}, err
 	}
 	resp, err := client.copyFromURLHandleResponse(httpResp)
 	return resp, err
 }
 
 // copyFromURLCreateRequest creates the CopyFromURL request.
-func (client *Client) copyFromURLCreateRequest(ctx context.Context, containerName string, blob string, xmsRequiresSync Enum26, copySource string, options *ClientCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions, cpkScopeInfo *CpkScopeInfo) (*policy.Request, error) {
+func (client *BlobClient) copyFromURLCreateRequest(ctx context.Context, containerName string, blob string, xmsRequiresSync Enum26, copySource string, options *BlobClientCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions, cpkScopeInfo *CpkScopeInfo) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -586,15 +586,15 @@ func (client *Client) copyFromURLCreateRequest(ctx context.Context, containerNam
 }
 
 // copyFromURLHandleResponse handles the CopyFromURL response.
-func (client *Client) copyFromURLHandleResponse(resp *http.Response) (ClientCopyFromURLResponse, error) {
-	result := ClientCopyFromURLResponse{}
+func (client *BlobClient) copyFromURLHandleResponse(resp *http.Response) (BlobClientCopyFromURLResponse, error) {
+	result := BlobClientCopyFromURLResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Content-MD5"); val != "" {
 		contentMD5, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {
-			return ClientCopyFromURLResponse{}, err
+			return BlobClientCopyFromURLResponse{}, err
 		}
 		result.ContentMD5 = contentMD5
 	}
@@ -607,7 +607,7 @@ func (client *Client) copyFromURLHandleResponse(resp *http.Response) (ClientCopy
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientCopyFromURLResponse{}, err
+			return BlobClientCopyFromURLResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -620,7 +620,7 @@ func (client *Client) copyFromURLHandleResponse(resp *http.Response) (ClientCopy
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientCopyFromURLResponse{}, err
+			return BlobClientCopyFromURLResponse{}, err
 		}
 		result.LastModified = &lastModified
 	}
@@ -636,7 +636,7 @@ func (client *Client) copyFromURLHandleResponse(resp *http.Response) (ClientCopy
 	if val := resp.Header.Get("x-ms-content-crc64"); val != "" {
 		xMSContentCRC64, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {
-			return ClientCopyFromURLResponse{}, err
+			return BlobClientCopyFromURLResponse{}, err
 		}
 		result.XMSContentCRC64 = xMSContentCRC64
 	}
@@ -648,33 +648,33 @@ func (client *Client) copyFromURLHandleResponse(resp *http.Response) (ClientCopy
 //   - containerName - The container name.
 //   - blob - The blob name.
 //   - comp - comp
-//   - options - ClientCreateSnapshotOptions contains the optional parameters for the Client.CreateSnapshot method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - options - BlobClientCreateSnapshotOptions contains the optional parameters for the BlobClient.CreateSnapshot method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-func (client *Client) CreateSnapshot(ctx context.Context, containerName string, blob string, comp Enum25, options *ClientCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (ClientCreateSnapshotResponse, error) {
+func (client *BlobClient) CreateSnapshot(ctx context.Context, containerName string, blob string, comp Enum25, options *BlobClientCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (BlobClientCreateSnapshotResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.CreateSnapshot", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.CreateSnapshot", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.createSnapshotCreateRequest(ctx, containerName, blob, comp, options, cpkInfo, cpkScopeInfo, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
-		return ClientCreateSnapshotResponse{}, err
+		return BlobClientCreateSnapshotResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientCreateSnapshotResponse{}, err
+		return BlobClientCreateSnapshotResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusCreated) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientCreateSnapshotResponse{}, err
+		return BlobClientCreateSnapshotResponse{}, err
 	}
 	resp, err := client.createSnapshotHandleResponse(httpResp)
 	return resp, err
 }
 
 // createSnapshotCreateRequest creates the CreateSnapshot request.
-func (client *Client) createSnapshotCreateRequest(ctx context.Context, containerName string, blob string, comp Enum25, options *ClientCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) createSnapshotCreateRequest(ctx context.Context, containerName string, blob string, comp Enum25, options *BlobClientCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -740,15 +740,15 @@ func (client *Client) createSnapshotCreateRequest(ctx context.Context, container
 }
 
 // createSnapshotHandleResponse handles the CreateSnapshot response.
-func (client *Client) createSnapshotHandleResponse(resp *http.Response) (ClientCreateSnapshotResponse, error) {
-	result := ClientCreateSnapshotResponse{}
+func (client *BlobClient) createSnapshotHandleResponse(resp *http.Response) (BlobClientCreateSnapshotResponse, error) {
+	result := BlobClientCreateSnapshotResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientCreateSnapshotResponse{}, err
+			return BlobClientCreateSnapshotResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -758,14 +758,14 @@ func (client *Client) createSnapshotHandleResponse(resp *http.Response) (ClientC
 	if val := resp.Header.Get("x-ms-request-server-encrypted"); val != "" {
 		isServerEncrypted, err := strconv.ParseBool(val)
 		if err != nil {
-			return ClientCreateSnapshotResponse{}, err
+			return BlobClientCreateSnapshotResponse{}, err
 		}
 		result.IsServerEncrypted = &isServerEncrypted
 	}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientCreateSnapshotResponse{}, err
+			return BlobClientCreateSnapshotResponse{}, err
 		}
 		result.LastModified = &lastModified
 	}
@@ -798,31 +798,31 @@ func (client *Client) createSnapshotHandleResponse(resp *http.Response) (ClientC
 // If the operation fails it returns an *azcore.ResponseError type.
 //   - containerName - The container name.
 //   - blob - The blob name.
-//   - options - ClientDeleteOptions contains the optional parameters for the Client.Delete method.
+//   - options - BlobClientDeleteOptions contains the optional parameters for the BlobClient.Delete method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-func (client *Client) Delete(ctx context.Context, containerName string, blob string, options *ClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ClientDeleteResponse, error) {
+func (client *BlobClient) Delete(ctx context.Context, containerName string, blob string, options *BlobClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (BlobClientDeleteResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.Delete", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.Delete", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.deleteCreateRequest(ctx, containerName, blob, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
-		return ClientDeleteResponse{}, err
+		return BlobClientDeleteResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientDeleteResponse{}, err
+		return BlobClientDeleteResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientDeleteResponse{}, err
+		return BlobClientDeleteResponse{}, err
 	}
 	resp, err := client.deleteHandleResponse(httpResp)
 	return resp, err
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *Client) deleteCreateRequest(ctx context.Context, containerName string, blob string, options *ClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) deleteCreateRequest(ctx context.Context, containerName string, blob string, options *BlobClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -880,15 +880,15 @@ func (client *Client) deleteCreateRequest(ctx context.Context, containerName str
 }
 
 // deleteHandleResponse handles the Delete response.
-func (client *Client) deleteHandleResponse(resp *http.Response) (ClientDeleteResponse, error) {
-	result := ClientDeleteResponse{}
+func (client *BlobClient) deleteHandleResponse(resp *http.Response) (BlobClientDeleteResponse, error) {
+	result := BlobClientDeleteResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientDeleteResponse{}, err
+			return BlobClientDeleteResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -906,30 +906,30 @@ func (client *Client) deleteHandleResponse(resp *http.Response) (ClientDeleteRes
 //   - containerName - The container name.
 //   - blob - The blob name.
 //   - comp - comp
-//   - options - ClientDeleteImmutabilityPolicyOptions contains the optional parameters for the Client.DeleteImmutabilityPolicy
+//   - options - BlobClientDeleteImmutabilityPolicyOptions contains the optional parameters for the BlobClient.DeleteImmutabilityPolicy
 //     method.
-func (client *Client) DeleteImmutabilityPolicy(ctx context.Context, containerName string, blob string, comp Enum23, options *ClientDeleteImmutabilityPolicyOptions) (ClientDeleteImmutabilityPolicyResponse, error) {
+func (client *BlobClient) DeleteImmutabilityPolicy(ctx context.Context, containerName string, blob string, comp Enum23, options *BlobClientDeleteImmutabilityPolicyOptions) (BlobClientDeleteImmutabilityPolicyResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.DeleteImmutabilityPolicy", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.DeleteImmutabilityPolicy", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.deleteImmutabilityPolicyCreateRequest(ctx, containerName, blob, comp, options)
 	if err != nil {
-		return ClientDeleteImmutabilityPolicyResponse{}, err
+		return BlobClientDeleteImmutabilityPolicyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientDeleteImmutabilityPolicyResponse{}, err
+		return BlobClientDeleteImmutabilityPolicyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientDeleteImmutabilityPolicyResponse{}, err
+		return BlobClientDeleteImmutabilityPolicyResponse{}, err
 	}
 	resp, err := client.deleteImmutabilityPolicyHandleResponse(httpResp)
 	return resp, err
 }
 
 // deleteImmutabilityPolicyCreateRequest creates the DeleteImmutabilityPolicy request.
-func (client *Client) deleteImmutabilityPolicyCreateRequest(ctx context.Context, containerName string, blob string, comp Enum23, options *ClientDeleteImmutabilityPolicyOptions) (*policy.Request, error) {
+func (client *BlobClient) deleteImmutabilityPolicyCreateRequest(ctx context.Context, containerName string, blob string, comp Enum23, options *BlobClientDeleteImmutabilityPolicyOptions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -958,15 +958,15 @@ func (client *Client) deleteImmutabilityPolicyCreateRequest(ctx context.Context,
 }
 
 // deleteImmutabilityPolicyHandleResponse handles the DeleteImmutabilityPolicy response.
-func (client *Client) deleteImmutabilityPolicyHandleResponse(resp *http.Response) (ClientDeleteImmutabilityPolicyResponse, error) {
-	result := ClientDeleteImmutabilityPolicyResponse{}
+func (client *BlobClient) deleteImmutabilityPolicyHandleResponse(resp *http.Response) (BlobClientDeleteImmutabilityPolicyResponse, error) {
+	result := BlobClientDeleteImmutabilityPolicyResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientDeleteImmutabilityPolicyResponse{}, err
+			return BlobClientDeleteImmutabilityPolicyResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -984,32 +984,32 @@ func (client *Client) deleteImmutabilityPolicyHandleResponse(resp *http.Response
 // If the operation fails it returns an *azcore.ResponseError type.
 //   - containerName - The container name.
 //   - blob - The blob name.
-//   - options - ClientDownloadOptions contains the optional parameters for the Client.Download method.
+//   - options - BlobClientDownloadOptions contains the optional parameters for the BlobClient.Download method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-func (client *Client) Download(ctx context.Context, containerName string, blob string, options *ClientDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (ClientDownloadResponse, error) {
+func (client *BlobClient) Download(ctx context.Context, containerName string, blob string, options *BlobClientDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlobClientDownloadResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.Download", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.Download", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.downloadCreateRequest(ctx, containerName, blob, options, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
 	if err != nil {
-		return ClientDownloadResponse{}, err
+		return BlobClientDownloadResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientDownloadResponse{}, err
+		return BlobClientDownloadResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusPartialContent) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientDownloadResponse{}, err
+		return BlobClientDownloadResponse{}, err
 	}
 	resp, err := client.downloadHandleResponse(httpResp)
 	return resp, err
 }
 
 // downloadCreateRequest creates the Download request.
-func (client *Client) downloadCreateRequest(ctx context.Context, containerName string, blob string, options *ClientDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) downloadCreateRequest(ctx context.Context, containerName string, blob string, options *BlobClientDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -1080,8 +1080,8 @@ func (client *Client) downloadCreateRequest(ctx context.Context, containerName s
 }
 
 // downloadHandleResponse handles the Download response.
-func (client *Client) downloadHandleResponse(resp *http.Response) (ClientDownloadResponse, error) {
-	result := ClientDownloadResponse{Body: resp.Body}
+func (client *BlobClient) downloadHandleResponse(resp *http.Response) (BlobClientDownloadResponse, error) {
+	result := BlobClientDownloadResponse{Body: resp.Body}
 	if val := resp.Header.Get("Accept-Ranges"); val != "" {
 		result.AcceptRanges = &val
 	}
@@ -1089,21 +1089,21 @@ func (client *Client) downloadHandleResponse(resp *http.Response) (ClientDownloa
 		blobCommittedBlockCount32, err := strconv.ParseInt(val, 10, 32)
 		blobCommittedBlockCount := int32(blobCommittedBlockCount32)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.BlobCommittedBlockCount = &blobCommittedBlockCount
 	}
 	if val := resp.Header.Get("x-ms-blob-content-md5"); val != "" {
 		blobContentMD5, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.BlobContentMD5 = blobContentMD5
 	}
 	if val := resp.Header.Get("x-ms-blob-sequence-number"); val != "" {
 		blobSequenceNumber, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.BlobSequenceNumber = &blobSequenceNumber
 	}
@@ -1119,7 +1119,7 @@ func (client *Client) downloadHandleResponse(resp *http.Response) (ClientDownloa
 	if val := resp.Header.Get("x-ms-content-crc64"); val != "" {
 		contentCRC64, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.ContentCRC64 = contentCRC64
 	}
@@ -1135,14 +1135,14 @@ func (client *Client) downloadHandleResponse(resp *http.Response) (ClientDownloa
 	if val := resp.Header.Get("Content-Length"); val != "" {
 		contentLength, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.ContentLength = &contentLength
 	}
 	if val := resp.Header.Get("Content-MD5"); val != "" {
 		contentMD5, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.ContentMD5 = contentMD5
 	}
@@ -1155,7 +1155,7 @@ func (client *Client) downloadHandleResponse(resp *http.Response) (ClientDownloa
 	if val := resp.Header.Get("x-ms-copy-completion-time"); val != "" {
 		copyCompletionTime, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.CopyCompletionTime = &copyCompletionTime
 	}
@@ -1177,14 +1177,14 @@ func (client *Client) downloadHandleResponse(resp *http.Response) (ClientDownloa
 	if val := resp.Header.Get("x-ms-creation-time"); val != "" {
 		creationTime, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.CreationTime = &creationTime
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -1200,7 +1200,7 @@ func (client *Client) downloadHandleResponse(resp *http.Response) (ClientDownloa
 	if val := resp.Header.Get("x-ms-immutability-policy-until-date"); val != "" {
 		immutabilityPolicyExpiresOn, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.ImmutabilityPolicyExpiresOn = &immutabilityPolicyExpiresOn
 	}
@@ -1210,35 +1210,35 @@ func (client *Client) downloadHandleResponse(resp *http.Response) (ClientDownloa
 	if val := resp.Header.Get("x-ms-is-current-version"); val != "" {
 		isCurrentVersion, err := strconv.ParseBool(val)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.IsCurrentVersion = &isCurrentVersion
 	}
 	if val := resp.Header.Get("x-ms-blob-sealed"); val != "" {
 		isSealed, err := strconv.ParseBool(val)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.IsSealed = &isSealed
 	}
 	if val := resp.Header.Get("x-ms-server-encrypted"); val != "" {
 		isServerEncrypted, err := strconv.ParseBool(val)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.IsServerEncrypted = &isServerEncrypted
 	}
 	if val := resp.Header.Get("x-ms-last-access-time"); val != "" {
 		lastAccessed, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.LastAccessed = &lastAccessed
 	}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.LastModified = &lastModified
 	}
@@ -1254,7 +1254,7 @@ func (client *Client) downloadHandleResponse(resp *http.Response) (ClientDownloa
 	if val := resp.Header.Get("x-ms-legal-hold"); val != "" {
 		legalHold, err := strconv.ParseBool(val)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.LegalHold = &legalHold
 	}
@@ -1283,7 +1283,7 @@ func (client *Client) downloadHandleResponse(resp *http.Response) (ClientDownloa
 	if val := resp.Header.Get("x-ms-tag-count"); val != "" {
 		tagCount, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			return ClientDownloadResponse{}, err
+			return BlobClientDownloadResponse{}, err
 		}
 		result.TagCount = &tagCount
 	}
@@ -1302,29 +1302,29 @@ func (client *Client) downloadHandleResponse(resp *http.Response) (ClientDownloa
 //   - blob - The blob name.
 //   - restype - restype
 //   - comp - comp
-//   - options - ClientGetAccountInfoOptions contains the optional parameters for the Client.GetAccountInfo method.
-func (client *Client) GetAccountInfo(ctx context.Context, containerName string, blob string, restype Enum8, comp Enum1, options *ClientGetAccountInfoOptions) (ClientGetAccountInfoResponse, error) {
+//   - options - BlobClientGetAccountInfoOptions contains the optional parameters for the BlobClient.GetAccountInfo method.
+func (client *BlobClient) GetAccountInfo(ctx context.Context, containerName string, blob string, restype Enum8, comp Enum1, options *BlobClientGetAccountInfoOptions) (BlobClientGetAccountInfoResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.GetAccountInfo", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.GetAccountInfo", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.getAccountInfoCreateRequest(ctx, containerName, blob, restype, comp, options)
 	if err != nil {
-		return ClientGetAccountInfoResponse{}, err
+		return BlobClientGetAccountInfoResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientGetAccountInfoResponse{}, err
+		return BlobClientGetAccountInfoResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientGetAccountInfoResponse{}, err
+		return BlobClientGetAccountInfoResponse{}, err
 	}
 	resp, err := client.getAccountInfoHandleResponse(httpResp)
 	return resp, err
 }
 
 // getAccountInfoCreateRequest creates the GetAccountInfo request.
-func (client *Client) getAccountInfoCreateRequest(ctx context.Context, containerName string, blob string, restype Enum8, comp Enum1, _ *ClientGetAccountInfoOptions) (*policy.Request, error) {
+func (client *BlobClient) getAccountInfoCreateRequest(ctx context.Context, containerName string, blob string, restype Enum8, comp Enum1, _ *BlobClientGetAccountInfoOptions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -1348,8 +1348,8 @@ func (client *Client) getAccountInfoCreateRequest(ctx context.Context, container
 }
 
 // getAccountInfoHandleResponse handles the GetAccountInfo response.
-func (client *Client) getAccountInfoHandleResponse(resp *http.Response) (ClientGetAccountInfoResponse, error) {
-	result := ClientGetAccountInfoResponse{}
+func (client *BlobClient) getAccountInfoHandleResponse(resp *http.Response) (BlobClientGetAccountInfoResponse, error) {
+	result := BlobClientGetAccountInfoResponse{}
 	if val := resp.Header.Get("x-ms-account-kind"); val != "" {
 		result.AccountKind = (*AccountKind)(&val)
 	}
@@ -1359,7 +1359,7 @@ func (client *Client) getAccountInfoHandleResponse(resp *http.Response) (ClientG
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientGetAccountInfoResponse{}, err
+			return BlobClientGetAccountInfoResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -1380,32 +1380,32 @@ func (client *Client) getAccountInfoHandleResponse(resp *http.Response) (ClientG
 // If the operation fails it returns an *azcore.ResponseError type.
 //   - containerName - The container name.
 //   - blob - The blob name.
-//   - options - ClientGetPropertiesOptions contains the optional parameters for the Client.GetProperties method.
+//   - options - BlobClientGetPropertiesOptions contains the optional parameters for the BlobClient.GetProperties method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-func (client *Client) GetProperties(ctx context.Context, containerName string, blob string, options *ClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (ClientGetPropertiesResponse, error) {
+func (client *BlobClient) GetProperties(ctx context.Context, containerName string, blob string, options *BlobClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlobClientGetPropertiesResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.GetProperties", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.GetProperties", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.getPropertiesCreateRequest(ctx, containerName, blob, options, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
 	if err != nil {
-		return ClientGetPropertiesResponse{}, err
+		return BlobClientGetPropertiesResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientGetPropertiesResponse{}, err
+		return BlobClientGetPropertiesResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientGetPropertiesResponse{}, err
+		return BlobClientGetPropertiesResponse{}, err
 	}
 	resp, err := client.getPropertiesHandleResponse(httpResp)
 	return resp, err
 }
 
 // getPropertiesCreateRequest creates the GetProperties request.
-func (client *Client) getPropertiesCreateRequest(ctx context.Context, containerName string, blob string, options *ClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) getPropertiesCreateRequest(ctx context.Context, containerName string, blob string, options *BlobClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -1466,8 +1466,8 @@ func (client *Client) getPropertiesCreateRequest(ctx context.Context, containerN
 }
 
 // getPropertiesHandleResponse handles the GetProperties response.
-func (client *Client) getPropertiesHandleResponse(resp *http.Response) (ClientGetPropertiesResponse, error) {
-	result := ClientGetPropertiesResponse{}
+func (client *BlobClient) getPropertiesHandleResponse(resp *http.Response) (BlobClientGetPropertiesResponse, error) {
+	result := BlobClientGetPropertiesResponse{}
 	if val := resp.Header.Get("Accept-Ranges"); val != "" {
 		result.AcceptRanges = &val
 	}
@@ -1477,14 +1477,14 @@ func (client *Client) getPropertiesHandleResponse(resp *http.Response) (ClientGe
 	if val := resp.Header.Get("x-ms-access-tier-change-time"); val != "" {
 		accessTierChangeTime, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.AccessTierChangeTime = &accessTierChangeTime
 	}
 	if val := resp.Header.Get("x-ms-access-tier-inferred"); val != "" {
 		accessTierInferred, err := strconv.ParseBool(val)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.AccessTierInferred = &accessTierInferred
 	}
@@ -1495,14 +1495,14 @@ func (client *Client) getPropertiesHandleResponse(resp *http.Response) (ClientGe
 		blobCommittedBlockCount32, err := strconv.ParseInt(val, 10, 32)
 		blobCommittedBlockCount := int32(blobCommittedBlockCount32)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.BlobCommittedBlockCount = &blobCommittedBlockCount
 	}
 	if val := resp.Header.Get("x-ms-blob-sequence-number"); val != "" {
 		blobSequenceNumber, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.BlobSequenceNumber = &blobSequenceNumber
 	}
@@ -1527,14 +1527,14 @@ func (client *Client) getPropertiesHandleResponse(resp *http.Response) (ClientGe
 	if val := resp.Header.Get("Content-Length"); val != "" {
 		contentLength, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.ContentLength = &contentLength
 	}
 	if val := resp.Header.Get("Content-MD5"); val != "" {
 		contentMD5, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.ContentMD5 = contentMD5
 	}
@@ -1544,7 +1544,7 @@ func (client *Client) getPropertiesHandleResponse(resp *http.Response) (ClientGe
 	if val := resp.Header.Get("x-ms-copy-completion-time"); val != "" {
 		copyCompletionTime, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.CopyCompletionTime = &copyCompletionTime
 	}
@@ -1566,14 +1566,14 @@ func (client *Client) getPropertiesHandleResponse(resp *http.Response) (ClientGe
 	if val := resp.Header.Get("x-ms-creation-time"); val != "" {
 		creationTime, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.CreationTime = &creationTime
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -1592,14 +1592,14 @@ func (client *Client) getPropertiesHandleResponse(resp *http.Response) (ClientGe
 	if val := resp.Header.Get("x-ms-expiry-time"); val != "" {
 		expiresOn, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.ExpiresOn = &expiresOn
 	}
 	if val := resp.Header.Get("x-ms-immutability-policy-until-date"); val != "" {
 		immutabilityPolicyExpiresOn, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.ImmutabilityPolicyExpiresOn = &immutabilityPolicyExpiresOn
 	}
@@ -1609,42 +1609,42 @@ func (client *Client) getPropertiesHandleResponse(resp *http.Response) (ClientGe
 	if val := resp.Header.Get("x-ms-is-current-version"); val != "" {
 		isCurrentVersion, err := strconv.ParseBool(val)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.IsCurrentVersion = &isCurrentVersion
 	}
 	if val := resp.Header.Get("x-ms-incremental-copy"); val != "" {
 		isIncrementalCopy, err := strconv.ParseBool(val)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.IsIncrementalCopy = &isIncrementalCopy
 	}
 	if val := resp.Header.Get("x-ms-blob-sealed"); val != "" {
 		isSealed, err := strconv.ParseBool(val)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.IsSealed = &isSealed
 	}
 	if val := resp.Header.Get("x-ms-server-encrypted"); val != "" {
 		isServerEncrypted, err := strconv.ParseBool(val)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.IsServerEncrypted = &isServerEncrypted
 	}
 	if val := resp.Header.Get("x-ms-last-access-time"); val != "" {
 		lastAccessed, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.LastAccessed = &lastAccessed
 	}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.LastModified = &lastModified
 	}
@@ -1660,7 +1660,7 @@ func (client *Client) getPropertiesHandleResponse(resp *http.Response) (ClientGe
 	if val := resp.Header.Get("x-ms-legal-hold"); val != "" {
 		legalHold, err := strconv.ParseBool(val)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.LegalHold = &legalHold
 	}
@@ -1692,7 +1692,7 @@ func (client *Client) getPropertiesHandleResponse(resp *http.Response) (ClientGe
 	if val := resp.Header.Get("x-ms-tag-count"); val != "" {
 		tagCount, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			return ClientGetPropertiesResponse{}, err
+			return BlobClientGetPropertiesResponse{}, err
 		}
 		result.TagCount = &tagCount
 	}
@@ -1710,31 +1710,31 @@ func (client *Client) getPropertiesHandleResponse(resp *http.Response) (ClientGe
 //   - containerName - The container name.
 //   - blob - The blob name.
 //   - comp - comp
-//   - options - ClientGetTagsOptions contains the optional parameters for the Client.GetTags method.
+//   - options - BlobClientGetTagsOptions contains the optional parameters for the BlobClient.GetTags method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-func (client *Client) GetTags(ctx context.Context, containerName string, blob string, comp Enum39, options *ClientGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (ClientGetTagsResponse, error) {
+func (client *BlobClient) GetTags(ctx context.Context, containerName string, blob string, comp Enum39, options *BlobClientGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (BlobClientGetTagsResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.GetTags", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.GetTags", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.getTagsCreateRequest(ctx, containerName, blob, comp, options, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
-		return ClientGetTagsResponse{}, err
+		return BlobClientGetTagsResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientGetTagsResponse{}, err
+		return BlobClientGetTagsResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientGetTagsResponse{}, err
+		return BlobClientGetTagsResponse{}, err
 	}
 	resp, err := client.getTagsHandleResponse(httpResp)
 	return resp, err
 }
 
 // getTagsCreateRequest creates the GetTags request.
-func (client *Client) getTagsCreateRequest(ctx context.Context, containerName string, blob string, comp Enum39, options *ClientGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) getTagsCreateRequest(ctx context.Context, containerName string, blob string, comp Enum39, options *BlobClientGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -1775,15 +1775,15 @@ func (client *Client) getTagsCreateRequest(ctx context.Context, containerName st
 }
 
 // getTagsHandleResponse handles the GetTags response.
-func (client *Client) getTagsHandleResponse(resp *http.Response) (ClientGetTagsResponse, error) {
-	result := ClientGetTagsResponse{}
+func (client *BlobClient) getTagsHandleResponse(resp *http.Response) (BlobClientGetTagsResponse, error) {
+	result := BlobClientGetTagsResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientGetTagsResponse{}, err
+			return BlobClientGetTagsResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -1793,8 +1793,8 @@ func (client *Client) getTagsHandleResponse(resp *http.Response) (ClientGetTagsR
 	if val := resp.Header.Get("x-ms-version"); val != "" {
 		result.Version = &val
 	}
-	if err := runtime.UnmarshalAsXML(resp, &result.Tags); err != nil {
-		return ClientGetTagsResponse{}, err
+	if err := runtime.UnmarshalAsXML(resp, &result.BlobTags); err != nil {
+		return BlobClientGetTagsResponse{}, err
 	}
 	return result, nil
 }
@@ -1804,32 +1804,32 @@ func (client *Client) getTagsHandleResponse(resp *http.Response) (ClientGetTagsR
 //   - containerName - The container name.
 //   - blob - The blob name.
 //   - comp - comp
-//   - options - ClientQueryOptions contains the optional parameters for the Client.Query method.
+//   - options - BlobClientQueryOptions contains the optional parameters for the BlobClient.Query method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-func (client *Client) Query(ctx context.Context, containerName string, blob string, comp Enum37, options *ClientQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (ClientQueryResponse, error) {
+func (client *BlobClient) Query(ctx context.Context, containerName string, blob string, comp Enum37, options *BlobClientQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlobClientQueryResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.Query", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.Query", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.queryCreateRequest(ctx, containerName, blob, comp, options, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
 	if err != nil {
-		return ClientQueryResponse{}, err
+		return BlobClientQueryResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientQueryResponse{}, err
+		return BlobClientQueryResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusPartialContent) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientQueryResponse{}, err
+		return BlobClientQueryResponse{}, err
 	}
 	resp, err := client.queryHandleResponse(httpResp)
 	return resp, err
 }
 
 // queryCreateRequest creates the Query request.
-func (client *Client) queryCreateRequest(ctx context.Context, containerName string, blob string, comp Enum37, options *ClientQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) queryCreateRequest(ctx context.Context, containerName string, blob string, comp Enum37, options *BlobClientQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -1895,8 +1895,8 @@ func (client *Client) queryCreateRequest(ctx context.Context, containerName stri
 }
 
 // queryHandleResponse handles the Query response.
-func (client *Client) queryHandleResponse(resp *http.Response) (ClientQueryResponse, error) {
-	result := ClientQueryResponse{Body: resp.Body}
+func (client *BlobClient) queryHandleResponse(resp *http.Response) (BlobClientQueryResponse, error) {
+	result := BlobClientQueryResponse{Body: resp.Body}
 	if val := resp.Header.Get("Accept-Ranges"); val != "" {
 		result.AcceptRanges = &val
 	}
@@ -1904,21 +1904,21 @@ func (client *Client) queryHandleResponse(resp *http.Response) (ClientQueryRespo
 		blobCommittedBlockCount32, err := strconv.ParseInt(val, 10, 32)
 		blobCommittedBlockCount := int32(blobCommittedBlockCount32)
 		if err != nil {
-			return ClientQueryResponse{}, err
+			return BlobClientQueryResponse{}, err
 		}
 		result.BlobCommittedBlockCount = &blobCommittedBlockCount
 	}
 	if val := resp.Header.Get("x-ms-blob-content-md5"); val != "" {
 		blobContentMD5, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {
-			return ClientQueryResponse{}, err
+			return BlobClientQueryResponse{}, err
 		}
 		result.BlobContentMD5 = blobContentMD5
 	}
 	if val := resp.Header.Get("x-ms-blob-sequence-number"); val != "" {
 		blobSequenceNumber, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			return ClientQueryResponse{}, err
+			return BlobClientQueryResponse{}, err
 		}
 		result.BlobSequenceNumber = &blobSequenceNumber
 	}
@@ -1934,7 +1934,7 @@ func (client *Client) queryHandleResponse(resp *http.Response) (ClientQueryRespo
 	if val := resp.Header.Get("x-ms-content-crc64"); val != "" {
 		contentCRC64, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {
-			return ClientQueryResponse{}, err
+			return BlobClientQueryResponse{}, err
 		}
 		result.ContentCRC64 = contentCRC64
 	}
@@ -1950,14 +1950,14 @@ func (client *Client) queryHandleResponse(resp *http.Response) (ClientQueryRespo
 	if val := resp.Header.Get("Content-Length"); val != "" {
 		contentLength, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			return ClientQueryResponse{}, err
+			return BlobClientQueryResponse{}, err
 		}
 		result.ContentLength = &contentLength
 	}
 	if val := resp.Header.Get("Content-MD5"); val != "" {
 		contentMD5, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {
-			return ClientQueryResponse{}, err
+			return BlobClientQueryResponse{}, err
 		}
 		result.ContentMD5 = contentMD5
 	}
@@ -1970,7 +1970,7 @@ func (client *Client) queryHandleResponse(resp *http.Response) (ClientQueryRespo
 	if val := resp.Header.Get("x-ms-copy-completion-time"); val != "" {
 		copyCompletionTime, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientQueryResponse{}, err
+			return BlobClientQueryResponse{}, err
 		}
 		result.CopyCompletionTime = &copyCompletionTime
 	}
@@ -1992,7 +1992,7 @@ func (client *Client) queryHandleResponse(resp *http.Response) (ClientQueryRespo
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientQueryResponse{}, err
+			return BlobClientQueryResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -2008,14 +2008,14 @@ func (client *Client) queryHandleResponse(resp *http.Response) (ClientQueryRespo
 	if val := resp.Header.Get("x-ms-server-encrypted"); val != "" {
 		isServerEncrypted, err := strconv.ParseBool(val)
 		if err != nil {
-			return ClientQueryResponse{}, err
+			return BlobClientQueryResponse{}, err
 		}
 		result.IsServerEncrypted = &isServerEncrypted
 	}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientQueryResponse{}, err
+			return BlobClientQueryResponse{}, err
 		}
 		result.LastModified = &lastModified
 	}
@@ -2051,30 +2051,30 @@ func (client *Client) queryHandleResponse(resp *http.Response) (ClientQueryRespo
 //   - blob - The blob name.
 //   - comp - comp
 //   - leaseID - Specifies the current lease ID on the resource.
-//   - options - ClientReleaseLeaseOptions contains the optional parameters for the Client.ReleaseLease method.
+//   - options - BlobClientReleaseLeaseOptions contains the optional parameters for the BlobClient.ReleaseLease method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-func (client *Client) ReleaseLease(ctx context.Context, containerName string, blob string, comp Enum16, leaseID string, options *ClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientReleaseLeaseResponse, error) {
+func (client *BlobClient) ReleaseLease(ctx context.Context, containerName string, blob string, comp Enum16, leaseID string, options *BlobClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobClientReleaseLeaseResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.ReleaseLease", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.ReleaseLease", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.releaseLeaseCreateRequest(ctx, containerName, blob, comp, leaseID, options, modifiedAccessConditions)
 	if err != nil {
-		return ClientReleaseLeaseResponse{}, err
+		return BlobClientReleaseLeaseResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientReleaseLeaseResponse{}, err
+		return BlobClientReleaseLeaseResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientReleaseLeaseResponse{}, err
+		return BlobClientReleaseLeaseResponse{}, err
 	}
 	resp, err := client.releaseLeaseHandleResponse(httpResp)
 	return resp, err
 }
 
 // releaseLeaseCreateRequest creates the ReleaseLease request.
-func (client *Client) releaseLeaseCreateRequest(ctx context.Context, containerName string, blob string, comp Enum16, leaseID string, options *ClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) releaseLeaseCreateRequest(ctx context.Context, containerName string, blob string, comp Enum16, leaseID string, options *BlobClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -2120,15 +2120,15 @@ func (client *Client) releaseLeaseCreateRequest(ctx context.Context, containerNa
 }
 
 // releaseLeaseHandleResponse handles the ReleaseLease response.
-func (client *Client) releaseLeaseHandleResponse(resp *http.Response) (ClientReleaseLeaseResponse, error) {
-	result := ClientReleaseLeaseResponse{}
+func (client *BlobClient) releaseLeaseHandleResponse(resp *http.Response) (BlobClientReleaseLeaseResponse, error) {
+	result := BlobClientReleaseLeaseResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientReleaseLeaseResponse{}, err
+			return BlobClientReleaseLeaseResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -2138,7 +2138,7 @@ func (client *Client) releaseLeaseHandleResponse(resp *http.Response) (ClientRel
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientReleaseLeaseResponse{}, err
+			return BlobClientReleaseLeaseResponse{}, err
 		}
 		result.LastModified = &lastModified
 	}
@@ -2157,30 +2157,30 @@ func (client *Client) releaseLeaseHandleResponse(resp *http.Response) (ClientRel
 //   - blob - The blob name.
 //   - comp - comp
 //   - leaseID - Specifies the current lease ID on the resource.
-//   - options - ClientRenewLeaseOptions contains the optional parameters for the Client.RenewLease method.
+//   - options - BlobClientRenewLeaseOptions contains the optional parameters for the BlobClient.RenewLease method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-func (client *Client) RenewLease(ctx context.Context, containerName string, blob string, comp Enum16, leaseID string, options *ClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientRenewLeaseResponse, error) {
+func (client *BlobClient) RenewLease(ctx context.Context, containerName string, blob string, comp Enum16, leaseID string, options *BlobClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobClientRenewLeaseResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.RenewLease", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.RenewLease", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.renewLeaseCreateRequest(ctx, containerName, blob, comp, leaseID, options, modifiedAccessConditions)
 	if err != nil {
-		return ClientRenewLeaseResponse{}, err
+		return BlobClientRenewLeaseResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientRenewLeaseResponse{}, err
+		return BlobClientRenewLeaseResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientRenewLeaseResponse{}, err
+		return BlobClientRenewLeaseResponse{}, err
 	}
 	resp, err := client.renewLeaseHandleResponse(httpResp)
 	return resp, err
 }
 
 // renewLeaseCreateRequest creates the RenewLease request.
-func (client *Client) renewLeaseCreateRequest(ctx context.Context, containerName string, blob string, comp Enum16, leaseID string, options *ClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) renewLeaseCreateRequest(ctx context.Context, containerName string, blob string, comp Enum16, leaseID string, options *BlobClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -2226,15 +2226,15 @@ func (client *Client) renewLeaseCreateRequest(ctx context.Context, containerName
 }
 
 // renewLeaseHandleResponse handles the RenewLease response.
-func (client *Client) renewLeaseHandleResponse(resp *http.Response) (ClientRenewLeaseResponse, error) {
-	result := ClientRenewLeaseResponse{}
+func (client *BlobClient) renewLeaseHandleResponse(resp *http.Response) (BlobClientRenewLeaseResponse, error) {
+	result := BlobClientRenewLeaseResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientRenewLeaseResponse{}, err
+			return BlobClientRenewLeaseResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -2244,7 +2244,7 @@ func (client *Client) renewLeaseHandleResponse(resp *http.Response) (ClientRenew
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientRenewLeaseResponse{}, err
+			return BlobClientRenewLeaseResponse{}, err
 		}
 		result.LastModified = &lastModified
 	}
@@ -2266,29 +2266,29 @@ func (client *Client) renewLeaseHandleResponse(resp *http.Response) (ClientRenew
 //   - blob - The blob name.
 //   - comp - comp
 //   - expiryOptions - Required. Indicates mode of the expiry time
-//   - options - ClientSetExpiryOptions contains the optional parameters for the Client.SetExpiry method.
-func (client *Client) SetExpiry(ctx context.Context, containerName string, blob string, comp Enum21, expiryOptions BlobExpiryOptions, options *ClientSetExpiryOptions) (ClientSetExpiryResponse, error) {
+//   - options - BlobClientSetExpiryOptions contains the optional parameters for the BlobClient.SetExpiry method.
+func (client *BlobClient) SetExpiry(ctx context.Context, containerName string, blob string, comp Enum21, expiryOptions BlobExpiryOptions, options *BlobClientSetExpiryOptions) (BlobClientSetExpiryResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.SetExpiry", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.SetExpiry", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.setExpiryCreateRequest(ctx, containerName, blob, comp, expiryOptions, options)
 	if err != nil {
-		return ClientSetExpiryResponse{}, err
+		return BlobClientSetExpiryResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientSetExpiryResponse{}, err
+		return BlobClientSetExpiryResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientSetExpiryResponse{}, err
+		return BlobClientSetExpiryResponse{}, err
 	}
 	resp, err := client.setExpiryHandleResponse(httpResp)
 	return resp, err
 }
 
 // setExpiryCreateRequest creates the SetExpiry request.
-func (client *Client) setExpiryCreateRequest(ctx context.Context, containerName string, blob string, comp Enum21, expiryOptions BlobExpiryOptions, options *ClientSetExpiryOptions) (*policy.Request, error) {
+func (client *BlobClient) setExpiryCreateRequest(ctx context.Context, containerName string, blob string, comp Enum21, expiryOptions BlobExpiryOptions, options *BlobClientSetExpiryOptions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -2321,15 +2321,15 @@ func (client *Client) setExpiryCreateRequest(ctx context.Context, containerName 
 }
 
 // setExpiryHandleResponse handles the SetExpiry response.
-func (client *Client) setExpiryHandleResponse(resp *http.Response) (ClientSetExpiryResponse, error) {
-	result := ClientSetExpiryResponse{}
+func (client *BlobClient) setExpiryHandleResponse(resp *http.Response) (BlobClientSetExpiryResponse, error) {
+	result := BlobClientSetExpiryResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientSetExpiryResponse{}, err
+			return BlobClientSetExpiryResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -2339,7 +2339,7 @@ func (client *Client) setExpiryHandleResponse(resp *http.Response) (ClientSetExp
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientSetExpiryResponse{}, err
+			return BlobClientSetExpiryResponse{}, err
 		}
 		result.LastModified = &lastModified
 	}
@@ -2357,32 +2357,32 @@ func (client *Client) setExpiryHandleResponse(resp *http.Response) (ClientSetExp
 //   - containerName - The container name.
 //   - blob - The blob name.
 //   - comp - comp
-//   - options - ClientSetHTTPHeadersOptions contains the optional parameters for the Client.SetHTTPHeaders method.
-//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the Client.SetHTTPHeaders method.
+//   - options - BlobClientSetHTTPHeadersOptions contains the optional parameters for the BlobClient.SetHTTPHeaders method.
+//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the BlobClient.SetHTTPHeaders method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-func (client *Client) SetHTTPHeaders(ctx context.Context, containerName string, blob string, comp Enum1, options *ClientSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ClientSetHTTPHeadersResponse, error) {
+func (client *BlobClient) SetHTTPHeaders(ctx context.Context, containerName string, blob string, comp Enum1, options *BlobClientSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (BlobClientSetHTTPHeadersResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.SetHTTPHeaders", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.SetHTTPHeaders", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.setHTTPHeadersCreateRequest(ctx, containerName, blob, comp, options, blobHTTPHeaders, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
-		return ClientSetHTTPHeadersResponse{}, err
+		return BlobClientSetHTTPHeadersResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientSetHTTPHeadersResponse{}, err
+		return BlobClientSetHTTPHeadersResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientSetHTTPHeadersResponse{}, err
+		return BlobClientSetHTTPHeadersResponse{}, err
 	}
 	resp, err := client.setHTTPHeadersHandleResponse(httpResp)
 	return resp, err
 }
 
 // setHTTPHeadersCreateRequest creates the SetHTTPHeaders request.
-func (client *Client) setHTTPHeadersCreateRequest(ctx context.Context, containerName string, blob string, comp Enum1, options *ClientSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) setHTTPHeadersCreateRequest(ctx context.Context, containerName string, blob string, comp Enum1, options *BlobClientSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -2447,12 +2447,12 @@ func (client *Client) setHTTPHeadersCreateRequest(ctx context.Context, container
 }
 
 // setHTTPHeadersHandleResponse handles the SetHTTPHeaders response.
-func (client *Client) setHTTPHeadersHandleResponse(resp *http.Response) (ClientSetHTTPHeadersResponse, error) {
-	result := ClientSetHTTPHeadersResponse{}
+func (client *BlobClient) setHTTPHeadersHandleResponse(resp *http.Response) (BlobClientSetHTTPHeadersResponse, error) {
+	result := BlobClientSetHTTPHeadersResponse{}
 	if val := resp.Header.Get("x-ms-blob-sequence-number"); val != "" {
 		blobSequenceNumber, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			return ClientSetHTTPHeadersResponse{}, err
+			return BlobClientSetHTTPHeadersResponse{}, err
 		}
 		result.BlobSequenceNumber = &blobSequenceNumber
 	}
@@ -2462,7 +2462,7 @@ func (client *Client) setHTTPHeadersHandleResponse(resp *http.Response) (ClientS
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientSetHTTPHeadersResponse{}, err
+			return BlobClientSetHTTPHeadersResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -2472,7 +2472,7 @@ func (client *Client) setHTTPHeadersHandleResponse(resp *http.Response) (ClientS
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientSetHTTPHeadersResponse{}, err
+			return BlobClientSetHTTPHeadersResponse{}, err
 		}
 		result.LastModified = &lastModified
 	}
@@ -2490,30 +2490,31 @@ func (client *Client) setHTTPHeadersHandleResponse(resp *http.Response) (ClientS
 //   - containerName - The container name.
 //   - blob - The blob name.
 //   - comp - comp
-//   - options - ClientSetImmutabilityPolicyOptions contains the optional parameters for the Client.SetImmutabilityPolicy method.
+//   - options - BlobClientSetImmutabilityPolicyOptions contains the optional parameters for the BlobClient.SetImmutabilityPolicy
+//     method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-func (client *Client) SetImmutabilityPolicy(ctx context.Context, containerName string, blob string, comp Enum23, options *ClientSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientSetImmutabilityPolicyResponse, error) {
+func (client *BlobClient) SetImmutabilityPolicy(ctx context.Context, containerName string, blob string, comp Enum23, options *BlobClientSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (BlobClientSetImmutabilityPolicyResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.SetImmutabilityPolicy", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.SetImmutabilityPolicy", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.setImmutabilityPolicyCreateRequest(ctx, containerName, blob, comp, options, modifiedAccessConditions)
 	if err != nil {
-		return ClientSetImmutabilityPolicyResponse{}, err
+		return BlobClientSetImmutabilityPolicyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientSetImmutabilityPolicyResponse{}, err
+		return BlobClientSetImmutabilityPolicyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientSetImmutabilityPolicyResponse{}, err
+		return BlobClientSetImmutabilityPolicyResponse{}, err
 	}
 	resp, err := client.setImmutabilityPolicyHandleResponse(httpResp)
 	return resp, err
 }
 
 // setImmutabilityPolicyCreateRequest creates the SetImmutabilityPolicy request.
-func (client *Client) setImmutabilityPolicyCreateRequest(ctx context.Context, containerName string, blob string, comp Enum23, options *ClientSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) setImmutabilityPolicyCreateRequest(ctx context.Context, containerName string, blob string, comp Enum23, options *BlobClientSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -2551,22 +2552,22 @@ func (client *Client) setImmutabilityPolicyCreateRequest(ctx context.Context, co
 }
 
 // setImmutabilityPolicyHandleResponse handles the SetImmutabilityPolicy response.
-func (client *Client) setImmutabilityPolicyHandleResponse(resp *http.Response) (ClientSetImmutabilityPolicyResponse, error) {
-	result := ClientSetImmutabilityPolicyResponse{}
+func (client *BlobClient) setImmutabilityPolicyHandleResponse(resp *http.Response) (BlobClientSetImmutabilityPolicyResponse, error) {
+	result := BlobClientSetImmutabilityPolicyResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientSetImmutabilityPolicyResponse{}, err
+			return BlobClientSetImmutabilityPolicyResponse{}, err
 		}
 		result.Date = &date
 	}
 	if val := resp.Header.Get("x-ms-immutability-policy-until-date"); val != "" {
 		immutabilityPolicyExpiry, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientSetImmutabilityPolicyResponse{}, err
+			return BlobClientSetImmutabilityPolicyResponse{}, err
 		}
 		result.ImmutabilityPolicyExpiry = &immutabilityPolicyExpiry
 	}
@@ -2588,29 +2589,29 @@ func (client *Client) setImmutabilityPolicyHandleResponse(resp *http.Response) (
 //   - blob - The blob name.
 //   - comp - comp
 //   - legalHold - Specified if a legal hold should be set on the blob.
-//   - options - ClientSetLegalHoldOptions contains the optional parameters for the Client.SetLegalHold method.
-func (client *Client) SetLegalHold(ctx context.Context, containerName string, blob string, comp Enum24, legalHold bool, options *ClientSetLegalHoldOptions) (ClientSetLegalHoldResponse, error) {
+//   - options - BlobClientSetLegalHoldOptions contains the optional parameters for the BlobClient.SetLegalHold method.
+func (client *BlobClient) SetLegalHold(ctx context.Context, containerName string, blob string, comp Enum24, legalHold bool, options *BlobClientSetLegalHoldOptions) (BlobClientSetLegalHoldResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.SetLegalHold", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.SetLegalHold", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.setLegalHoldCreateRequest(ctx, containerName, blob, comp, legalHold, options)
 	if err != nil {
-		return ClientSetLegalHoldResponse{}, err
+		return BlobClientSetLegalHoldResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientSetLegalHoldResponse{}, err
+		return BlobClientSetLegalHoldResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientSetLegalHoldResponse{}, err
+		return BlobClientSetLegalHoldResponse{}, err
 	}
 	resp, err := client.setLegalHoldHandleResponse(httpResp)
 	return resp, err
 }
 
 // setLegalHoldCreateRequest creates the SetLegalHold request.
-func (client *Client) setLegalHoldCreateRequest(ctx context.Context, containerName string, blob string, comp Enum24, legalHold bool, options *ClientSetLegalHoldOptions) (*policy.Request, error) {
+func (client *BlobClient) setLegalHoldCreateRequest(ctx context.Context, containerName string, blob string, comp Enum24, legalHold bool, options *BlobClientSetLegalHoldOptions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -2640,22 +2641,22 @@ func (client *Client) setLegalHoldCreateRequest(ctx context.Context, containerNa
 }
 
 // setLegalHoldHandleResponse handles the SetLegalHold response.
-func (client *Client) setLegalHoldHandleResponse(resp *http.Response) (ClientSetLegalHoldResponse, error) {
-	result := ClientSetLegalHoldResponse{}
+func (client *BlobClient) setLegalHoldHandleResponse(resp *http.Response) (BlobClientSetLegalHoldResponse, error) {
+	result := BlobClientSetLegalHoldResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientSetLegalHoldResponse{}, err
+			return BlobClientSetLegalHoldResponse{}, err
 		}
 		result.Date = &date
 	}
 	if val := resp.Header.Get("x-ms-legal-hold"); val != "" {
 		legalHold, err := strconv.ParseBool(val)
 		if err != nil {
-			return ClientSetLegalHoldResponse{}, err
+			return BlobClientSetLegalHoldResponse{}, err
 		}
 		result.LegalHold = &legalHold
 	}
@@ -2674,33 +2675,33 @@ func (client *Client) setLegalHoldHandleResponse(resp *http.Response) (ClientSet
 //   - containerName - The container name.
 //   - blob - The blob name.
 //   - comp - comp
-//   - options - ClientSetMetadataOptions contains the optional parameters for the Client.SetMetadata method.
+//   - options - BlobClientSetMetadataOptions contains the optional parameters for the BlobClient.SetMetadata method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-func (client *Client) SetMetadata(ctx context.Context, containerName string, blob string, comp Enum12, options *ClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (ClientSetMetadataResponse, error) {
+func (client *BlobClient) SetMetadata(ctx context.Context, containerName string, blob string, comp Enum12, options *BlobClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlobClientSetMetadataResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.SetMetadata", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.SetMetadata", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.setMetadataCreateRequest(ctx, containerName, blob, comp, options, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
-		return ClientSetMetadataResponse{}, err
+		return BlobClientSetMetadataResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientSetMetadataResponse{}, err
+		return BlobClientSetMetadataResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientSetMetadataResponse{}, err
+		return BlobClientSetMetadataResponse{}, err
 	}
 	resp, err := client.setMetadataHandleResponse(httpResp)
 	return resp, err
 }
 
 // setMetadataCreateRequest creates the SetMetadata request.
-func (client *Client) setMetadataCreateRequest(ctx context.Context, containerName string, blob string, comp Enum12, options *ClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) setMetadataCreateRequest(ctx context.Context, containerName string, blob string, comp Enum12, options *BlobClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -2766,15 +2767,15 @@ func (client *Client) setMetadataCreateRequest(ctx context.Context, containerNam
 }
 
 // setMetadataHandleResponse handles the SetMetadata response.
-func (client *Client) setMetadataHandleResponse(resp *http.Response) (ClientSetMetadataResponse, error) {
-	result := ClientSetMetadataResponse{}
+func (client *BlobClient) setMetadataHandleResponse(resp *http.Response) (BlobClientSetMetadataResponse, error) {
+	result := BlobClientSetMetadataResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientSetMetadataResponse{}, err
+			return BlobClientSetMetadataResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -2790,14 +2791,14 @@ func (client *Client) setMetadataHandleResponse(resp *http.Response) (ClientSetM
 	if val := resp.Header.Get("x-ms-request-server-encrypted"); val != "" {
 		isServerEncrypted, err := strconv.ParseBool(val)
 		if err != nil {
-			return ClientSetMetadataResponse{}, err
+			return BlobClientSetMetadataResponse{}, err
 		}
 		result.IsServerEncrypted = &isServerEncrypted
 	}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientSetMetadataResponse{}, err
+			return BlobClientSetMetadataResponse{}, err
 		}
 		result.LastModified = &lastModified
 	}
@@ -2818,31 +2819,31 @@ func (client *Client) setMetadataHandleResponse(resp *http.Response) (ClientSetM
 //   - containerName - The container name.
 //   - blob - The blob name.
 //   - comp - comp
-//   - options - ClientSetTagsOptions contains the optional parameters for the Client.SetTags method.
+//   - options - BlobClientSetTagsOptions contains the optional parameters for the BlobClient.SetTags method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-func (client *Client) SetTags(ctx context.Context, containerName string, blob string, comp Enum39, options *ClientSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (ClientSetTagsResponse, error) {
+func (client *BlobClient) SetTags(ctx context.Context, containerName string, blob string, comp Enum39, options *BlobClientSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (BlobClientSetTagsResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.SetTags", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.SetTags", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.setTagsCreateRequest(ctx, containerName, blob, comp, options, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
-		return ClientSetTagsResponse{}, err
+		return BlobClientSetTagsResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientSetTagsResponse{}, err
+		return BlobClientSetTagsResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientSetTagsResponse{}, err
+		return BlobClientSetTagsResponse{}, err
 	}
 	resp, err := client.setTagsHandleResponse(httpResp)
 	return resp, err
 }
 
 // setTagsCreateRequest creates the SetTags request.
-func (client *Client) setTagsCreateRequest(ctx context.Context, containerName string, blob string, comp Enum39, options *ClientSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) setTagsCreateRequest(ctx context.Context, containerName string, blob string, comp Enum39, options *BlobClientSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -2892,15 +2893,15 @@ func (client *Client) setTagsCreateRequest(ctx context.Context, containerName st
 }
 
 // setTagsHandleResponse handles the SetTags response.
-func (client *Client) setTagsHandleResponse(resp *http.Response) (ClientSetTagsResponse, error) {
-	result := ClientSetTagsResponse{}
+func (client *BlobClient) setTagsHandleResponse(resp *http.Response) (BlobClientSetTagsResponse, error) {
+	result := BlobClientSetTagsResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientSetTagsResponse{}, err
+			return BlobClientSetTagsResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -2922,31 +2923,31 @@ func (client *Client) setTagsHandleResponse(resp *http.Response) (ClientSetTagsR
 //   - blob - The blob name.
 //   - comp - comp
 //   - tier - Indicates the tier to be set on the blob.
-//   - options - ClientSetTierOptions contains the optional parameters for the Client.SetTier method.
+//   - options - BlobClientSetTierOptions contains the optional parameters for the BlobClient.SetTier method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-func (client *Client) SetTier(ctx context.Context, containerName string, blob string, comp Enum29, tier AccessTier, options *ClientSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ClientSetTierResponse, error) {
+func (client *BlobClient) SetTier(ctx context.Context, containerName string, blob string, comp Enum29, tier AccessTier, options *BlobClientSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (BlobClientSetTierResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.SetTier", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.SetTier", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.setTierCreateRequest(ctx, containerName, blob, comp, tier, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
-		return ClientSetTierResponse{}, err
+		return BlobClientSetTierResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientSetTierResponse{}, err
+		return BlobClientSetTierResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusAccepted) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientSetTierResponse{}, err
+		return BlobClientSetTierResponse{}, err
 	}
 	resp, err := client.setTierHandleResponse(httpResp)
 	return resp, err
 }
 
 // setTierCreateRequest creates the SetTier request.
-func (client *Client) setTierCreateRequest(ctx context.Context, containerName string, blob string, comp Enum29, tier AccessTier, options *ClientSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) setTierCreateRequest(ctx context.Context, containerName string, blob string, comp Enum29, tier AccessTier, options *BlobClientSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -2991,8 +2992,8 @@ func (client *Client) setTierCreateRequest(ctx context.Context, containerName st
 }
 
 // setTierHandleResponse handles the SetTier response.
-func (client *Client) setTierHandleResponse(resp *http.Response) (ClientSetTierResponse, error) {
-	result := ClientSetTierResponse{}
+func (client *BlobClient) setTierHandleResponse(resp *http.Response) (BlobClientSetTierResponse, error) {
+	result := BlobClientSetTierResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -3012,33 +3013,33 @@ func (client *Client) setTierHandleResponse(resp *http.Response) (ClientSetTierR
 //   - copySource - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies
 //     a page blob snapshot. The value should be URL-encoded as it would appear in a request
 //     URI. The source blob must either be public or must be authenticated via a shared access signature.
-//   - options - ClientStartCopyFromURLOptions contains the optional parameters for the Client.StartCopyFromURL method.
-//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the Client.StartCopyFromURL
+//   - options - BlobClientStartCopyFromURLOptions contains the optional parameters for the BlobClient.StartCopyFromURL method.
+//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the BlobClient.StartCopyFromURL
 //     method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-func (client *Client) StartCopyFromURL(ctx context.Context, containerName string, blob string, copySource string, options *ClientStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (ClientStartCopyFromURLResponse, error) {
+func (client *BlobClient) StartCopyFromURL(ctx context.Context, containerName string, blob string, copySource string, options *BlobClientStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (BlobClientStartCopyFromURLResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.StartCopyFromURL", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.StartCopyFromURL", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.startCopyFromURLCreateRequest(ctx, containerName, blob, copySource, options, sourceModifiedAccessConditions, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
-		return ClientStartCopyFromURLResponse{}, err
+		return BlobClientStartCopyFromURLResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientStartCopyFromURLResponse{}, err
+		return BlobClientStartCopyFromURLResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusAccepted) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientStartCopyFromURLResponse{}, err
+		return BlobClientStartCopyFromURLResponse{}, err
 	}
 	resp, err := client.startCopyFromURLHandleResponse(httpResp)
 	return resp, err
 }
 
 // startCopyFromURLCreateRequest creates the StartCopyFromURL request.
-func (client *Client) startCopyFromURLCreateRequest(ctx context.Context, containerName string, blob string, copySource string, options *ClientStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *BlobClient) startCopyFromURLCreateRequest(ctx context.Context, containerName string, blob string, copySource string, options *BlobClientStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -3128,8 +3129,8 @@ func (client *Client) startCopyFromURLCreateRequest(ctx context.Context, contain
 }
 
 // startCopyFromURLHandleResponse handles the StartCopyFromURL response.
-func (client *Client) startCopyFromURLHandleResponse(resp *http.Response) (ClientStartCopyFromURLResponse, error) {
-	result := ClientStartCopyFromURLResponse{}
+func (client *BlobClient) startCopyFromURLHandleResponse(resp *http.Response) (BlobClientStartCopyFromURLResponse, error) {
+	result := BlobClientStartCopyFromURLResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -3142,7 +3143,7 @@ func (client *Client) startCopyFromURLHandleResponse(resp *http.Response) (Clien
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientStartCopyFromURLResponse{}, err
+			return BlobClientStartCopyFromURLResponse{}, err
 		}
 		result.Date = &date
 	}
@@ -3152,7 +3153,7 @@ func (client *Client) startCopyFromURLHandleResponse(resp *http.Response) (Clien
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientStartCopyFromURLResponse{}, err
+			return BlobClientStartCopyFromURLResponse{}, err
 		}
 		result.LastModified = &lastModified
 	}
@@ -3173,29 +3174,29 @@ func (client *Client) startCopyFromURLHandleResponse(resp *http.Response) (Clien
 //   - containerName - The container name.
 //   - blob - The blob name.
 //   - comp - comp
-//   - options - ClientUndeleteOptions contains the optional parameters for the Client.Undelete method.
-func (client *Client) Undelete(ctx context.Context, containerName string, blob string, comp Enum14, options *ClientUndeleteOptions) (ClientUndeleteResponse, error) {
+//   - options - BlobClientUndeleteOptions contains the optional parameters for the BlobClient.Undelete method.
+func (client *BlobClient) Undelete(ctx context.Context, containerName string, blob string, comp Enum14, options *BlobClientUndeleteOptions) (BlobClientUndeleteResponse, error) {
 	var err error
-	ctx, endSpan := runtime.StartSpan(ctx, "Client.Undelete", client.internal.Tracer(), nil)
+	ctx, endSpan := runtime.StartSpan(ctx, "BlobClient.Undelete", client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.undeleteCreateRequest(ctx, containerName, blob, comp, options)
 	if err != nil {
-		return ClientUndeleteResponse{}, err
+		return BlobClientUndeleteResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientUndeleteResponse{}, err
+		return BlobClientUndeleteResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientUndeleteResponse{}, err
+		return BlobClientUndeleteResponse{}, err
 	}
 	resp, err := client.undeleteHandleResponse(httpResp)
 	return resp, err
 }
 
 // undeleteCreateRequest creates the Undelete request.
-func (client *Client) undeleteCreateRequest(ctx context.Context, containerName string, blob string, comp Enum14, options *ClientUndeleteOptions) (*policy.Request, error) {
+func (client *BlobClient) undeleteCreateRequest(ctx context.Context, containerName string, blob string, comp Enum14, options *BlobClientUndeleteOptions) (*policy.Request, error) {
 	urlPath := "/{containerName}/{blob}"
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
@@ -3224,15 +3225,15 @@ func (client *Client) undeleteCreateRequest(ctx context.Context, containerName s
 }
 
 // undeleteHandleResponse handles the Undelete response.
-func (client *Client) undeleteHandleResponse(resp *http.Response) (ClientUndeleteResponse, error) {
-	result := ClientUndeleteResponse{}
+func (client *BlobClient) undeleteHandleResponse(resp *http.Response) (BlobClientUndeleteResponse, error) {
+	result := BlobClientUndeleteResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
 		if err != nil {
-			return ClientUndeleteResponse{}, err
+			return BlobClientUndeleteResponse{}, err
 		}
 		result.Date = &date
 	}

--- a/packages/autorest.go/test/storage/azblob/zz_blockblob_client.go
+++ b/packages/autorest.go/test/storage/azblob/zz_blockblob_client.go
@@ -43,10 +43,10 @@ type BlockBlobClient struct {
 //   - blocks - Blob Blocks.
 //   - options - BlockBlobClientCommitBlockListOptions contains the optional parameters for the BlockBlobClient.CommitBlockList
 //     method.
-//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the Client.SetHTTPHeaders method.
+//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the BlobClient.SetHTTPHeaders method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
 func (client *BlockBlobClient) CommitBlockList(ctx context.Context, containerName string, blob string, comp Enum31, blocks BlockLookupList, options *BlockBlobClientCommitBlockListOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlockBlobClientCommitBlockListResponse, error) {
 	var err error
@@ -365,12 +365,12 @@ func (client *BlockBlobClient) getBlockListHandleResponse(resp *http.Response) (
 //     URI. The source blob must either be public or must be authenticated via a shared access signature.
 //   - options - BlockBlobClientPutBlobFromURLOptions contains the optional parameters for the BlockBlobClient.PutBlobFromURL
 //     method.
-//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the Client.SetHTTPHeaders method.
+//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the BlobClient.SetHTTPHeaders method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the Client.StartCopyFromURL
+//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the BlobClient.StartCopyFromURL
 //     method.
 func (client *BlockBlobClient) PutBlobFromURL(ctx context.Context, containerName string, blob string, contentLength int64, copySource string, options *BlockBlobClientPutBlobFromURLOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (BlockBlobClientPutBlobFromURLResponse, error) {
 	var err error
@@ -581,8 +581,8 @@ func (client *BlockBlobClient) putBlobFromURLHandleResponse(resp *http.Response)
 //   - body - Initial data
 //   - options - BlockBlobClientStageBlockOptions contains the optional parameters for the BlockBlobClient.StageBlock method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 func (client *BlockBlobClient) StageBlock(ctx context.Context, containerName string, blob string, comp Enum30, blockID string, contentLength int64, body io.ReadSeekCloser, options *BlockBlobClientStageBlockOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo) (BlockBlobClientStageBlockResponse, error) {
 	var err error
 	ctx, endSpan := runtime.StartSpan(ctx, "BlockBlobClient.StageBlock", client.internal.Tracer(), nil)
@@ -720,10 +720,10 @@ func (client *BlockBlobClient) stageBlockHandleResponse(resp *http.Response) (Bl
 //   - sourceURL - Specify a URL to the copy source.
 //   - options - BlockBlobClientStageBlockFromURLOptions contains the optional parameters for the BlockBlobClient.StageBlockFromURL
 //     method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the Client.StartCopyFromURL
+//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the BlobClient.StartCopyFromURL
 //     method.
 func (client *BlockBlobClient) StageBlockFromURL(ctx context.Context, containerName string, blob string, comp Enum30, blockID string, contentLength int64, sourceURL string, options *BlockBlobClientStageBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (BlockBlobClientStageBlockFromURLResponse, error) {
 	var err error
@@ -875,10 +875,10 @@ func (client *BlockBlobClient) stageBlockFromURLHandleResponse(resp *http.Respon
 //   - contentLength - The length of the request.
 //   - body - Initial data
 //   - options - BlockBlobClientUploadOptions contains the optional parameters for the BlockBlobClient.Upload method.
-//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the Client.SetHTTPHeaders method.
+//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the BlobClient.SetHTTPHeaders method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
 func (client *BlockBlobClient) Upload(ctx context.Context, containerName string, blob string, contentLength int64, body io.ReadSeekCloser, options *BlockBlobClientUploadOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlockBlobClientUploadResponse, error) {
 	var err error

--- a/packages/autorest.go/test/storage/azblob/zz_models.go
+++ b/packages/autorest.go/test/storage/azblob/zz_models.go
@@ -34,6 +34,129 @@ type ArrowField struct {
 	Scale     *int32  `xml:"Scale"`
 }
 
+type BlobFlatListSegment struct {
+	// REQUIRED
+	BlobItems []*BlobItemInternal `xml:"Blob"`
+}
+
+type BlobHierarchyListSegment struct {
+	// REQUIRED
+	BlobItems    []*BlobItemInternal `xml:"Blob"`
+	BlobPrefixes []*BlobPrefix       `xml:"BlobPrefix"`
+}
+
+// BlobItemInternal - An Azure Storage blob
+type BlobItemInternal struct {
+	// REQUIRED
+	Deleted *bool `xml:"Deleted"`
+
+	// REQUIRED
+	Name *BlobName `xml:"Name"`
+
+	// REQUIRED; Properties of a blob
+	Properties *BlobPropertiesInternal `xml:"Properties"`
+
+	// REQUIRED
+	Snapshot *string `xml:"Snapshot"`
+
+	// Blob tags
+	BlobTags         *BlobTags     `xml:"Tags"`
+	HasVersionsOnly  *bool         `xml:"HasVersionsOnly"`
+	IsCurrentVersion *bool         `xml:"IsCurrentVersion"`
+	Metadata         *BlobMetadata `xml:"Metadata"`
+
+	// Dictionary of
+	ObjectReplicationMetadata map[string]*string `xml:"OrMetadata"`
+	VersionID                 *string            `xml:"VersionId"`
+}
+
+type BlobMetadata struct {
+	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
+	AdditionalProperties map[string]*string
+	Encrypted            *string `xml:"Encrypted,attr"`
+}
+
+type BlobName struct {
+	// The name of the blob.
+	Content *string `xml:",chardata"`
+
+	// Indicates if the blob name is encoded.
+	Encoded *bool `xml:"Encoded,attr"`
+}
+
+type BlobPrefix struct {
+	// REQUIRED
+	Name *BlobName `xml:"Name"`
+}
+
+// BlobPropertiesInternal - Properties of a blob
+type BlobPropertiesInternal struct {
+	// REQUIRED
+	Etag *string `xml:"Etag"`
+
+	// REQUIRED
+	LastModified         *time.Time     `xml:"Last-Modified"`
+	AccessTier           *AccessTier    `xml:"AccessTier"`
+	AccessTierChangeTime *time.Time     `xml:"AccessTierChangeTime"`
+	AccessTierInferred   *bool          `xml:"AccessTierInferred"`
+	ArchiveStatus        *ArchiveStatus `xml:"ArchiveStatus"`
+	BlobSequenceNumber   *int64         `xml:"x-ms-blob-sequence-number"`
+	BlobType             *BlobType      `xml:"BlobType"`
+	CacheControl         *string        `xml:"Cache-Control"`
+	ContentDisposition   *string        `xml:"Content-Disposition"`
+	ContentEncoding      *string        `xml:"Content-Encoding"`
+	ContentLanguage      *string        `xml:"Content-Language"`
+
+	// Size in bytes
+	ContentLength             *int64          `xml:"Content-Length"`
+	ContentMD5                []byte          `xml:"Content-MD5"`
+	ContentType               *string         `xml:"Content-Type"`
+	CopyCompletionTime        *time.Time      `xml:"CopyCompletionTime"`
+	CopyID                    *string         `xml:"CopyId"`
+	CopyProgress              *string         `xml:"CopyProgress"`
+	CopySource                *string         `xml:"CopySource"`
+	CopyStatus                *CopyStatusType `xml:"CopyStatus"`
+	CopyStatusDescription     *string         `xml:"CopyStatusDescription"`
+	CreationTime              *time.Time      `xml:"Creation-Time"`
+	CustomerProvidedKeySHA256 *string         `xml:"CustomerProvidedKeySha256"`
+	DeletedTime               *time.Time      `xml:"DeletedTime"`
+	DestinationSnapshot       *string         `xml:"DestinationSnapshot"`
+
+	// The name of the encryption scope under which the blob is encrypted.
+	EncryptionScope             *string                     `xml:"EncryptionScope"`
+	ExpiresOn                   *time.Time                  `xml:"Expiry-Time"`
+	ImmutabilityPolicyExpiresOn *time.Time                  `xml:"ImmutabilityPolicyUntilDate"`
+	ImmutabilityPolicyMode      *BlobImmutabilityPolicyMode `xml:"ImmutabilityPolicyMode"`
+	IncrementalCopy             *bool                       `xml:"IncrementalCopy"`
+	IsSealed                    *bool                       `xml:"Sealed"`
+	LastAccessedOn              *time.Time                  `xml:"LastAccessTime"`
+	LeaseDuration               *LeaseDurationType          `xml:"LeaseDuration"`
+	LeaseState                  *LeaseStateType             `xml:"LeaseState"`
+	LeaseStatus                 *LeaseStatusType            `xml:"LeaseStatus"`
+	LegalHold                   *bool                       `xml:"LegalHold"`
+
+	// If an object is in rehydrate pending state then this header is returned with priority of rehydrate. Valid values are High
+	// and Standard.
+	RehydratePriority      *RehydratePriority `xml:"RehydratePriority"`
+	RemainingRetentionDays *int32             `xml:"RemainingRetentionDays"`
+	ServerEncrypted        *bool              `xml:"ServerEncrypted"`
+	TagCount               *int32             `xml:"TagCount"`
+}
+
+type BlobTag struct {
+	// REQUIRED
+	Key *string `xml:"Key"`
+
+	// REQUIRED
+	Value *string `xml:"Value"`
+}
+
+// BlobTags - Blob tags
+type BlobTags struct {
+	// REQUIRED
+	BlobTagSet []*BlobTag `xml:"TagSet>Tag"`
+}
+
 // Block - Represents a single block in a block blob. It describes the block's ID and size.
 type Block struct {
 	// REQUIRED; The base64 encoded block ID.
@@ -151,8 +274,8 @@ type FilterBlobItem struct {
 	IsCurrentVersion *bool   `xml:"IsCurrentVersion"`
 
 	// Blob tags
-	Tags      *Tags   `xml:"Tags"`
-	VersionID *string `xml:"VersionId"`
+	Tags      *BlobTags `xml:"Tags"`
+	VersionID *string   `xml:"VersionId"`
 }
 
 // FilterBlobSegment - The result of a Filter Blobs API call
@@ -168,11 +291,6 @@ type FilterBlobSegment struct {
 	NextMarker *string `xml:"NextMarker"`
 }
 
-type FlatListSegment struct {
-	// REQUIRED
-	BlobItems []*ItemInternal `xml:"Blob"`
-}
-
 // GeoReplication - Geo-Replication information for the Secondary Storage Service
 type GeoReplication struct {
 	// REQUIRED; A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available
@@ -182,37 +300,6 @@ type GeoReplication struct {
 
 	// REQUIRED; The status of the secondary location
 	Status *GeoReplicationStatusType `xml:"Status"`
-}
-
-type HierarchyListSegment struct {
-	// REQUIRED
-	BlobItems    []*ItemInternal `xml:"Blob"`
-	BlobPrefixes []*Prefix       `xml:"BlobPrefix"`
-}
-
-// ItemInternal - An Azure Storage blob
-type ItemInternal struct {
-	// REQUIRED
-	Deleted *bool `xml:"Deleted"`
-
-	// REQUIRED
-	Name *Name `xml:"Name"`
-
-	// REQUIRED; Properties of a blob
-	Properties *PropertiesInternal `xml:"Properties"`
-
-	// REQUIRED
-	Snapshot *string `xml:"Snapshot"`
-
-	// Blob tags
-	BlobTags         *Tags     `xml:"Tags"`
-	HasVersionsOnly  *bool     `xml:"HasVersionsOnly"`
-	IsCurrentVersion *bool     `xml:"IsCurrentVersion"`
-	Metadata         *Metadata `xml:"Metadata"`
-
-	// Dictionary of
-	ObjectReplicationMetadata map[string]*string `xml:"OrMetadata"`
-	VersionID                 *string            `xml:"VersionId"`
 }
 
 // JSONTextConfiguration - json text configuration
@@ -236,7 +323,7 @@ type ListBlobsFlatSegmentResponse struct {
 	ContainerName *string `xml:"ContainerName,attr"`
 
 	// REQUIRED
-	Segment *FlatListSegment `xml:"Blobs"`
+	Segment *BlobFlatListSegment `xml:"Blobs"`
 
 	// REQUIRED
 	ServiceEndpoint *string `xml:"ServiceEndpoint,attr"`
@@ -252,7 +339,7 @@ type ListBlobsHierarchySegmentResponse struct {
 	ContainerName *string `xml:"ContainerName,attr"`
 
 	// REQUIRED
-	Segment *HierarchyListSegment `xml:"Blobs"`
+	Segment *BlobHierarchyListSegment `xml:"Blobs"`
 
 	// REQUIRED
 	ServiceEndpoint *string `xml:"ServiceEndpoint,attr"`
@@ -294,12 +381,6 @@ type Logging struct {
 	Write *bool `xml:"Write"`
 }
 
-type Metadata struct {
-	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties map[string]*string
-	Encrypted            *string `xml:"Encrypted,attr"`
-}
-
 // Metrics - a summary of request statistics grouped by API in hour or minute aggregates for blobs
 type Metrics struct {
 	// REQUIRED; Indicates whether metrics are enabled for the Blob service.
@@ -315,14 +396,6 @@ type Metrics struct {
 	Version *string `xml:"Version"`
 }
 
-type Name struct {
-	// The name of the blob.
-	Content *string `xml:",chardata"`
-
-	// Indicates if the blob name is encoded.
-	Encoded *bool `xml:"Encoded,attr"`
-}
-
 // PageList - the list of pages
 type PageList struct {
 	ClearRange []*ClearRange `xml:"ClearRange"`
@@ -336,65 +409,6 @@ type PageRange struct {
 
 	// REQUIRED
 	Start *int64 `xml:"Start"`
-}
-
-type Prefix struct {
-	// REQUIRED
-	Name *Name `xml:"Name"`
-}
-
-// PropertiesInternal - Properties of a blob
-type PropertiesInternal struct {
-	// REQUIRED
-	Etag *string `xml:"Etag"`
-
-	// REQUIRED
-	LastModified         *time.Time     `xml:"Last-Modified"`
-	AccessTier           *AccessTier    `xml:"AccessTier"`
-	AccessTierChangeTime *time.Time     `xml:"AccessTierChangeTime"`
-	AccessTierInferred   *bool          `xml:"AccessTierInferred"`
-	ArchiveStatus        *ArchiveStatus `xml:"ArchiveStatus"`
-	BlobSequenceNumber   *int64         `xml:"x-ms-blob-sequence-number"`
-	BlobType             *BlobType      `xml:"BlobType"`
-	CacheControl         *string        `xml:"Cache-Control"`
-	ContentDisposition   *string        `xml:"Content-Disposition"`
-	ContentEncoding      *string        `xml:"Content-Encoding"`
-	ContentLanguage      *string        `xml:"Content-Language"`
-
-	// Size in bytes
-	ContentLength             *int64          `xml:"Content-Length"`
-	ContentMD5                []byte          `xml:"Content-MD5"`
-	ContentType               *string         `xml:"Content-Type"`
-	CopyCompletionTime        *time.Time      `xml:"CopyCompletionTime"`
-	CopyID                    *string         `xml:"CopyId"`
-	CopyProgress              *string         `xml:"CopyProgress"`
-	CopySource                *string         `xml:"CopySource"`
-	CopyStatus                *CopyStatusType `xml:"CopyStatus"`
-	CopyStatusDescription     *string         `xml:"CopyStatusDescription"`
-	CreationTime              *time.Time      `xml:"Creation-Time"`
-	CustomerProvidedKeySHA256 *string         `xml:"CustomerProvidedKeySha256"`
-	DeletedTime               *time.Time      `xml:"DeletedTime"`
-	DestinationSnapshot       *string         `xml:"DestinationSnapshot"`
-
-	// The name of the encryption scope under which the blob is encrypted.
-	EncryptionScope             *string                     `xml:"EncryptionScope"`
-	ExpiresOn                   *time.Time                  `xml:"Expiry-Time"`
-	ImmutabilityPolicyExpiresOn *time.Time                  `xml:"ImmutabilityPolicyUntilDate"`
-	ImmutabilityPolicyMode      *BlobImmutabilityPolicyMode `xml:"ImmutabilityPolicyMode"`
-	IncrementalCopy             *bool                       `xml:"IncrementalCopy"`
-	IsSealed                    *bool                       `xml:"Sealed"`
-	LastAccessedOn              *time.Time                  `xml:"LastAccessTime"`
-	LeaseDuration               *LeaseDurationType          `xml:"LeaseDuration"`
-	LeaseState                  *LeaseStateType             `xml:"LeaseState"`
-	LeaseStatus                 *LeaseStatusType            `xml:"LeaseStatus"`
-	LegalHold                   *bool                       `xml:"LegalHold"`
-
-	// If an object is in rehydrate pending state then this header is returned with priority of rehydrate. Valid values are High
-	// and Standard.
-	RehydratePriority      *RehydratePriority `xml:"RehydratePriority"`
-	RemainingRetentionDays *int32             `xml:"RemainingRetentionDays"`
-	ServerEncrypted        *bool              `xml:"ServerEncrypted"`
-	TagCount               *int32             `xml:"TagCount"`
 }
 
 type QueryFormat struct {
@@ -500,20 +514,6 @@ type StorageServiceProperties struct {
 type StorageServiceStats struct {
 	// Geo-Replication information for the Secondary Storage Service
 	GeoReplication *GeoReplication `xml:"GeoReplication"`
-}
-
-type Tag struct {
-	// REQUIRED
-	Key *string `xml:"Key"`
-
-	// REQUIRED
-	Value *string `xml:"Value"`
-}
-
-// Tags - Blob tags
-type Tags struct {
-	// REQUIRED
-	BlobTagSet []*Tag `xml:"TagSet>Tag"`
 }
 
 // UserDelegationKey - A user delegation key

--- a/packages/autorest.go/test/storage/azblob/zz_models_serde.go
+++ b/packages/autorest.go/test/storage/azblob/zz_models_serde.go
@@ -43,6 +43,169 @@ func (a ArrowField) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	return enc.EncodeElement(aux, start)
 }
 
+// MarshalXML implements the xml.Marshaller interface for type BlobFlatListSegment.
+func (b BlobFlatListSegment) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	start.Name.Local = "Blobs"
+	type alias BlobFlatListSegment
+	aux := &struct {
+		*alias
+		BlobItems *[]*BlobItemInternal `xml:"Blob"`
+	}{
+		alias: (*alias)(&b),
+	}
+	if b.BlobItems != nil {
+		aux.BlobItems = &b.BlobItems
+	}
+	return enc.EncodeElement(aux, start)
+}
+
+// MarshalXML implements the xml.Marshaller interface for type BlobHierarchyListSegment.
+func (b BlobHierarchyListSegment) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	start.Name.Local = "Blobs"
+	type alias BlobHierarchyListSegment
+	aux := &struct {
+		*alias
+		BlobItems    *[]*BlobItemInternal `xml:"Blob"`
+		BlobPrefixes *[]*BlobPrefix       `xml:"BlobPrefix"`
+	}{
+		alias: (*alias)(&b),
+	}
+	if b.BlobItems != nil {
+		aux.BlobItems = &b.BlobItems
+	}
+	if b.BlobPrefixes != nil {
+		aux.BlobPrefixes = &b.BlobPrefixes
+	}
+	return enc.EncodeElement(aux, start)
+}
+
+// MarshalXML implements the xml.Marshaller interface for type BlobMetadata.
+func (b BlobMetadata) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	start.Name.Local = "Metadata"
+	type alias BlobMetadata
+	aux := &struct {
+		*alias
+		AdditionalProperties additionalProperties `xml:"Metadata"`
+	}{
+		alias: (*alias)(&b),
+	}
+	aux.AdditionalProperties = (additionalProperties)(b.AdditionalProperties)
+	return enc.EncodeElement(aux, start)
+}
+
+// MarshalXML implements the xml.Marshaller interface for type BlobPropertiesInternal.
+func (b BlobPropertiesInternal) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	start.Name.Local = "Properties"
+	type alias BlobPropertiesInternal
+	aux := &struct {
+		*alias
+		AccessTierChangeTime        *datetime.RFC1123 `xml:"AccessTierChangeTime"`
+		ContentMD5                  *string           `xml:"Content-MD5"`
+		CopyCompletionTime          *datetime.RFC1123 `xml:"CopyCompletionTime"`
+		CreationTime                *datetime.RFC1123 `xml:"Creation-Time"`
+		DeletedTime                 *datetime.RFC1123 `xml:"DeletedTime"`
+		ExpiresOn                   *datetime.RFC1123 `xml:"Expiry-Time"`
+		ImmutabilityPolicyExpiresOn *datetime.RFC1123 `xml:"ImmutabilityPolicyUntilDate"`
+		LastAccessedOn              *datetime.RFC1123 `xml:"LastAccessTime"`
+		LastModified                *datetime.RFC1123 `xml:"Last-Modified"`
+	}{
+		alias:                       (*alias)(&b),
+		AccessTierChangeTime:        (*datetime.RFC1123)(b.AccessTierChangeTime),
+		CopyCompletionTime:          (*datetime.RFC1123)(b.CopyCompletionTime),
+		CreationTime:                (*datetime.RFC1123)(b.CreationTime),
+		DeletedTime:                 (*datetime.RFC1123)(b.DeletedTime),
+		ExpiresOn:                   (*datetime.RFC1123)(b.ExpiresOn),
+		ImmutabilityPolicyExpiresOn: (*datetime.RFC1123)(b.ImmutabilityPolicyExpiresOn),
+		LastAccessedOn:              (*datetime.RFC1123)(b.LastAccessedOn),
+		LastModified:                (*datetime.RFC1123)(b.LastModified),
+	}
+	if b.ContentMD5 != nil {
+		encodedContentMD5 := runtime.EncodeByteArray(b.ContentMD5, runtime.Base64StdFormat)
+		aux.ContentMD5 = &encodedContentMD5
+	}
+	return enc.EncodeElement(aux, start)
+}
+
+// UnmarshalXML implements the xml.Unmarshaller interface for type BlobPropertiesInternal.
+func (b *BlobPropertiesInternal) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	type alias BlobPropertiesInternal
+	aux := &struct {
+		*alias
+		AccessTierChangeTime        *datetime.RFC1123 `xml:"AccessTierChangeTime"`
+		ContentMD5                  *string           `xml:"Content-MD5"`
+		CopyCompletionTime          *datetime.RFC1123 `xml:"CopyCompletionTime"`
+		CreationTime                *datetime.RFC1123 `xml:"Creation-Time"`
+		DeletedTime                 *datetime.RFC1123 `xml:"DeletedTime"`
+		ExpiresOn                   *datetime.RFC1123 `xml:"Expiry-Time"`
+		ImmutabilityPolicyExpiresOn *datetime.RFC1123 `xml:"ImmutabilityPolicyUntilDate"`
+		LastAccessedOn              *datetime.RFC1123 `xml:"LastAccessTime"`
+		LastModified                *datetime.RFC1123 `xml:"Last-Modified"`
+	}{
+		alias: (*alias)(b),
+	}
+	if err := dec.DecodeElement(aux, &start); err != nil {
+		return err
+	}
+	if aux.AccessTierChangeTime != nil && !(*time.Time)(aux.AccessTierChangeTime).IsZero() {
+		b.AccessTierChangeTime = (*time.Time)(aux.AccessTierChangeTime)
+	}
+	if aux.ContentMD5 != nil {
+		if err := runtime.DecodeByteArray(*aux.ContentMD5, &b.ContentMD5, runtime.Base64StdFormat); err != nil {
+			return err
+		}
+	}
+	if aux.CopyCompletionTime != nil && !(*time.Time)(aux.CopyCompletionTime).IsZero() {
+		b.CopyCompletionTime = (*time.Time)(aux.CopyCompletionTime)
+	}
+	if aux.CreationTime != nil && !(*time.Time)(aux.CreationTime).IsZero() {
+		b.CreationTime = (*time.Time)(aux.CreationTime)
+	}
+	if aux.DeletedTime != nil && !(*time.Time)(aux.DeletedTime).IsZero() {
+		b.DeletedTime = (*time.Time)(aux.DeletedTime)
+	}
+	if aux.ExpiresOn != nil && !(*time.Time)(aux.ExpiresOn).IsZero() {
+		b.ExpiresOn = (*time.Time)(aux.ExpiresOn)
+	}
+	if aux.ImmutabilityPolicyExpiresOn != nil && !(*time.Time)(aux.ImmutabilityPolicyExpiresOn).IsZero() {
+		b.ImmutabilityPolicyExpiresOn = (*time.Time)(aux.ImmutabilityPolicyExpiresOn)
+	}
+	if aux.LastAccessedOn != nil && !(*time.Time)(aux.LastAccessedOn).IsZero() {
+		b.LastAccessedOn = (*time.Time)(aux.LastAccessedOn)
+	}
+	if aux.LastModified != nil && !(*time.Time)(aux.LastModified).IsZero() {
+		b.LastModified = (*time.Time)(aux.LastModified)
+	}
+	return nil
+}
+
+// MarshalXML implements the xml.Marshaller interface for type BlobTag.
+func (b BlobTag) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	start.Name.Local = "Tag"
+	type alias BlobTag
+	aux := &struct {
+		*alias
+	}{
+		alias: (*alias)(&b),
+	}
+	return enc.EncodeElement(aux, start)
+}
+
+// MarshalXML implements the xml.Marshaller interface for type BlobTags.
+func (b BlobTags) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	start.Name.Local = "Tags"
+	type alias BlobTags
+	aux := &struct {
+		*alias
+		BlobTagSet *[]*BlobTag `xml:"TagSet>Tag"`
+	}{
+		alias: (*alias)(&b),
+	}
+	if b.BlobTagSet != nil {
+		aux.BlobTagSet = &b.BlobTagSet
+	}
+	return enc.EncodeElement(aux, start)
+}
+
 // MarshalXML implements the xml.Marshaller interface for type BlockList.
 func (b BlockList) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias BlockList
@@ -181,22 +344,6 @@ func (f FilterBlobSegment) MarshalXML(enc *xml.Encoder, start xml.StartElement) 
 	return enc.EncodeElement(aux, start)
 }
 
-// MarshalXML implements the xml.Marshaller interface for type FlatListSegment.
-func (f FlatListSegment) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
-	start.Name.Local = "Blobs"
-	type alias FlatListSegment
-	aux := &struct {
-		*alias
-		BlobItems *[]*ItemInternal `xml:"Blob"`
-	}{
-		alias: (*alias)(&f),
-	}
-	if f.BlobItems != nil {
-		aux.BlobItems = &f.BlobItems
-	}
-	return enc.EncodeElement(aux, start)
-}
-
 // MarshalXML implements the xml.Marshaller interface for type GeoReplication.
 func (g GeoReplication) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias GeoReplication
@@ -226,26 +373,6 @@ func (g *GeoReplication) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) 
 		g.LastSyncTime = (*time.Time)(aux.LastSyncTime)
 	}
 	return nil
-}
-
-// MarshalXML implements the xml.Marshaller interface for type HierarchyListSegment.
-func (h HierarchyListSegment) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
-	start.Name.Local = "Blobs"
-	type alias HierarchyListSegment
-	aux := &struct {
-		*alias
-		BlobItems    *[]*ItemInternal `xml:"Blob"`
-		BlobPrefixes *[]*Prefix       `xml:"BlobPrefix"`
-	}{
-		alias: (*alias)(&h),
-	}
-	if h.BlobItems != nil {
-		aux.BlobItems = &h.BlobItems
-	}
-	if h.BlobPrefixes != nil {
-		aux.BlobPrefixes = &h.BlobPrefixes
-	}
-	return enc.EncodeElement(aux, start)
 }
 
 // MarshalXML implements the xml.Marshaller interface for type JSONTextConfiguration.
@@ -319,91 +446,6 @@ func (p PageList) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	return enc.EncodeElement(aux, start)
 }
 
-// MarshalXML implements the xml.Marshaller interface for type PropertiesInternal.
-func (p PropertiesInternal) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
-	start.Name.Local = "Properties"
-	type alias PropertiesInternal
-	aux := &struct {
-		*alias
-		AccessTierChangeTime        *datetime.RFC1123 `xml:"AccessTierChangeTime"`
-		ContentMD5                  *string           `xml:"Content-MD5"`
-		CopyCompletionTime          *datetime.RFC1123 `xml:"CopyCompletionTime"`
-		CreationTime                *datetime.RFC1123 `xml:"Creation-Time"`
-		DeletedTime                 *datetime.RFC1123 `xml:"DeletedTime"`
-		ExpiresOn                   *datetime.RFC1123 `xml:"Expiry-Time"`
-		ImmutabilityPolicyExpiresOn *datetime.RFC1123 `xml:"ImmutabilityPolicyUntilDate"`
-		LastAccessedOn              *datetime.RFC1123 `xml:"LastAccessTime"`
-		LastModified                *datetime.RFC1123 `xml:"Last-Modified"`
-	}{
-		alias:                       (*alias)(&p),
-		AccessTierChangeTime:        (*datetime.RFC1123)(p.AccessTierChangeTime),
-		CopyCompletionTime:          (*datetime.RFC1123)(p.CopyCompletionTime),
-		CreationTime:                (*datetime.RFC1123)(p.CreationTime),
-		DeletedTime:                 (*datetime.RFC1123)(p.DeletedTime),
-		ExpiresOn:                   (*datetime.RFC1123)(p.ExpiresOn),
-		ImmutabilityPolicyExpiresOn: (*datetime.RFC1123)(p.ImmutabilityPolicyExpiresOn),
-		LastAccessedOn:              (*datetime.RFC1123)(p.LastAccessedOn),
-		LastModified:                (*datetime.RFC1123)(p.LastModified),
-	}
-	if p.ContentMD5 != nil {
-		encodedContentMD5 := runtime.EncodeByteArray(p.ContentMD5, runtime.Base64StdFormat)
-		aux.ContentMD5 = &encodedContentMD5
-	}
-	return enc.EncodeElement(aux, start)
-}
-
-// UnmarshalXML implements the xml.Unmarshaller interface for type PropertiesInternal.
-func (p *PropertiesInternal) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
-	type alias PropertiesInternal
-	aux := &struct {
-		*alias
-		AccessTierChangeTime        *datetime.RFC1123 `xml:"AccessTierChangeTime"`
-		ContentMD5                  *string           `xml:"Content-MD5"`
-		CopyCompletionTime          *datetime.RFC1123 `xml:"CopyCompletionTime"`
-		CreationTime                *datetime.RFC1123 `xml:"Creation-Time"`
-		DeletedTime                 *datetime.RFC1123 `xml:"DeletedTime"`
-		ExpiresOn                   *datetime.RFC1123 `xml:"Expiry-Time"`
-		ImmutabilityPolicyExpiresOn *datetime.RFC1123 `xml:"ImmutabilityPolicyUntilDate"`
-		LastAccessedOn              *datetime.RFC1123 `xml:"LastAccessTime"`
-		LastModified                *datetime.RFC1123 `xml:"Last-Modified"`
-	}{
-		alias: (*alias)(p),
-	}
-	if err := dec.DecodeElement(aux, &start); err != nil {
-		return err
-	}
-	if aux.AccessTierChangeTime != nil && !(*time.Time)(aux.AccessTierChangeTime).IsZero() {
-		p.AccessTierChangeTime = (*time.Time)(aux.AccessTierChangeTime)
-	}
-	if aux.ContentMD5 != nil {
-		if err := runtime.DecodeByteArray(*aux.ContentMD5, &p.ContentMD5, runtime.Base64StdFormat); err != nil {
-			return err
-		}
-	}
-	if aux.CopyCompletionTime != nil && !(*time.Time)(aux.CopyCompletionTime).IsZero() {
-		p.CopyCompletionTime = (*time.Time)(aux.CopyCompletionTime)
-	}
-	if aux.CreationTime != nil && !(*time.Time)(aux.CreationTime).IsZero() {
-		p.CreationTime = (*time.Time)(aux.CreationTime)
-	}
-	if aux.DeletedTime != nil && !(*time.Time)(aux.DeletedTime).IsZero() {
-		p.DeletedTime = (*time.Time)(aux.DeletedTime)
-	}
-	if aux.ExpiresOn != nil && !(*time.Time)(aux.ExpiresOn).IsZero() {
-		p.ExpiresOn = (*time.Time)(aux.ExpiresOn)
-	}
-	if aux.ImmutabilityPolicyExpiresOn != nil && !(*time.Time)(aux.ImmutabilityPolicyExpiresOn).IsZero() {
-		p.ImmutabilityPolicyExpiresOn = (*time.Time)(aux.ImmutabilityPolicyExpiresOn)
-	}
-	if aux.LastAccessedOn != nil && !(*time.Time)(aux.LastAccessedOn).IsZero() {
-		p.LastAccessedOn = (*time.Time)(aux.LastAccessedOn)
-	}
-	if aux.LastModified != nil && !(*time.Time)(aux.LastModified).IsZero() {
-		p.LastModified = (*time.Time)(aux.LastModified)
-	}
-	return nil
-}
-
 // MarshalJSON implements the json.Marshaller interface for type StorageError.
 func (s StorageError) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -442,21 +484,6 @@ func (s StorageServiceProperties) MarshalXML(enc *xml.Encoder, start xml.StartEl
 	}
 	if s.Cors != nil {
 		aux.Cors = &s.Cors
-	}
-	return enc.EncodeElement(aux, start)
-}
-
-// MarshalXML implements the xml.Marshaller interface for type Tags.
-func (t Tags) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
-	type alias Tags
-	aux := &struct {
-		*alias
-		BlobTagSet *[]*Tag `xml:"TagSet>Tag"`
-	}{
-		alias: (*alias)(&t),
-	}
-	if t.BlobTagSet != nil {
-		aux.BlobTagSet = &t.BlobTagSet
 	}
 	return enc.EncodeElement(aux, start)
 }

--- a/packages/autorest.go/test/storage/azblob/zz_options.go
+++ b/packages/autorest.go/test/storage/azblob/zz_options.go
@@ -107,7 +107,459 @@ type AppendPositionAccessConditions struct {
 	MaxSize *int64
 }
 
-// BlobHTTPHeaders contains a group of parameters for the Client.SetHTTPHeaders method.
+// BlobClientAbortCopyFromURLOptions contains the optional parameters for the BlobClient.AbortCopyFromURL method.
+type BlobClientAbortCopyFromURLOptions struct {
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientAcquireLeaseOptions contains the optional parameters for the BlobClient.AcquireLease method.
+type BlobClientAcquireLeaseOptions struct {
+	// Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease
+	// can be between 15 and 60 seconds. A lease duration cannot be changed using
+	// renew or change.
+	Duration *int32
+
+	// Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed lease ID is
+	// not in the correct format. See Guid Constructor (String) for a list of valid GUID
+	// string formats.
+	ProposedLeaseID *string
+
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientBreakLeaseOptions contains the optional parameters for the BlobClient.BreakLease method.
+type BlobClientBreakLeaseOptions struct {
+	// For a break operation, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60. This
+	// break period is only used if it is shorter than the time remaining on the
+	// lease. If longer, the time remaining on the lease is used. A new lease will not be available before the break period has
+	// expired, but the lease may be held for longer than the break period. If this
+	// header does not appear with a break operation, a fixed-duration lease breaks after the remaining lease period elapses,
+	// and an infinite lease breaks immediately.
+	BreakPeriod *int32
+
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientChangeLeaseOptions contains the optional parameters for the BlobClient.ChangeLease method.
+type BlobClientChangeLeaseOptions struct {
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientCopyFromURLOptions contains the optional parameters for the BlobClient.CopyFromURL method.
+type BlobClientCopyFromURLOptions struct {
+	// Optional. Used to set blob tags in various blob operations.
+	BlobTagsString *string
+
+	// Only Bearer type is supported. Credentials should be a valid OAuth access token to copy source.
+	CopySourceAuthorization *string
+
+	// Optional, default 'replace'. Indicates if source tags should be copied or replaced with the tags specified by x-ms-tags.
+	CopySourceTags *BlobCopySourceTags
+
+	// Specifies the date time when the blobs immutability policy is set to expire.
+	ImmutabilityPolicyExpiry *time.Time
+
+	// Specifies the immutability policy mode to set on the blob.
+	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+
+	// Specified if a legal hold should be set on the blob.
+	LegalHold *bool
+
+	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
+	// operation will copy the metadata from the source blob or file to the destination
+	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
+	// is not copied from the source blob or file. Note that beginning with
+	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
+	// Blobs, and Metadata for more information.
+	Metadata map[string]*string
+
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// Specify the md5 calculated for the range of bytes that must be read from the copy source.
+	SourceContentMD5 []byte
+
+	// Optional. Indicates the tier to be set on the blob.
+	Tier *AccessTier
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientCreateSnapshotOptions contains the optional parameters for the BlobClient.CreateSnapshot method.
+type BlobClientCreateSnapshotOptions struct {
+	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
+	// operation will copy the metadata from the source blob or file to the destination
+	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
+	// is not copied from the source blob or file. Note that beginning with
+	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
+	// Blobs, and Metadata for more information.
+	Metadata map[string]*string
+
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientDeleteImmutabilityPolicyOptions contains the optional parameters for the BlobClient.DeleteImmutabilityPolicy
+// method.
+type BlobClientDeleteImmutabilityPolicyOptions struct {
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientDeleteOptions contains the optional parameters for the BlobClient.Delete method.
+type BlobClientDeleteOptions struct {
+	// Optional. Only possible value is 'permanent', which specifies to permanently delete a blob if blob soft delete is enabled..
+	// Specifying any value will set the value to Permanent.
+	BlobDeleteType *string
+
+	// Required if the blob has associated snapshots. Specify one of the following two options: include: Delete the base blob
+	// and all of its snapshots. only: Delete only the blob's snapshots and not the blob
+	// itself
+	DeleteSnapshots *DeleteSnapshotsOptionType
+
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
+	Snapshot *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+
+	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
+	// It's for service version 2019-10-10 and newer.
+	VersionID *string
+}
+
+// BlobClientDownloadOptions contains the optional parameters for the BlobClient.Download method.
+type BlobClientDownloadOptions struct {
+	// Return only the bytes of the blob in the specified range.
+	Range *string
+
+	// When set to true and specified together with the Range, the service returns the CRC64 hash for the range, as long as the
+	// range is less than or equal to 4 MB in size.
+	RangeGetContentCRC64 *bool
+
+	// When set to true and specified together with the Range, the service returns the MD5 hash for the range, as long as the
+	// range is less than or equal to 4 MB in size.
+	RangeGetContentMD5 *bool
+
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
+	Snapshot *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+
+	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
+	// It's for service version 2019-10-10 and newer.
+	VersionID *string
+}
+
+// BlobClientGetAccountInfoOptions contains the optional parameters for the BlobClient.GetAccountInfo method.
+type BlobClientGetAccountInfoOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BlobClientGetPropertiesOptions contains the optional parameters for the BlobClient.GetProperties method.
+type BlobClientGetPropertiesOptions struct {
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
+	Snapshot *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+
+	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
+	// It's for service version 2019-10-10 and newer.
+	VersionID *string
+}
+
+// BlobClientGetTagsOptions contains the optional parameters for the BlobClient.GetTags method.
+type BlobClientGetTagsOptions struct {
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
+	Snapshot *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+
+	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
+	// It's for service version 2019-10-10 and newer.
+	VersionID *string
+}
+
+// BlobClientQueryOptions contains the optional parameters for the BlobClient.Query method.
+type BlobClientQueryOptions struct {
+	// the query request
+	QueryRequest *QueryRequest
+
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
+	Snapshot *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientReleaseLeaseOptions contains the optional parameters for the BlobClient.ReleaseLease method.
+type BlobClientReleaseLeaseOptions struct {
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientRenewLeaseOptions contains the optional parameters for the BlobClient.RenewLease method.
+type BlobClientRenewLeaseOptions struct {
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientSetExpiryOptions contains the optional parameters for the BlobClient.SetExpiry method.
+type BlobClientSetExpiryOptions struct {
+	// The time to set the blob to expiry
+	ExpiresOn *string
+
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientSetHTTPHeadersOptions contains the optional parameters for the BlobClient.SetHTTPHeaders method.
+type BlobClientSetHTTPHeadersOptions struct {
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientSetImmutabilityPolicyOptions contains the optional parameters for the BlobClient.SetImmutabilityPolicy method.
+type BlobClientSetImmutabilityPolicyOptions struct {
+	// Specifies the date time when the blobs immutability policy is set to expire.
+	ImmutabilityPolicyExpiry *time.Time
+
+	// Specifies the immutability policy mode to set on the blob.
+	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientSetLegalHoldOptions contains the optional parameters for the BlobClient.SetLegalHold method.
+type BlobClientSetLegalHoldOptions struct {
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientSetMetadataOptions contains the optional parameters for the BlobClient.SetMetadata method.
+type BlobClientSetMetadataOptions struct {
+	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
+	// operation will copy the metadata from the source blob or file to the destination
+	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
+	// is not copied from the source blob or file. Note that beginning with
+	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
+	// Blobs, and Metadata for more information.
+	Metadata map[string]*string
+
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientSetTagsOptions contains the optional parameters for the BlobClient.SetTags method.
+type BlobClientSetTagsOptions struct {
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// Blob tags
+	Tags *BlobTags
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+
+	// Specify the transactional crc64 for the body, to be validated by the service.
+	TransactionalContentCRC64 []byte
+
+	// Specify the transactional md5 for the body, to be validated by the service.
+	TransactionalContentMD5 []byte
+
+	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
+	// It's for service version 2019-10-10 and newer.
+	VersionID *string
+}
+
+// BlobClientSetTierOptions contains the optional parameters for the BlobClient.SetTier method.
+type BlobClientSetTierOptions struct {
+	// Optional: Indicates the priority with which to rehydrate an archived blob.
+	RehydratePriority *RehydratePriority
+
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
+	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
+	Snapshot *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+
+	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
+	// It's for service version 2019-10-10 and newer.
+	VersionID *string
+}
+
+// BlobClientStartCopyFromURLOptions contains the optional parameters for the BlobClient.StartCopyFromURL method.
+type BlobClientStartCopyFromURLOptions struct {
+	// Optional. Used to set blob tags in various blob operations.
+	BlobTagsString *string
+
+	// Specifies the date time when the blobs immutability policy is set to expire.
+	ImmutabilityPolicyExpiry *time.Time
+
+	// Specifies the immutability policy mode to set on the blob.
+	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+
+	// Specified if a legal hold should be set on the blob.
+	LegalHold *bool
+
+	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
+	// operation will copy the metadata from the source blob or file to the destination
+	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
+	// is not copied from the source blob or file. Note that beginning with
+	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
+	// Blobs, and Metadata for more information.
+	Metadata map[string]*string
+
+	// Optional: Indicates the priority with which to rehydrate an archived blob.
+	RehydratePriority *RehydratePriority
+
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// Overrides the sealed state of the destination blob. Service version 2019-12-12 and newer.
+	SealBlob *bool
+
+	// Optional. Indicates the tier to be set on the blob.
+	Tier *AccessTier
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobClientUndeleteOptions contains the optional parameters for the BlobClient.Undelete method.
+type BlobClientUndeleteOptions struct {
+	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
+	// analytics logging is enabled.
+	RequestID *string
+
+	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
+	Timeout *int32
+}
+
+// BlobHTTPHeaders contains a group of parameters for the BlobClient.SetHTTPHeaders method.
 type BlobHTTPHeaders struct {
 	// Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read request.
 	BlobCacheControl *string
@@ -305,457 +757,6 @@ type BlockBlobClientUploadOptions struct {
 
 	// Specify the transactional md5 for the body, to be validated by the service.
 	TransactionalContentMD5 []byte
-}
-
-// ClientAbortCopyFromURLOptions contains the optional parameters for the Client.AbortCopyFromURL method.
-type ClientAbortCopyFromURLOptions struct {
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientAcquireLeaseOptions contains the optional parameters for the Client.AcquireLease method.
-type ClientAcquireLeaseOptions struct {
-	// Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease
-	// can be between 15 and 60 seconds. A lease duration cannot be changed using
-	// renew or change.
-	Duration *int32
-
-	// Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed lease ID is
-	// not in the correct format. See Guid Constructor (String) for a list of valid GUID
-	// string formats.
-	ProposedLeaseID *string
-
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientBreakLeaseOptions contains the optional parameters for the Client.BreakLease method.
-type ClientBreakLeaseOptions struct {
-	// For a break operation, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60. This
-	// break period is only used if it is shorter than the time remaining on the
-	// lease. If longer, the time remaining on the lease is used. A new lease will not be available before the break period has
-	// expired, but the lease may be held for longer than the break period. If this
-	// header does not appear with a break operation, a fixed-duration lease breaks after the remaining lease period elapses,
-	// and an infinite lease breaks immediately.
-	BreakPeriod *int32
-
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientChangeLeaseOptions contains the optional parameters for the Client.ChangeLease method.
-type ClientChangeLeaseOptions struct {
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientCopyFromURLOptions contains the optional parameters for the Client.CopyFromURL method.
-type ClientCopyFromURLOptions struct {
-	// Optional. Used to set blob tags in various blob operations.
-	BlobTagsString *string
-
-	// Only Bearer type is supported. Credentials should be a valid OAuth access token to copy source.
-	CopySourceAuthorization *string
-
-	// Optional, default 'replace'. Indicates if source tags should be copied or replaced with the tags specified by x-ms-tags.
-	CopySourceTags *BlobCopySourceTags
-
-	// Specifies the date time when the blobs immutability policy is set to expire.
-	ImmutabilityPolicyExpiry *time.Time
-
-	// Specifies the immutability policy mode to set on the blob.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
-
-	// Specified if a legal hold should be set on the blob.
-	LegalHold *bool
-
-	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
-	// operation will copy the metadata from the source blob or file to the destination
-	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
-	// is not copied from the source blob or file. Note that beginning with
-	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
-	// Blobs, and Metadata for more information.
-	Metadata map[string]*string
-
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// Specify the md5 calculated for the range of bytes that must be read from the copy source.
-	SourceContentMD5 []byte
-
-	// Optional. Indicates the tier to be set on the blob.
-	Tier *AccessTier
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientCreateSnapshotOptions contains the optional parameters for the Client.CreateSnapshot method.
-type ClientCreateSnapshotOptions struct {
-	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
-	// operation will copy the metadata from the source blob or file to the destination
-	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
-	// is not copied from the source blob or file. Note that beginning with
-	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
-	// Blobs, and Metadata for more information.
-	Metadata map[string]*string
-
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientDeleteImmutabilityPolicyOptions contains the optional parameters for the Client.DeleteImmutabilityPolicy method.
-type ClientDeleteImmutabilityPolicyOptions struct {
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientDeleteOptions contains the optional parameters for the Client.Delete method.
-type ClientDeleteOptions struct {
-	// Optional. Only possible value is 'permanent', which specifies to permanently delete a blob if blob soft delete is enabled..
-	// Specifying any value will set the value to Permanent.
-	BlobDeleteType *string
-
-	// Required if the blob has associated snapshots. Specify one of the following two options: include: Delete the base blob
-	// and all of its snapshots. only: Delete only the blob's snapshots and not the blob
-	// itself
-	DeleteSnapshots *DeleteSnapshotsOptionType
-
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
-	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
-	Snapshot *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-
-	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
-	// It's for service version 2019-10-10 and newer.
-	VersionID *string
-}
-
-// ClientDownloadOptions contains the optional parameters for the Client.Download method.
-type ClientDownloadOptions struct {
-	// Return only the bytes of the blob in the specified range.
-	Range *string
-
-	// When set to true and specified together with the Range, the service returns the CRC64 hash for the range, as long as the
-	// range is less than or equal to 4 MB in size.
-	RangeGetContentCRC64 *bool
-
-	// When set to true and specified together with the Range, the service returns the MD5 hash for the range, as long as the
-	// range is less than or equal to 4 MB in size.
-	RangeGetContentMD5 *bool
-
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
-	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
-	Snapshot *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-
-	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
-	// It's for service version 2019-10-10 and newer.
-	VersionID *string
-}
-
-// ClientGetAccountInfoOptions contains the optional parameters for the Client.GetAccountInfo method.
-type ClientGetAccountInfoOptions struct {
-	// placeholder for future optional parameters
-}
-
-// ClientGetPropertiesOptions contains the optional parameters for the Client.GetProperties method.
-type ClientGetPropertiesOptions struct {
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
-	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
-	Snapshot *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-
-	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
-	// It's for service version 2019-10-10 and newer.
-	VersionID *string
-}
-
-// ClientGetTagsOptions contains the optional parameters for the Client.GetTags method.
-type ClientGetTagsOptions struct {
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
-	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
-	Snapshot *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-
-	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
-	// It's for service version 2019-10-10 and newer.
-	VersionID *string
-}
-
-// ClientQueryOptions contains the optional parameters for the Client.Query method.
-type ClientQueryOptions struct {
-	// the query request
-	QueryRequest *QueryRequest
-
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
-	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
-	Snapshot *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientReleaseLeaseOptions contains the optional parameters for the Client.ReleaseLease method.
-type ClientReleaseLeaseOptions struct {
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientRenewLeaseOptions contains the optional parameters for the Client.RenewLease method.
-type ClientRenewLeaseOptions struct {
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientSetExpiryOptions contains the optional parameters for the Client.SetExpiry method.
-type ClientSetExpiryOptions struct {
-	// The time to set the blob to expiry
-	ExpiresOn *string
-
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientSetHTTPHeadersOptions contains the optional parameters for the Client.SetHTTPHeaders method.
-type ClientSetHTTPHeadersOptions struct {
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientSetImmutabilityPolicyOptions contains the optional parameters for the Client.SetImmutabilityPolicy method.
-type ClientSetImmutabilityPolicyOptions struct {
-	// Specifies the date time when the blobs immutability policy is set to expire.
-	ImmutabilityPolicyExpiry *time.Time
-
-	// Specifies the immutability policy mode to set on the blob.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
-
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientSetLegalHoldOptions contains the optional parameters for the Client.SetLegalHold method.
-type ClientSetLegalHoldOptions struct {
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientSetMetadataOptions contains the optional parameters for the Client.SetMetadata method.
-type ClientSetMetadataOptions struct {
-	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
-	// operation will copy the metadata from the source blob or file to the destination
-	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
-	// is not copied from the source blob or file. Note that beginning with
-	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
-	// Blobs, and Metadata for more information.
-	Metadata map[string]*string
-
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientSetTagsOptions contains the optional parameters for the Client.SetTags method.
-type ClientSetTagsOptions struct {
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// Blob tags
-	Tags *Tags
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-
-	// Specify the transactional crc64 for the body, to be validated by the service.
-	TransactionalContentCRC64 []byte
-
-	// Specify the transactional md5 for the body, to be validated by the service.
-	TransactionalContentMD5 []byte
-
-	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
-	// It's for service version 2019-10-10 and newer.
-	VersionID *string
-}
-
-// ClientSetTierOptions contains the optional parameters for the Client.SetTier method.
-type ClientSetTierOptions struct {
-	// Optional: Indicates the priority with which to rehydrate an archived blob.
-	RehydratePriority *RehydratePriority
-
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
-	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
-	Snapshot *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-
-	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
-	// It's for service version 2019-10-10 and newer.
-	VersionID *string
-}
-
-// ClientStartCopyFromURLOptions contains the optional parameters for the Client.StartCopyFromURL method.
-type ClientStartCopyFromURLOptions struct {
-	// Optional. Used to set blob tags in various blob operations.
-	BlobTagsString *string
-
-	// Specifies the date time when the blobs immutability policy is set to expire.
-	ImmutabilityPolicyExpiry *time.Time
-
-	// Specifies the immutability policy mode to set on the blob.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
-
-	// Specified if a legal hold should be set on the blob.
-	LegalHold *bool
-
-	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
-	// operation will copy the metadata from the source blob or file to the destination
-	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
-	// is not copied from the source blob or file. Note that beginning with
-	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
-	// Blobs, and Metadata for more information.
-	Metadata map[string]*string
-
-	// Optional: Indicates the priority with which to rehydrate an archived blob.
-	RehydratePriority *RehydratePriority
-
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// Overrides the sealed state of the destination blob. Service version 2019-12-12 and newer.
-	SealBlob *bool
-
-	// Optional. Indicates the tier to be set on the blob.
-	Tier *AccessTier
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
-}
-
-// ClientUndeleteOptions contains the optional parameters for the Client.Undelete method.
-type ClientUndeleteOptions struct {
-	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
-	// analytics logging is enabled.
-	RequestID *string
-
-	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
-	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
-	Timeout *int32
 }
 
 // ContainerClientAcquireLeaseOptions contains the optional parameters for the ContainerClient.AcquireLease method.
@@ -1075,7 +1076,7 @@ type ContainerCpkScopeInfo struct {
 	PreventEncryptionScopeOverride *bool
 }
 
-// CpkInfo contains a group of parameters for the Client.Download method.
+// CpkInfo contains a group of parameters for the BlobClient.Download method.
 type CpkInfo struct {
 	// The algorithm used to produce the encryption key hash. Currently, the only accepted value is "AES256". Must be provided
 	// if the x-ms-encryption-key header is provided.. Specifying any value will set the value to AES256.
@@ -1090,7 +1091,7 @@ type CpkInfo struct {
 	EncryptionKeySHA256 *string
 }
 
-// CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+// CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 type CpkScopeInfo struct {
 	// Optional. Version 2019-07-07 and later. Specifies the name of the encryption scope to use to encrypt the data provided
 	// in the request. If not specified, encryption is performed with the default
@@ -1466,7 +1467,7 @@ type ServiceClientSubmitBatchOptions struct {
 	Timeout *int32
 }
 
-// SourceModifiedAccessConditions contains a group of parameters for the Client.StartCopyFromURL method.
+// SourceModifiedAccessConditions contains a group of parameters for the BlobClient.StartCopyFromURL method.
 type SourceModifiedAccessConditions struct {
 	// Specify an ETag value to operate only on blobs with a matching value.
 	SourceIfMatch *string

--- a/packages/autorest.go/test/storage/azblob/zz_pageblob_client.go
+++ b/packages/autorest.go/test/storage/azblob/zz_pageblob_client.go
@@ -37,8 +37,8 @@ type PageBlobClient struct {
 //   - contentLength - The length of the request.
 //   - options - PageBlobClientClearPagesOptions contains the optional parameters for the PageBlobClient.ClearPages method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 //   - SequenceNumberAccessConditions - SequenceNumberAccessConditions contains a group of parameters for the PageBlobClient.UploadPages
 //     method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
@@ -314,10 +314,10 @@ func (client *PageBlobClient) copyIncrementalHandleResponse(resp *http.Response)
 //   - blobContentLength - This header specifies the maximum size for the page blob, up to 1 TB. The page blob size must be aligned
 //     to a 512-byte boundary.
 //   - options - PageBlobClientCreateOptions contains the optional parameters for the PageBlobClient.Create method.
-//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the Client.SetHTTPHeaders method.
+//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the BlobClient.SetHTTPHeaders method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
 func (client *PageBlobClient) Create(ctx context.Context, containerName string, blob string, contentLength int64, blobContentLength int64, options *PageBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientCreateResponse, error) {
 	var err error
@@ -777,8 +777,8 @@ func (client *PageBlobClient) getPageRangesDiffHandleResponse(resp *http.Respons
 //     to a 512-byte boundary.
 //   - options - PageBlobClientResizeOptions contains the optional parameters for the PageBlobClient.Resize method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
 func (client *PageBlobClient) Resize(ctx context.Context, containerName string, blob string, comp Enum1, blobContentLength int64, options *PageBlobClientResizeOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientResizeResponse, error) {
 	var err error
@@ -1029,8 +1029,8 @@ func (client *PageBlobClient) updateSequenceNumberHandleResponse(resp *http.Resp
 //   - body - Initial data
 //   - options - PageBlobClientUploadPagesOptions contains the optional parameters for the PageBlobClient.UploadPages method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 //   - SequenceNumberAccessConditions - SequenceNumberAccessConditions contains a group of parameters for the PageBlobClient.UploadPages
 //     method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
@@ -1216,13 +1216,13 @@ func (client *PageBlobClient) uploadPagesHandleResponse(resp *http.Response) (Pa
 //     is required.
 //   - options - PageBlobClientUploadPagesFromURLOptions contains the optional parameters for the PageBlobClient.UploadPagesFromURL
 //     method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the BlobClient.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the BlobClient.SetMetadata method.
 //   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
 //   - SequenceNumberAccessConditions - SequenceNumberAccessConditions contains a group of parameters for the PageBlobClient.UploadPages
 //     method.
 //   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
-//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the Client.StartCopyFromURL
+//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the BlobClient.StartCopyFromURL
 //     method.
 func (client *PageBlobClient) UploadPagesFromURL(ctx context.Context, containerName string, blob string, comp Enum32, sourceURL string, sourceRange string, contentLength int64, rangeParam string, options *PageBlobClientUploadPagesFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (PageBlobClientUploadPagesFromURLResponse, error) {
 	var err error

--- a/packages/autorest.go/test/storage/azblob/zz_responses.go
+++ b/packages/autorest.go/test/storage/azblob/zz_responses.go
@@ -151,6 +151,858 @@ type AppendBlobClientSealResponse struct {
 	Version *string
 }
 
+// BlobClientAbortCopyFromURLResponse contains the response from method BlobClient.AbortCopyFromURL.
+type BlobClientAbortCopyFromURLResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientAcquireLeaseResponse contains the response from method BlobClient.AcquireLease.
+type BlobClientAcquireLeaseResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// LastModified contains the information returned from the Last-Modified header response.
+	LastModified *time.Time
+
+	// LeaseID contains the information returned from the x-ms-lease-id header response.
+	LeaseID *string
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientBreakLeaseResponse contains the response from method BlobClient.BreakLease.
+type BlobClientBreakLeaseResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// LastModified contains the information returned from the Last-Modified header response.
+	LastModified *time.Time
+
+	// LeaseTime contains the information returned from the x-ms-lease-time header response.
+	LeaseTime *int32
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientChangeLeaseResponse contains the response from method BlobClient.ChangeLease.
+type BlobClientChangeLeaseResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// LastModified contains the information returned from the Last-Modified header response.
+	LastModified *time.Time
+
+	// LeaseID contains the information returned from the x-ms-lease-id header response.
+	LeaseID *string
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientCopyFromURLResponse contains the response from method BlobClient.CopyFromURL.
+type BlobClientCopyFromURLResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// ContentMD5 contains the information returned from the Content-MD5 header response.
+	ContentMD5 []byte
+
+	// CopyID contains the information returned from the x-ms-copy-id header response.
+	CopyID *string
+
+	// CopyStatus contains the information returned from the x-ms-copy-status header response.
+	CopyStatus *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// EncryptionScope contains the information returned from the x-ms-encryption-scope header response.
+	EncryptionScope *string
+
+	// LastModified contains the information returned from the Last-Modified header response.
+	LastModified *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+
+	// VersionID contains the information returned from the x-ms-version-id header response.
+	VersionID *string
+
+	// XMSContentCRC64 contains the information returned from the x-ms-content-crc64 header response.
+	XMSContentCRC64 []byte
+}
+
+// BlobClientCreateSnapshotResponse contains the response from method BlobClient.CreateSnapshot.
+type BlobClientCreateSnapshotResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// IsServerEncrypted contains the information returned from the x-ms-request-server-encrypted header response.
+	IsServerEncrypted *bool
+
+	// LastModified contains the information returned from the Last-Modified header response.
+	LastModified *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Snapshot contains the information returned from the x-ms-snapshot header response.
+	Snapshot *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+
+	// VersionID contains the information returned from the x-ms-version-id header response.
+	VersionID *string
+}
+
+// BlobClientDeleteImmutabilityPolicyResponse contains the response from method BlobClient.DeleteImmutabilityPolicy.
+type BlobClientDeleteImmutabilityPolicyResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientDeleteResponse contains the response from method BlobClient.Delete.
+type BlobClientDeleteResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientDownloadResponse contains the response from method BlobClient.Download.
+type BlobClientDownloadResponse struct {
+	// AcceptRanges contains the information returned from the Accept-Ranges header response.
+	AcceptRanges *string
+
+	// BlobCommittedBlockCount contains the information returned from the x-ms-blob-committed-block-count header response.
+	BlobCommittedBlockCount *int32
+
+	// BlobContentMD5 contains the information returned from the x-ms-blob-content-md5 header response.
+	BlobContentMD5 []byte
+
+	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
+	BlobSequenceNumber *int64
+
+	// BlobType contains the information returned from the x-ms-blob-type header response.
+	BlobType *BlobType
+
+	// Body contains the streaming response.
+	Body io.ReadCloser
+
+	// CacheControl contains the information returned from the Cache-Control header response.
+	CacheControl *string
+
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// ContentCRC64 contains the information returned from the x-ms-content-crc64 header response.
+	ContentCRC64 []byte
+
+	// ContentDisposition contains the information returned from the Content-Disposition header response.
+	ContentDisposition *string
+
+	// ContentEncoding contains the information returned from the Content-Encoding header response.
+	ContentEncoding *string
+
+	// ContentLanguage contains the information returned from the Content-Language header response.
+	ContentLanguage *string
+
+	// ContentLength contains the information returned from the Content-Length header response.
+	ContentLength *int64
+
+	// ContentMD5 contains the information returned from the Content-MD5 header response.
+	ContentMD5 []byte
+
+	// ContentRange contains the information returned from the Content-Range header response.
+	ContentRange *string
+
+	// ContentType contains the information returned from the Content-Type header response.
+	ContentType *string
+
+	// CopyCompletionTime contains the information returned from the x-ms-copy-completion-time header response.
+	CopyCompletionTime *time.Time
+
+	// CopyID contains the information returned from the x-ms-copy-id header response.
+	CopyID *string
+
+	// CopyProgress contains the information returned from the x-ms-copy-progress header response.
+	CopyProgress *string
+
+	// CopySource contains the information returned from the x-ms-copy-source header response.
+	CopySource *string
+
+	// CopyStatus contains the information returned from the x-ms-copy-status header response.
+	CopyStatus *CopyStatusType
+
+	// CopyStatusDescription contains the information returned from the x-ms-copy-status-description header response.
+	CopyStatusDescription *string
+
+	// CreationTime contains the information returned from the x-ms-creation-time header response.
+	CreationTime *time.Time
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// EncryptionKeySHA256 contains the information returned from the x-ms-encryption-key-sha256 header response.
+	EncryptionKeySHA256 *string
+
+	// EncryptionScope contains the information returned from the x-ms-encryption-scope header response.
+	EncryptionScope *string
+
+	// ImmutabilityPolicyExpiresOn contains the information returned from the x-ms-immutability-policy-until-date header response.
+	ImmutabilityPolicyExpiresOn *time.Time
+
+	// ImmutabilityPolicyMode contains the information returned from the x-ms-immutability-policy-mode header response.
+	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+
+	// IsCurrentVersion contains the information returned from the x-ms-is-current-version header response.
+	IsCurrentVersion *bool
+
+	// IsSealed contains the information returned from the x-ms-blob-sealed header response.
+	IsSealed *bool
+
+	// IsServerEncrypted contains the information returned from the x-ms-server-encrypted header response.
+	IsServerEncrypted *bool
+
+	// LastAccessed contains the information returned from the x-ms-last-access-time header response.
+	LastAccessed *time.Time
+
+	// LastModified contains the information returned from the Last-Modified header response.
+	LastModified *time.Time
+
+	// LeaseDuration contains the information returned from the x-ms-lease-duration header response.
+	LeaseDuration *LeaseDurationType
+
+	// LeaseState contains the information returned from the x-ms-lease-state header response.
+	LeaseState *LeaseStateType
+
+	// LeaseStatus contains the information returned from the x-ms-lease-status header response.
+	LeaseStatus *LeaseStatusType
+
+	// LegalHold contains the information returned from the x-ms-legal-hold header response.
+	LegalHold *bool
+
+	// Metadata contains the information returned from the x-ms-meta header response.
+	Metadata map[string]*string
+
+	// ObjectReplicationPolicyID contains the information returned from the x-ms-or-policy-id header response.
+	ObjectReplicationPolicyID *string
+
+	// ObjectReplicationRules contains the information returned from the x-ms-or header response.
+	ObjectReplicationRules map[string]*string
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// TagCount contains the information returned from the x-ms-tag-count header response.
+	TagCount *int64
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+
+	// VersionID contains the information returned from the x-ms-version-id header response.
+	VersionID *string
+}
+
+// BlobClientGetAccountInfoResponse contains the response from method BlobClient.GetAccountInfo.
+type BlobClientGetAccountInfoResponse struct {
+	// AccountKind contains the information returned from the x-ms-account-kind header response.
+	AccountKind *AccountKind
+
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// SKUName contains the information returned from the x-ms-sku-name header response.
+	SKUName *SKUName
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientGetPropertiesResponse contains the response from method BlobClient.GetProperties.
+type BlobClientGetPropertiesResponse struct {
+	// AcceptRanges contains the information returned from the Accept-Ranges header response.
+	AcceptRanges *string
+
+	// AccessTier contains the information returned from the x-ms-access-tier header response.
+	AccessTier *string
+
+	// AccessTierChangeTime contains the information returned from the x-ms-access-tier-change-time header response.
+	AccessTierChangeTime *time.Time
+
+	// AccessTierInferred contains the information returned from the x-ms-access-tier-inferred header response.
+	AccessTierInferred *bool
+
+	// ArchiveStatus contains the information returned from the x-ms-archive-status header response.
+	ArchiveStatus *string
+
+	// BlobCommittedBlockCount contains the information returned from the x-ms-blob-committed-block-count header response.
+	BlobCommittedBlockCount *int32
+
+	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
+	BlobSequenceNumber *int64
+
+	// BlobType contains the information returned from the x-ms-blob-type header response.
+	BlobType *BlobType
+
+	// CacheControl contains the information returned from the Cache-Control header response.
+	CacheControl *string
+
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// ContentDisposition contains the information returned from the Content-Disposition header response.
+	ContentDisposition *string
+
+	// ContentEncoding contains the information returned from the Content-Encoding header response.
+	ContentEncoding *string
+
+	// ContentLanguage contains the information returned from the Content-Language header response.
+	ContentLanguage *string
+
+	// ContentLength contains the information returned from the Content-Length header response.
+	ContentLength *int64
+
+	// ContentMD5 contains the information returned from the Content-MD5 header response.
+	ContentMD5 []byte
+
+	// ContentType contains the information returned from the Content-Type header response.
+	ContentType *string
+
+	// CopyCompletionTime contains the information returned from the x-ms-copy-completion-time header response.
+	CopyCompletionTime *time.Time
+
+	// CopyID contains the information returned from the x-ms-copy-id header response.
+	CopyID *string
+
+	// CopyProgress contains the information returned from the x-ms-copy-progress header response.
+	CopyProgress *string
+
+	// CopySource contains the information returned from the x-ms-copy-source header response.
+	CopySource *string
+
+	// CopyStatus contains the information returned from the x-ms-copy-status header response.
+	CopyStatus *CopyStatusType
+
+	// CopyStatusDescription contains the information returned from the x-ms-copy-status-description header response.
+	CopyStatusDescription *string
+
+	// CreationTime contains the information returned from the x-ms-creation-time header response.
+	CreationTime *time.Time
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// DestinationSnapshot contains the information returned from the x-ms-copy-destination-snapshot header response.
+	DestinationSnapshot *string
+
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// EncryptionKeySHA256 contains the information returned from the x-ms-encryption-key-sha256 header response.
+	EncryptionKeySHA256 *string
+
+	// EncryptionScope contains the information returned from the x-ms-encryption-scope header response.
+	EncryptionScope *string
+
+	// ExpiresOn contains the information returned from the x-ms-expiry-time header response.
+	ExpiresOn *time.Time
+
+	// ImmutabilityPolicyExpiresOn contains the information returned from the x-ms-immutability-policy-until-date header response.
+	ImmutabilityPolicyExpiresOn *time.Time
+
+	// ImmutabilityPolicyMode contains the information returned from the x-ms-immutability-policy-mode header response.
+	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+
+	// IsCurrentVersion contains the information returned from the x-ms-is-current-version header response.
+	IsCurrentVersion *bool
+
+	// IsIncrementalCopy contains the information returned from the x-ms-incremental-copy header response.
+	IsIncrementalCopy *bool
+
+	// IsSealed contains the information returned from the x-ms-blob-sealed header response.
+	IsSealed *bool
+
+	// IsServerEncrypted contains the information returned from the x-ms-server-encrypted header response.
+	IsServerEncrypted *bool
+
+	// LastAccessed contains the information returned from the x-ms-last-access-time header response.
+	LastAccessed *time.Time
+
+	// LastModified contains the information returned from the Last-Modified header response.
+	LastModified *time.Time
+
+	// LeaseDuration contains the information returned from the x-ms-lease-duration header response.
+	LeaseDuration *LeaseDurationType
+
+	// LeaseState contains the information returned from the x-ms-lease-state header response.
+	LeaseState *LeaseStateType
+
+	// LeaseStatus contains the information returned from the x-ms-lease-status header response.
+	LeaseStatus *LeaseStatusType
+
+	// LegalHold contains the information returned from the x-ms-legal-hold header response.
+	LegalHold *bool
+
+	// Metadata contains the information returned from the x-ms-meta header response.
+	Metadata map[string]*string
+
+	// ObjectReplicationPolicyID contains the information returned from the x-ms-or-policy-id header response.
+	ObjectReplicationPolicyID *string
+
+	// ObjectReplicationRules contains the information returned from the x-ms-or header response.
+	ObjectReplicationRules map[string]*string
+
+	// RehydratePriority contains the information returned from the x-ms-rehydrate-priority header response.
+	RehydratePriority *string
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// TagCount contains the information returned from the x-ms-tag-count header response.
+	TagCount *int64
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+
+	// VersionID contains the information returned from the x-ms-version-id header response.
+	VersionID *string
+}
+
+// BlobClientGetTagsResponse contains the response from method BlobClient.GetTags.
+type BlobClientGetTagsResponse struct {
+	// Blob tags
+	BlobTags
+
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientQueryResponse contains the response from method BlobClient.Query.
+type BlobClientQueryResponse struct {
+	// AcceptRanges contains the information returned from the Accept-Ranges header response.
+	AcceptRanges *string
+
+	// BlobCommittedBlockCount contains the information returned from the x-ms-blob-committed-block-count header response.
+	BlobCommittedBlockCount *int32
+
+	// BlobContentMD5 contains the information returned from the x-ms-blob-content-md5 header response.
+	BlobContentMD5 []byte
+
+	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
+	BlobSequenceNumber *int64
+
+	// BlobType contains the information returned from the x-ms-blob-type header response.
+	BlobType *BlobType
+
+	// Body contains the streaming response.
+	Body io.ReadCloser
+
+	// CacheControl contains the information returned from the Cache-Control header response.
+	CacheControl *string
+
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// ContentCRC64 contains the information returned from the x-ms-content-crc64 header response.
+	ContentCRC64 []byte
+
+	// ContentDisposition contains the information returned from the Content-Disposition header response.
+	ContentDisposition *string
+
+	// ContentEncoding contains the information returned from the Content-Encoding header response.
+	ContentEncoding *string
+
+	// ContentLanguage contains the information returned from the Content-Language header response.
+	ContentLanguage *string
+
+	// ContentLength contains the information returned from the Content-Length header response.
+	ContentLength *int64
+
+	// ContentMD5 contains the information returned from the Content-MD5 header response.
+	ContentMD5 []byte
+
+	// ContentRange contains the information returned from the Content-Range header response.
+	ContentRange *string
+
+	// ContentType contains the information returned from the Content-Type header response.
+	ContentType *string
+
+	// CopyCompletionTime contains the information returned from the x-ms-copy-completion-time header response.
+	CopyCompletionTime *time.Time
+
+	// CopyID contains the information returned from the x-ms-copy-id header response.
+	CopyID *string
+
+	// CopyProgress contains the information returned from the x-ms-copy-progress header response.
+	CopyProgress *string
+
+	// CopySource contains the information returned from the x-ms-copy-source header response.
+	CopySource *string
+
+	// CopyStatus contains the information returned from the x-ms-copy-status header response.
+	CopyStatus *CopyStatusType
+
+	// CopyStatusDescription contains the information returned from the x-ms-copy-status-description header response.
+	CopyStatusDescription *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// EncryptionKeySHA256 contains the information returned from the x-ms-encryption-key-sha256 header response.
+	EncryptionKeySHA256 *string
+
+	// EncryptionScope contains the information returned from the x-ms-encryption-scope header response.
+	EncryptionScope *string
+
+	// IsServerEncrypted contains the information returned from the x-ms-server-encrypted header response.
+	IsServerEncrypted *bool
+
+	// LastModified contains the information returned from the Last-Modified header response.
+	LastModified *time.Time
+
+	// LeaseDuration contains the information returned from the x-ms-lease-duration header response.
+	LeaseDuration *LeaseDurationType
+
+	// LeaseState contains the information returned from the x-ms-lease-state header response.
+	LeaseState *LeaseStateType
+
+	// LeaseStatus contains the information returned from the x-ms-lease-status header response.
+	LeaseStatus *LeaseStatusType
+
+	// Metadata contains the information returned from the x-ms-meta header response.
+	Metadata map[string]*string
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientReleaseLeaseResponse contains the response from method BlobClient.ReleaseLease.
+type BlobClientReleaseLeaseResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// LastModified contains the information returned from the Last-Modified header response.
+	LastModified *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientRenewLeaseResponse contains the response from method BlobClient.RenewLease.
+type BlobClientRenewLeaseResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// LastModified contains the information returned from the Last-Modified header response.
+	LastModified *time.Time
+
+	// LeaseID contains the information returned from the x-ms-lease-id header response.
+	LeaseID *string
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientSetExpiryResponse contains the response from method BlobClient.SetExpiry.
+type BlobClientSetExpiryResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// LastModified contains the information returned from the Last-Modified header response.
+	LastModified *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientSetHTTPHeadersResponse contains the response from method BlobClient.SetHTTPHeaders.
+type BlobClientSetHTTPHeadersResponse struct {
+	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
+	BlobSequenceNumber *int64
+
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// LastModified contains the information returned from the Last-Modified header response.
+	LastModified *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientSetImmutabilityPolicyResponse contains the response from method BlobClient.SetImmutabilityPolicy.
+type BlobClientSetImmutabilityPolicyResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// ImmutabilityPolicyExpiry contains the information returned from the x-ms-immutability-policy-until-date header response.
+	ImmutabilityPolicyExpiry *time.Time
+
+	// ImmutabilityPolicyMode contains the information returned from the x-ms-immutability-policy-mode header response.
+	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientSetLegalHoldResponse contains the response from method BlobClient.SetLegalHold.
+type BlobClientSetLegalHoldResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// LegalHold contains the information returned from the x-ms-legal-hold header response.
+	LegalHold *bool
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientSetMetadataResponse contains the response from method BlobClient.SetMetadata.
+type BlobClientSetMetadataResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// EncryptionKeySHA256 contains the information returned from the x-ms-encryption-key-sha256 header response.
+	EncryptionKeySHA256 *string
+
+	// EncryptionScope contains the information returned from the x-ms-encryption-scope header response.
+	EncryptionScope *string
+
+	// IsServerEncrypted contains the information returned from the x-ms-request-server-encrypted header response.
+	IsServerEncrypted *bool
+
+	// LastModified contains the information returned from the Last-Modified header response.
+	LastModified *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+
+	// VersionID contains the information returned from the x-ms-version-id header response.
+	VersionID *string
+}
+
+// BlobClientSetTagsResponse contains the response from method BlobClient.SetTags.
+type BlobClientSetTagsResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientSetTierResponse contains the response from method BlobClient.SetTier.
+type BlobClientSetTierResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
+// BlobClientStartCopyFromURLResponse contains the response from method BlobClient.StartCopyFromURL.
+type BlobClientStartCopyFromURLResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// CopyID contains the information returned from the x-ms-copy-id header response.
+	CopyID *string
+
+	// CopyStatus contains the information returned from the x-ms-copy-status header response.
+	CopyStatus *CopyStatusType
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// ETag contains the information returned from the ETag header response.
+	ETag *string
+
+	// LastModified contains the information returned from the Last-Modified header response.
+	LastModified *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+
+	// VersionID contains the information returned from the x-ms-version-id header response.
+	VersionID *string
+}
+
+// BlobClientUndeleteResponse contains the response from method BlobClient.Undelete.
+type BlobClientUndeleteResponse struct {
+	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
+	ClientRequestID *string
+
+	// Date contains the information returned from the Date header response.
+	Date *time.Time
+
+	// RequestID contains the information returned from the x-ms-request-id header response.
+	RequestID *string
+
+	// Version contains the information returned from the x-ms-version header response.
+	Version *string
+}
+
 // BlockBlobClientCommitBlockListResponse contains the response from method BlockBlobClient.CommitBlockList.
 type BlockBlobClientCommitBlockListResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
@@ -349,858 +1201,6 @@ type BlockBlobClientUploadResponse struct {
 
 	// VersionID contains the information returned from the x-ms-version-id header response.
 	VersionID *string
-}
-
-// ClientAbortCopyFromURLResponse contains the response from method Client.AbortCopyFromURL.
-type ClientAbortCopyFromURLResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientAcquireLeaseResponse contains the response from method Client.AcquireLease.
-type ClientAcquireLeaseResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// ETag contains the information returned from the ETag header response.
-	ETag *string
-
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *time.Time
-
-	// LeaseID contains the information returned from the x-ms-lease-id header response.
-	LeaseID *string
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientBreakLeaseResponse contains the response from method Client.BreakLease.
-type ClientBreakLeaseResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// ETag contains the information returned from the ETag header response.
-	ETag *string
-
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *time.Time
-
-	// LeaseTime contains the information returned from the x-ms-lease-time header response.
-	LeaseTime *int32
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientChangeLeaseResponse contains the response from method Client.ChangeLease.
-type ClientChangeLeaseResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// ETag contains the information returned from the ETag header response.
-	ETag *string
-
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *time.Time
-
-	// LeaseID contains the information returned from the x-ms-lease-id header response.
-	LeaseID *string
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientCopyFromURLResponse contains the response from method Client.CopyFromURL.
-type ClientCopyFromURLResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// ContentMD5 contains the information returned from the Content-MD5 header response.
-	ContentMD5 []byte
-
-	// CopyID contains the information returned from the x-ms-copy-id header response.
-	CopyID *string
-
-	// CopyStatus contains the information returned from the x-ms-copy-status header response.
-	CopyStatus *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// ETag contains the information returned from the ETag header response.
-	ETag *string
-
-	// EncryptionScope contains the information returned from the x-ms-encryption-scope header response.
-	EncryptionScope *string
-
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *time.Time
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-
-	// VersionID contains the information returned from the x-ms-version-id header response.
-	VersionID *string
-
-	// XMSContentCRC64 contains the information returned from the x-ms-content-crc64 header response.
-	XMSContentCRC64 []byte
-}
-
-// ClientCreateSnapshotResponse contains the response from method Client.CreateSnapshot.
-type ClientCreateSnapshotResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// ETag contains the information returned from the ETag header response.
-	ETag *string
-
-	// IsServerEncrypted contains the information returned from the x-ms-request-server-encrypted header response.
-	IsServerEncrypted *bool
-
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *time.Time
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Snapshot contains the information returned from the x-ms-snapshot header response.
-	Snapshot *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-
-	// VersionID contains the information returned from the x-ms-version-id header response.
-	VersionID *string
-}
-
-// ClientDeleteImmutabilityPolicyResponse contains the response from method Client.DeleteImmutabilityPolicy.
-type ClientDeleteImmutabilityPolicyResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientDeleteResponse contains the response from method Client.Delete.
-type ClientDeleteResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientDownloadResponse contains the response from method Client.Download.
-type ClientDownloadResponse struct {
-	// AcceptRanges contains the information returned from the Accept-Ranges header response.
-	AcceptRanges *string
-
-	// BlobCommittedBlockCount contains the information returned from the x-ms-blob-committed-block-count header response.
-	BlobCommittedBlockCount *int32
-
-	// BlobContentMD5 contains the information returned from the x-ms-blob-content-md5 header response.
-	BlobContentMD5 []byte
-
-	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
-	BlobSequenceNumber *int64
-
-	// BlobType contains the information returned from the x-ms-blob-type header response.
-	BlobType *BlobType
-
-	// Body contains the streaming response.
-	Body io.ReadCloser
-
-	// CacheControl contains the information returned from the Cache-Control header response.
-	CacheControl *string
-
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// ContentCRC64 contains the information returned from the x-ms-content-crc64 header response.
-	ContentCRC64 []byte
-
-	// ContentDisposition contains the information returned from the Content-Disposition header response.
-	ContentDisposition *string
-
-	// ContentEncoding contains the information returned from the Content-Encoding header response.
-	ContentEncoding *string
-
-	// ContentLanguage contains the information returned from the Content-Language header response.
-	ContentLanguage *string
-
-	// ContentLength contains the information returned from the Content-Length header response.
-	ContentLength *int64
-
-	// ContentMD5 contains the information returned from the Content-MD5 header response.
-	ContentMD5 []byte
-
-	// ContentRange contains the information returned from the Content-Range header response.
-	ContentRange *string
-
-	// ContentType contains the information returned from the Content-Type header response.
-	ContentType *string
-
-	// CopyCompletionTime contains the information returned from the x-ms-copy-completion-time header response.
-	CopyCompletionTime *time.Time
-
-	// CopyID contains the information returned from the x-ms-copy-id header response.
-	CopyID *string
-
-	// CopyProgress contains the information returned from the x-ms-copy-progress header response.
-	CopyProgress *string
-
-	// CopySource contains the information returned from the x-ms-copy-source header response.
-	CopySource *string
-
-	// CopyStatus contains the information returned from the x-ms-copy-status header response.
-	CopyStatus *CopyStatusType
-
-	// CopyStatusDescription contains the information returned from the x-ms-copy-status-description header response.
-	CopyStatusDescription *string
-
-	// CreationTime contains the information returned from the x-ms-creation-time header response.
-	CreationTime *time.Time
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// ETag contains the information returned from the ETag header response.
-	ETag *string
-
-	// EncryptionKeySHA256 contains the information returned from the x-ms-encryption-key-sha256 header response.
-	EncryptionKeySHA256 *string
-
-	// EncryptionScope contains the information returned from the x-ms-encryption-scope header response.
-	EncryptionScope *string
-
-	// ImmutabilityPolicyExpiresOn contains the information returned from the x-ms-immutability-policy-until-date header response.
-	ImmutabilityPolicyExpiresOn *time.Time
-
-	// ImmutabilityPolicyMode contains the information returned from the x-ms-immutability-policy-mode header response.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
-
-	// IsCurrentVersion contains the information returned from the x-ms-is-current-version header response.
-	IsCurrentVersion *bool
-
-	// IsSealed contains the information returned from the x-ms-blob-sealed header response.
-	IsSealed *bool
-
-	// IsServerEncrypted contains the information returned from the x-ms-server-encrypted header response.
-	IsServerEncrypted *bool
-
-	// LastAccessed contains the information returned from the x-ms-last-access-time header response.
-	LastAccessed *time.Time
-
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *time.Time
-
-	// LeaseDuration contains the information returned from the x-ms-lease-duration header response.
-	LeaseDuration *LeaseDurationType
-
-	// LeaseState contains the information returned from the x-ms-lease-state header response.
-	LeaseState *LeaseStateType
-
-	// LeaseStatus contains the information returned from the x-ms-lease-status header response.
-	LeaseStatus *LeaseStatusType
-
-	// LegalHold contains the information returned from the x-ms-legal-hold header response.
-	LegalHold *bool
-
-	// Metadata contains the information returned from the x-ms-meta header response.
-	Metadata map[string]*string
-
-	// ObjectReplicationPolicyID contains the information returned from the x-ms-or-policy-id header response.
-	ObjectReplicationPolicyID *string
-
-	// ObjectReplicationRules contains the information returned from the x-ms-or header response.
-	ObjectReplicationRules map[string]*string
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// TagCount contains the information returned from the x-ms-tag-count header response.
-	TagCount *int64
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-
-	// VersionID contains the information returned from the x-ms-version-id header response.
-	VersionID *string
-}
-
-// ClientGetAccountInfoResponse contains the response from method Client.GetAccountInfo.
-type ClientGetAccountInfoResponse struct {
-	// AccountKind contains the information returned from the x-ms-account-kind header response.
-	AccountKind *AccountKind
-
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// SKUName contains the information returned from the x-ms-sku-name header response.
-	SKUName *SKUName
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientGetPropertiesResponse contains the response from method Client.GetProperties.
-type ClientGetPropertiesResponse struct {
-	// AcceptRanges contains the information returned from the Accept-Ranges header response.
-	AcceptRanges *string
-
-	// AccessTier contains the information returned from the x-ms-access-tier header response.
-	AccessTier *string
-
-	// AccessTierChangeTime contains the information returned from the x-ms-access-tier-change-time header response.
-	AccessTierChangeTime *time.Time
-
-	// AccessTierInferred contains the information returned from the x-ms-access-tier-inferred header response.
-	AccessTierInferred *bool
-
-	// ArchiveStatus contains the information returned from the x-ms-archive-status header response.
-	ArchiveStatus *string
-
-	// BlobCommittedBlockCount contains the information returned from the x-ms-blob-committed-block-count header response.
-	BlobCommittedBlockCount *int32
-
-	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
-	BlobSequenceNumber *int64
-
-	// BlobType contains the information returned from the x-ms-blob-type header response.
-	BlobType *BlobType
-
-	// CacheControl contains the information returned from the Cache-Control header response.
-	CacheControl *string
-
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// ContentDisposition contains the information returned from the Content-Disposition header response.
-	ContentDisposition *string
-
-	// ContentEncoding contains the information returned from the Content-Encoding header response.
-	ContentEncoding *string
-
-	// ContentLanguage contains the information returned from the Content-Language header response.
-	ContentLanguage *string
-
-	// ContentLength contains the information returned from the Content-Length header response.
-	ContentLength *int64
-
-	// ContentMD5 contains the information returned from the Content-MD5 header response.
-	ContentMD5 []byte
-
-	// ContentType contains the information returned from the Content-Type header response.
-	ContentType *string
-
-	// CopyCompletionTime contains the information returned from the x-ms-copy-completion-time header response.
-	CopyCompletionTime *time.Time
-
-	// CopyID contains the information returned from the x-ms-copy-id header response.
-	CopyID *string
-
-	// CopyProgress contains the information returned from the x-ms-copy-progress header response.
-	CopyProgress *string
-
-	// CopySource contains the information returned from the x-ms-copy-source header response.
-	CopySource *string
-
-	// CopyStatus contains the information returned from the x-ms-copy-status header response.
-	CopyStatus *CopyStatusType
-
-	// CopyStatusDescription contains the information returned from the x-ms-copy-status-description header response.
-	CopyStatusDescription *string
-
-	// CreationTime contains the information returned from the x-ms-creation-time header response.
-	CreationTime *time.Time
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// DestinationSnapshot contains the information returned from the x-ms-copy-destination-snapshot header response.
-	DestinationSnapshot *string
-
-	// ETag contains the information returned from the ETag header response.
-	ETag *string
-
-	// EncryptionKeySHA256 contains the information returned from the x-ms-encryption-key-sha256 header response.
-	EncryptionKeySHA256 *string
-
-	// EncryptionScope contains the information returned from the x-ms-encryption-scope header response.
-	EncryptionScope *string
-
-	// ExpiresOn contains the information returned from the x-ms-expiry-time header response.
-	ExpiresOn *time.Time
-
-	// ImmutabilityPolicyExpiresOn contains the information returned from the x-ms-immutability-policy-until-date header response.
-	ImmutabilityPolicyExpiresOn *time.Time
-
-	// ImmutabilityPolicyMode contains the information returned from the x-ms-immutability-policy-mode header response.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
-
-	// IsCurrentVersion contains the information returned from the x-ms-is-current-version header response.
-	IsCurrentVersion *bool
-
-	// IsIncrementalCopy contains the information returned from the x-ms-incremental-copy header response.
-	IsIncrementalCopy *bool
-
-	// IsSealed contains the information returned from the x-ms-blob-sealed header response.
-	IsSealed *bool
-
-	// IsServerEncrypted contains the information returned from the x-ms-server-encrypted header response.
-	IsServerEncrypted *bool
-
-	// LastAccessed contains the information returned from the x-ms-last-access-time header response.
-	LastAccessed *time.Time
-
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *time.Time
-
-	// LeaseDuration contains the information returned from the x-ms-lease-duration header response.
-	LeaseDuration *LeaseDurationType
-
-	// LeaseState contains the information returned from the x-ms-lease-state header response.
-	LeaseState *LeaseStateType
-
-	// LeaseStatus contains the information returned from the x-ms-lease-status header response.
-	LeaseStatus *LeaseStatusType
-
-	// LegalHold contains the information returned from the x-ms-legal-hold header response.
-	LegalHold *bool
-
-	// Metadata contains the information returned from the x-ms-meta header response.
-	Metadata map[string]*string
-
-	// ObjectReplicationPolicyID contains the information returned from the x-ms-or-policy-id header response.
-	ObjectReplicationPolicyID *string
-
-	// ObjectReplicationRules contains the information returned from the x-ms-or header response.
-	ObjectReplicationRules map[string]*string
-
-	// RehydratePriority contains the information returned from the x-ms-rehydrate-priority header response.
-	RehydratePriority *string
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// TagCount contains the information returned from the x-ms-tag-count header response.
-	TagCount *int64
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-
-	// VersionID contains the information returned from the x-ms-version-id header response.
-	VersionID *string
-}
-
-// ClientGetTagsResponse contains the response from method Client.GetTags.
-type ClientGetTagsResponse struct {
-	// Blob tags
-	Tags
-
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientQueryResponse contains the response from method Client.Query.
-type ClientQueryResponse struct {
-	// AcceptRanges contains the information returned from the Accept-Ranges header response.
-	AcceptRanges *string
-
-	// BlobCommittedBlockCount contains the information returned from the x-ms-blob-committed-block-count header response.
-	BlobCommittedBlockCount *int32
-
-	// BlobContentMD5 contains the information returned from the x-ms-blob-content-md5 header response.
-	BlobContentMD5 []byte
-
-	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
-	BlobSequenceNumber *int64
-
-	// BlobType contains the information returned from the x-ms-blob-type header response.
-	BlobType *BlobType
-
-	// Body contains the streaming response.
-	Body io.ReadCloser
-
-	// CacheControl contains the information returned from the Cache-Control header response.
-	CacheControl *string
-
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// ContentCRC64 contains the information returned from the x-ms-content-crc64 header response.
-	ContentCRC64 []byte
-
-	// ContentDisposition contains the information returned from the Content-Disposition header response.
-	ContentDisposition *string
-
-	// ContentEncoding contains the information returned from the Content-Encoding header response.
-	ContentEncoding *string
-
-	// ContentLanguage contains the information returned from the Content-Language header response.
-	ContentLanguage *string
-
-	// ContentLength contains the information returned from the Content-Length header response.
-	ContentLength *int64
-
-	// ContentMD5 contains the information returned from the Content-MD5 header response.
-	ContentMD5 []byte
-
-	// ContentRange contains the information returned from the Content-Range header response.
-	ContentRange *string
-
-	// ContentType contains the information returned from the Content-Type header response.
-	ContentType *string
-
-	// CopyCompletionTime contains the information returned from the x-ms-copy-completion-time header response.
-	CopyCompletionTime *time.Time
-
-	// CopyID contains the information returned from the x-ms-copy-id header response.
-	CopyID *string
-
-	// CopyProgress contains the information returned from the x-ms-copy-progress header response.
-	CopyProgress *string
-
-	// CopySource contains the information returned from the x-ms-copy-source header response.
-	CopySource *string
-
-	// CopyStatus contains the information returned from the x-ms-copy-status header response.
-	CopyStatus *CopyStatusType
-
-	// CopyStatusDescription contains the information returned from the x-ms-copy-status-description header response.
-	CopyStatusDescription *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// ETag contains the information returned from the ETag header response.
-	ETag *string
-
-	// EncryptionKeySHA256 contains the information returned from the x-ms-encryption-key-sha256 header response.
-	EncryptionKeySHA256 *string
-
-	// EncryptionScope contains the information returned from the x-ms-encryption-scope header response.
-	EncryptionScope *string
-
-	// IsServerEncrypted contains the information returned from the x-ms-server-encrypted header response.
-	IsServerEncrypted *bool
-
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *time.Time
-
-	// LeaseDuration contains the information returned from the x-ms-lease-duration header response.
-	LeaseDuration *LeaseDurationType
-
-	// LeaseState contains the information returned from the x-ms-lease-state header response.
-	LeaseState *LeaseStateType
-
-	// LeaseStatus contains the information returned from the x-ms-lease-status header response.
-	LeaseStatus *LeaseStatusType
-
-	// Metadata contains the information returned from the x-ms-meta header response.
-	Metadata map[string]*string
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientReleaseLeaseResponse contains the response from method Client.ReleaseLease.
-type ClientReleaseLeaseResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// ETag contains the information returned from the ETag header response.
-	ETag *string
-
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *time.Time
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientRenewLeaseResponse contains the response from method Client.RenewLease.
-type ClientRenewLeaseResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// ETag contains the information returned from the ETag header response.
-	ETag *string
-
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *time.Time
-
-	// LeaseID contains the information returned from the x-ms-lease-id header response.
-	LeaseID *string
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientSetExpiryResponse contains the response from method Client.SetExpiry.
-type ClientSetExpiryResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// ETag contains the information returned from the ETag header response.
-	ETag *string
-
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *time.Time
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientSetHTTPHeadersResponse contains the response from method Client.SetHTTPHeaders.
-type ClientSetHTTPHeadersResponse struct {
-	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
-	BlobSequenceNumber *int64
-
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// ETag contains the information returned from the ETag header response.
-	ETag *string
-
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *time.Time
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientSetImmutabilityPolicyResponse contains the response from method Client.SetImmutabilityPolicy.
-type ClientSetImmutabilityPolicyResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// ImmutabilityPolicyExpiry contains the information returned from the x-ms-immutability-policy-until-date header response.
-	ImmutabilityPolicyExpiry *time.Time
-
-	// ImmutabilityPolicyMode contains the information returned from the x-ms-immutability-policy-mode header response.
-	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientSetLegalHoldResponse contains the response from method Client.SetLegalHold.
-type ClientSetLegalHoldResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// LegalHold contains the information returned from the x-ms-legal-hold header response.
-	LegalHold *bool
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientSetMetadataResponse contains the response from method Client.SetMetadata.
-type ClientSetMetadataResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// ETag contains the information returned from the ETag header response.
-	ETag *string
-
-	// EncryptionKeySHA256 contains the information returned from the x-ms-encryption-key-sha256 header response.
-	EncryptionKeySHA256 *string
-
-	// EncryptionScope contains the information returned from the x-ms-encryption-scope header response.
-	EncryptionScope *string
-
-	// IsServerEncrypted contains the information returned from the x-ms-request-server-encrypted header response.
-	IsServerEncrypted *bool
-
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *time.Time
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-
-	// VersionID contains the information returned from the x-ms-version-id header response.
-	VersionID *string
-}
-
-// ClientSetTagsResponse contains the response from method Client.SetTags.
-type ClientSetTagsResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientSetTierResponse contains the response from method Client.SetTier.
-type ClientSetTierResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-}
-
-// ClientStartCopyFromURLResponse contains the response from method Client.StartCopyFromURL.
-type ClientStartCopyFromURLResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// CopyID contains the information returned from the x-ms-copy-id header response.
-	CopyID *string
-
-	// CopyStatus contains the information returned from the x-ms-copy-status header response.
-	CopyStatus *CopyStatusType
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// ETag contains the information returned from the ETag header response.
-	ETag *string
-
-	// LastModified contains the information returned from the Last-Modified header response.
-	LastModified *time.Time
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
-
-	// VersionID contains the information returned from the x-ms-version-id header response.
-	VersionID *string
-}
-
-// ClientUndeleteResponse contains the response from method Client.Undelete.
-type ClientUndeleteResponse struct {
-	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
-	ClientRequestID *string
-
-	// Date contains the information returned from the Date header response.
-	Date *time.Time
-
-	// RequestID contains the information returned from the x-ms-request-id header response.
-	RequestID *string
-
-	// Version contains the information returned from the x-ms-version header response.
-	Version *string
 }
 
 // ContainerClientAcquireLeaseResponse contains the response from method ContainerClient.AcquireLease.


### PR DESCRIPTION
The serialized name defaults to the swagger property name which might not match the array's element type name.  In this case, use the element type name instead.
Updated regeneration script to avoid stuttering clean-up for azblob as it contains a type that's impacted by this issue (i.e. add a test).