### PR TITLE
Update vm pool name to not use variable

### DIFF
--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -26,14 +26,13 @@ extends:
     - stage: Release
 
       variables: 
-        - template: /eng/pipelines/templates/variables/image.yml
         - template: /eng/pipelines/templates/variables/globals.yml
 
       jobs:
         - deployment: Release
           pool:
-            name: $(LINUXPOOL)
-            image: $(LINUXVMIMAGE)
+            image: ubuntu-24.04
+            name: azsdk-pool
             os: linux
           environment: package-publish
           templateContext:


### PR DESCRIPTION
This pull request makes a minor update to the `eng/pipelines/publish-release.yml` pipeline configuration. The change updates the deployment pool to use a specific image and pool name, ensuring consistency with current infrastructure standards.

- **Pipeline configuration update:**
  - Changed the deployment pool in `publish-release.yml` to use `image: ubuntu-24.04` and `name: azsdk-pool` instead of the previous `$(LINUXPOOL)` and `$(LINUXVMIMAGE)` variables.