### PR TITLE
Unblock prepare release

### DIFF
--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -29,7 +29,67 @@ extends:
         - template: /eng/pipelines/templates/variables/globals.yml
 
       jobs:
+        - job: Build
+          pool:
+            image: ubuntu-24.04
+            name: azsdk-pool
+            os: linux
+          templateContext:
+            outputs:
+              - output: pipelineArtifact
+                displayName: "Publish release tarballs"
+                targetPath: "$(Build.ArtifactStagingDirectory)/release-assets"
+                artifactName: "release_assets"
+          steps:
+            - checkout: self
+              path: s
+
+            - template: /eng/pipelines/templates/steps/set-env.yaml
+              parameters:
+                GoVersion: $(GoVersionLatest)
+
+            - pwsh: |
+                New-Item -ItemType Directory -Force -Path "$(Build.ArtifactStagingDirectory)/release-assets" | Out-Null
+              displayName: "Create release artifacts directory"
+
+            - ${{ if eq(parameters.release_autorestgo, true) }}:
+              - template: /eng/pipelines/templates/steps/build-test-go.yaml
+              - template: /eng/pipelines/templates/steps/publish-release.yaml
+                parameters:
+                  PackagePath: "autorest.go"
+                  PackageFileName: "autorest-go"
+                  ReleaseName: "Autorest for Go v$(currentVersion)"
+                  ReleaseNotes: "Autorest for Go track 2"
+                  PublishDevVersion: ${{ parameters.publish_dev }}
+                  Operation: "pack"
+                  InputType: "source"
+
+            - ${{ if eq(parameters.release_autorestgotest, true) }}:
+              - template: /eng/pipelines/templates/steps/build-test-gotest.yaml
+              - template: /eng/pipelines/templates/steps/publish-release.yaml
+                parameters:
+                  PackagePath: "autorest.gotest"
+                  PackageFileName: "autorest-gotest"
+                  ReleaseName: "@autorest/gotest_v$(currentVersion)"
+                  ReleaseNotes: "Go test generation"
+                  PublishDevVersion: ${{ parameters.publish_dev }}
+                  Operation: "pack"
+                  InputType: "source"
+
+            - ${{ if eq(parameters.release_typespecgo, true) }}:
+              - template: /eng/pipelines/templates/steps/build-test-typespec.yaml
+              - template: /eng/pipelines/templates/steps/publish-release.yaml
+                parameters:
+                  PackagePath: "typespec-go"
+                  PackageFileName: "azure-tools-typespec-go"
+                  ReleaseName: "TypeSpec emitter for Go SDKs v$(currentVersion)"
+                  ReleaseNotes: "TypeSpec emitter for Go SDKs"
+                  PublishDevVersion: ${{ parameters.publish_dev }}
+                  Operation: "pack"
+                  InputType: "source"
+
         - deployment: Release
+          dependsOn: Build
           pool:
             image: ubuntu-24.04
             name: azsdk-pool
@@ -38,44 +98,54 @@ extends:
           templateContext:
             type: releaseJob
             isProduction: true
+            inputs:
+              - input: pipelineArtifact
+                artifactName: release_assets
+                targetPath: $(Pipeline.Workspace)/release-assets
 
           strategy:
             runOnce:
               deploy:
                 steps:
-                  - checkout: self
-                    path: s
-  
-                  - template: /eng/pipelines/templates/steps/set-env.yaml
-                    parameters:
-                      GoVersion: $(GoVersionLatest)
+                  - task: NodeTool@0
+                    displayName: "Install Node.js $(NodeVersion)"
+                    inputs:
+                      versionSpec: "$(NodeVersion)"
+
+                  - ${{ if ne(parameters.publish_dev, true) }}:
+                    - pwsh: |
+                        "//registry.npmjs.org/:_authToken=$(azure-sdk-npm-token)" | Out-File -FilePath "$HOME/.npmrc" -Encoding ascii
+                      displayName: "Configure npm auth"
 
                   - ${{ if eq(parameters.release_autorestgo, true) }}:
-                    - template: /eng/pipelines/templates/steps/build-test-go.yaml
                     - template: /eng/pipelines/templates/steps/publish-release.yaml
                       parameters:
                         PackagePath: "autorest.go"
                         PackageFileName: "autorest-go"
-                        ReleaseName: "Autorest for Go v$currentVersion"
+                        ReleaseName: "Autorest for Go v$(currentVersion)"
                         ReleaseNotes: "Autorest for Go track 2"
                         PublishDevVersion: ${{ parameters.publish_dev }}
+                        Operation: "publish"
+                        InputType: "artifact"
 
                   - ${{ if eq(parameters.release_autorestgotest, true) }}:
-                    - template: /eng/pipelines/templates/steps/build-test-gotest.yaml
                     - template: /eng/pipelines/templates/steps/publish-release.yaml
                       parameters:
                         PackagePath: "autorest.gotest"
                         PackageFileName: "autorest-gotest"
-                        ReleaseName: "@autorest/gotest_v$currentVersion"
+                        ReleaseName: "@autorest/gotest_v$(currentVersion)"
                         ReleaseNotes: "Go test generation"
                         PublishDevVersion: ${{ parameters.publish_dev }}
+                        Operation: "publish"
+                        InputType: "artifact"
 
                   - ${{ if eq(parameters.release_typespecgo, true) }}:
-                    - template: /eng/pipelines/templates/steps/build-test-typespec.yaml
                     - template: /eng/pipelines/templates/steps/publish-release.yaml
                       parameters:
                         PackagePath: "typespec-go"
                         PackageFileName: "azure-tools-typespec-go"
-                        ReleaseName: "TypeSpec emitter for Go SDKs v$currentVersion"
+                        ReleaseName: "TypeSpec emitter for Go SDKs v$(currentVersion)"
                         ReleaseNotes: "TypeSpec emitter for Go SDKs"
                         PublishDevVersion: ${{ parameters.publish_dev }}
+                        Operation: "publish"
+                        InputType: "artifact"

--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -19,6 +19,9 @@ parameters:
   type: boolean
   default: false
 
+variables:
+  BuildNpmrcPath: "$(Agent.TempDirectory)/publish-release/.npmrc"
+
 extends: 
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -47,6 +50,7 @@ extends:
             - template: /eng/pipelines/templates/steps/set-env.yaml
               parameters:
                 GoVersion: $(GoVersionLatest)
+                npmrcPath: $(BuildNpmrcPath)
 
             - pwsh: |
                 New-Item -ItemType Directory -Force -Path "$(Build.ArtifactStagingDirectory)/release-assets" | Out-Null
@@ -54,6 +58,8 @@ extends:
 
             - ${{ if eq(parameters.release_autorestgo, true) }}:
               - template: /eng/pipelines/templates/steps/build-test-go.yaml
+                parameters:
+                  npmrcPath: $(BuildNpmrcPath)
               - template: /eng/pipelines/templates/steps/publish-release.yaml
                 parameters:
                   PackagePath: "autorest.go"
@@ -63,9 +69,12 @@ extends:
                   PublishDevVersion: ${{ parameters.publish_dev }}
                   Operation: "pack"
                   InputType: "source"
+                  npmrcPath: $(BuildNpmrcPath)
 
             - ${{ if eq(parameters.release_autorestgotest, true) }}:
               - template: /eng/pipelines/templates/steps/build-test-gotest.yaml
+                parameters:
+                  npmrcPath: $(BuildNpmrcPath)
               - template: /eng/pipelines/templates/steps/publish-release.yaml
                 parameters:
                   PackagePath: "autorest.gotest"
@@ -75,9 +84,12 @@ extends:
                   PublishDevVersion: ${{ parameters.publish_dev }}
                   Operation: "pack"
                   InputType: "source"
+                  npmrcPath: $(BuildNpmrcPath)
 
             - ${{ if eq(parameters.release_typespecgo, true) }}:
               - template: /eng/pipelines/templates/steps/build-test-typespec.yaml
+                parameters:
+                  npmrcPath: $(BuildNpmrcPath)
               - template: /eng/pipelines/templates/steps/publish-release.yaml
                 parameters:
                   PackagePath: "typespec-go"
@@ -87,6 +99,7 @@ extends:
                   PublishDevVersion: ${{ parameters.publish_dev }}
                   Operation: "pack"
                   InputType: "source"
+                  npmrcPath: $(BuildNpmrcPath)
 
     - stage: Release
       dependsOn: Build

--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -43,7 +43,9 @@ extends:
             runOnce:
               deploy:
                 steps:
-                
+                  - checkout: self
+                    path: s
+  
                   - template: /eng/pipelines/templates/steps/set-env.yaml
                     parameters:
                       GoVersion: $(GoVersionLatest)

--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -23,9 +23,9 @@ extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
     stages:
-    - stage: Release
+    - stage: Build
 
-      variables: 
+      variables:
         - template: /eng/pipelines/templates/variables/globals.yml
 
       jobs:
@@ -88,8 +88,14 @@ extends:
                   Operation: "pack"
                   InputType: "source"
 
+    - stage: Release
+      dependsOn: Build
+
+      variables:
+        - template: /eng/pipelines/templates/variables/globals.yml
+
+      jobs:
         - deployment: Release
-          dependsOn: Build
           pool:
             image: ubuntu-24.04
             name: azsdk-pool

--- a/eng/pipelines/templates/steps/build-test-go.yaml
+++ b/eng/pipelines/templates/steps/build-test-go.yaml
@@ -1,5 +1,6 @@
 parameters:
   GoTestPath: "$(System.DefaultWorkingDirectory)/packages/autorest.go/test"
+  npmrcPath: "$(Agent.TempDirectory)/set-env/.npmrc"
 
 steps:
   - script: |
@@ -7,11 +8,15 @@ steps:
       pnpm build
     displayName: "Build Generator Sources"
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.go
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - script: |
       pnpm -w format:check
     displayName: "Formatting and Lint"
     workingDirectory: $(System.DefaultWorkingDirectory)
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - script: |
       export currentVersion=$(node -p -e "require('./package.json').version")
@@ -19,6 +24,8 @@ steps:
       npm install -g autorest-go-$currentVersion.tgz
     displayName: "Create and install npm tarball"
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.go
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - script: |
       export currentVersion=$(node -p -e "require('./package.json').version")
@@ -32,6 +39,8 @@ steps:
       fi
     displayName: "Regenerate Autorest Tests"
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.go
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - script: |
       set -e
@@ -124,10 +133,14 @@ steps:
       popd
     displayName: "Run Acceptance Tests - go$(GoVersion)"
     timeoutInMinutes: 10
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - pwsh: pnpm test
     displayName: "Run Unit Tests - go$(GoVersion)"
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.go
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - task: PublishTestResults@2
     inputs:

--- a/eng/pipelines/templates/steps/build-test-gotest.yaml
+++ b/eng/pipelines/templates/steps/build-test-gotest.yaml
@@ -1,20 +1,29 @@
+parameters:
+  npmrcPath: "$(Agent.TempDirectory)/set-env/.npmrc"
+
 steps:
   - script: |
       pnpm install
       pnpm build
     displayName: "Build Generator Sources"
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.gotest
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - script: |
       pnpm -w format:check
     displayName: "Formatting and Lint"
     workingDirectory: $(System.DefaultWorkingDirectory)
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - script: |
       export PATH=$PATH:$HOME/go/bin
       pnpm test
     displayName: "Run Tests - go$(GoVersion)"
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.gotest
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - task: PublishTestResults@2
     inputs:

--- a/eng/pipelines/templates/steps/build-test-typespec.yaml
+++ b/eng/pipelines/templates/steps/build-test-typespec.yaml
@@ -1,6 +1,7 @@
 parameters:
   GoTestPath: "$(System.DefaultWorkingDirectory)/packages/typespec-go/test"
   Nightly: false
+  npmrcPath: "$(Agent.TempDirectory)/set-env/.npmrc"
 
 steps:
   - script: |
@@ -12,16 +13,22 @@ steps:
       pnpm build
     displayName: "Build Emitter Sources"
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/typespec-go
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - script: |
       pnpm test
     displayName: "Run Unit Tests"
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/typespec-go
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - script: |
       pnpm -w format:check
     displayName: "Formatting and Lint"
     workingDirectory: $(System.DefaultWorkingDirectory)
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - script: |
       export currentVersion=$(node -p -e "require('./package.json').version")
@@ -33,6 +40,8 @@ steps:
       fi
     displayName: "Create and install npm tarball"
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/typespec-go
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - script: |
       pnpm tspcompile --emitter-installed --verbose
@@ -44,6 +53,8 @@ steps:
     displayName: "Regenerate TypeSpec Tests"
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/typespec-go/test
     failOnStderr: true
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - script: |
       set -e
@@ -87,6 +98,8 @@ steps:
     displayName: "Run All Tests - go$(GoVersion)"
     timeoutInMinutes: 10
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/typespec-go
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - task: PublishTestResults@2
     inputs:

--- a/eng/pipelines/templates/steps/create-authenticated-npmrc.yml
+++ b/eng/pipelines/templates/steps/create-authenticated-npmrc.yml
@@ -1,0 +1,34 @@
+parameters:
+  - name: npmrcPath
+    type: string
+  - name: registryUrl
+    type: string
+    default: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/'
+  - name: CustomCondition
+    type: string
+    default: succeeded()
+  - name: ServiceConnection
+    type: string
+    default: ''
+
+steps:
+- pwsh: |
+    Write-Host "Creating .npmrc file ${{ parameters.npmrcPath }} for registry ${{ parameters.registryUrl }}"
+    $parentFolder = Split-Path -Path '${{ parameters.npmrcPath }}' -Parent
+    
+    if (!(Test-Path $parentFolder)) {
+      Write-Host "Creating folder $parentFolder"
+      New-Item -Path $parentFolder -ItemType Directory | Out-Null
+    }
+
+    $content = "registry=${{ parameters.registryUrl }}"
+    $content | Out-File '${{ parameters.npmrcPath }}'
+  displayName: 'Create .npmrc'
+  condition: ${{ parameters.CustomCondition }}
+
+- task: npmAuthenticate@0
+  displayName: Authenticate .npmrc
+  condition: ${{ parameters.CustomCondition }}
+  inputs:
+    workingFile: ${{ parameters.npmrcPath }}
+    azureDevOpsServiceConnection: ${{ parameters.ServiceConnection }}

--- a/eng/pipelines/templates/steps/publish-release.yaml
+++ b/eng/pipelines/templates/steps/publish-release.yaml
@@ -1,49 +1,98 @@
 parameters:
-  PackagePath: "not-specified"
-  PackageFileName: "not-specfied"
-  ReleaseName: "not-specified"
-  ReleaseNotes: "not-specfied"
-  PublishDevVersion: true
+- name: PackagePath
+  type: string
+  default: "not-specified"
+- name: PackageFileName
+  type: string
+  default: "not-specfied"
+- name: ReleaseName
+  type: string
+  default: "not-specified"
+- name: ReleaseNotes
+  type: string
+  default: "not-specfied"
+- name: PublishDevVersion
+  type: boolean
+  default: true
+- name: Operation
+  type: string
+  default: "publish"
+  values:
+  - "pack"
+  - "publish"
+- name: InputType
+  type: string
+  default: "source"
+  values:
+  - "source"
+  - "artifact"
+- name: PackRoot
+  type: string
+  default: "$(Build.ArtifactStagingDirectory)/release-assets"
+- name: ArtifactRoot
+  type: string
+  default: "$(Pipeline.Workspace)/release-assets"
 
 steps:
   - pwsh: |
-      $currentVersion = node -p -e "require('./packages/${{ parameters.PackagePath }}/package.json').version"
-      Write-Host "##vso[task.setvariable variable=currentVersion]$currentVersion"
-    displayName: "Get Current Version"
-  - template: /eng/pipelines/templates/steps/verify-changelog.yml
-    parameters:
-      PackagePath: ${{ parameters.PackagePath }}
-      VersionString: $(currentVersion)
-  - pwsh: |
-      $currentVersion = node -p -e "require('./packages/${{ parameters.PackagePath }}/package.json').version"
       $releaseNotes = "${{ parameters.ReleaseNotes }}"
-      if ('${{ parameters.PublishDevVersion }}' -eq 'true') {
-        $currentVersion="$currentVersion-$(Build.BuildNumber)"
-        $releaseNotes = "Preview version of ${{ parameters.ReleaseNotes }}"
-      }
-      cd packages/${{ parameters.PackagePath }}
-      npm version --no-git-tag-version $currentVersion
-      pnpm pack
-      npm install -g ${{ parameters.PackageFileName }}-$currentVersion.tgz
-      if ($LASTEXITCODE) {
-        exit $LASTEXITCODE
-      }
-      npx publish-release `
-        --token $(azuresdk-github-pat) `
-        --repo autorest.go `
-        --owner azure `
-        --name "${{ parameters.ReleaseName }}" `
-        --tag v$currentVersion `
-        --notes="$releaseNotes" `
-        --prerelease `
-        --editRelease false `
-        --assets ${{ parameters.PackageFileName }}-$currentVersion.tgz `
-        --target_commitish $(Build.SourceBranchName);
-    displayName: "Publish GitHub Release ${{ parameters.PackagePath }}"
 
-  - ${{ if ne(parameters.PublishDevVersion, true) }}:
-    - script: |
+      if ('${{ parameters.InputType }}' -eq 'source') {
+        $currentVersion = node -p -e "require('./packages/${{ parameters.PackagePath }}/package.json').version"
+        if ('${{ parameters.PublishDevVersion }}' -eq 'true') {
+          $currentVersion = "$currentVersion-$(Build.BuildNumber)"
+          $releaseNotes = "Preview version of $releaseNotes"
+        }
+        $packageAssetPath = "${{ parameters.PackRoot }}/${{ parameters.PackagePath }}/${{ parameters.PackageFileName }}-$currentVersion.tgz"
+      }
+      else {
+        $asset = Get-ChildItem "${{ parameters.ArtifactRoot }}/${{ parameters.PackagePath }}" -Filter "${{ parameters.PackageFileName }}-*.tgz" | Select-Object -First 1
+        if (-not $asset) {
+          throw "Unable to find artifact for ${{ parameters.PackagePath }}"
+        }
+
+        $currentVersion = $asset.BaseName -replace '^${{ parameters.PackageFileName }}-', ''
+        if ('${{ parameters.PublishDevVersion }}' -eq 'true') {
+          $releaseNotes = "Preview version of $releaseNotes"
+        }
+        $packageAssetPath = $asset.FullName
+      }
+
+      Write-Host "##vso[task.setvariable variable=currentVersion]$currentVersion"
+      Write-Host "##vso[task.setvariable variable=releaseNotes]$releaseNotes"
+      Write-Host "##vso[task.setvariable variable=packageAssetPath]$packageAssetPath"
+    displayName: "Resolve Release Metadata ${{ parameters.PackagePath }}"
+
+  - ${{ if and(eq(parameters.Operation, 'pack'), eq(parameters.InputType, 'source')) }}:
+    - template: /eng/pipelines/templates/steps/verify-changelog.yml
+      parameters:
+        PackagePath: ${{ parameters.PackagePath }}
+        VersionString: $(currentVersion)
+
+    - pwsh: |
         cd packages/${{ parameters.PackagePath }}
-        echo "//registry.npmjs.org/:_authToken=$(azure-sdk-npm-token)" > ./.npmrc
-        pnpm publish --access public --no-git-checks --tag latest
+        npm version --no-git-tag-version $(currentVersion)
+        pnpm pack
+        New-Item -ItemType Directory -Force -Path "${{ parameters.PackRoot }}/${{ parameters.PackagePath }}" | Out-Null
+        Copy-Item "./${{ parameters.PackageFileName }}-$(currentVersion).tgz" "${{ parameters.PackRoot }}/${{ parameters.PackagePath }}/"
+      displayName: "Pack ${{ parameters.PackagePath }}"
+
+  - ${{ if eq(parameters.Operation, 'publish') }}:
+    - pwsh: |
+        npx publish-release `
+          --token $(azuresdk-github-pat) `
+          --repo autorest.go `
+          --owner azure `
+          --name "${{ parameters.ReleaseName }}" `
+          --tag v$(currentVersion) `
+          --notes="$(releaseNotes)" `
+          --prerelease `
+          --editRelease false `
+          --assets "$(packageAssetPath)" `
+          --target_commitish $(Build.SourceBranchName)
+      displayName: "Publish GitHub Release ${{ parameters.PackagePath }}"
+
+  - ${{ if and(eq(parameters.Operation, 'publish'), ne(parameters.PublishDevVersion, true)) }}:
+    - script: |
+        npm publish "$(packageAssetPath)" --access public --tag latest
       displayName: "Publish to npm ${{ parameters.PackagePath }}"

--- a/eng/pipelines/templates/steps/publish-release.yaml
+++ b/eng/pipelines/templates/steps/publish-release.yaml
@@ -32,17 +32,25 @@ parameters:
 - name: ArtifactRoot
   type: string
   default: "$(Pipeline.Workspace)/release-assets"
+- name: npmrcPath
+  type: string
+  default: "$(Agent.TempDirectory)/publish-release/.npmrc"
 
 steps:
   - pwsh: |
       $releaseNotes = "${{ parameters.ReleaseNotes }}"
 
       if ('${{ parameters.InputType }}' -eq 'source') {
-        $currentVersion = node -p -e "require('./packages/${{ parameters.PackagePath }}/package.json').version"
+        $baseVersion = node -p -e "require('./packages/${{ parameters.PackagePath }}/package.json').version"
         if ('${{ parameters.PublishDevVersion }}' -eq 'true') {
-          $currentVersion = "$currentVersion-$(Build.BuildNumber)"
+          $currentVersion = "$baseVersion-$(Build.BuildNumber)"
           $releaseNotes = "Preview version of $releaseNotes"
         }
+        else {
+          $currentVersion = $baseVersion
+        }
+
+        $changelogVersion = $baseVersion
         $packageAssetPath = "${{ parameters.PackRoot }}/${{ parameters.PackagePath }}/${{ parameters.PackageFileName }}-$currentVersion.tgz"
       }
       else {
@@ -55,19 +63,25 @@ steps:
         if ('${{ parameters.PublishDevVersion }}' -eq 'true') {
           $releaseNotes = "Preview version of $releaseNotes"
         }
+        $changelogVersion = $currentVersion
         $packageAssetPath = $asset.FullName
       }
 
       Write-Host "##vso[task.setvariable variable=currentVersion]$currentVersion"
+      Write-Host "##vso[task.setvariable variable=changelogVersion]$changelogVersion"
       Write-Host "##vso[task.setvariable variable=releaseNotes]$releaseNotes"
       Write-Host "##vso[task.setvariable variable=packageAssetPath]$packageAssetPath"
     displayName: "Resolve Release Metadata ${{ parameters.PackagePath }}"
 
   - ${{ if and(eq(parameters.Operation, 'pack'), eq(parameters.InputType, 'source')) }}:
+    - template: /eng/pipelines/templates/steps/create-authenticated-npmrc.yml
+      parameters:
+        npmrcPath: ${{ parameters.npmrcPath }}
+
     - template: /eng/pipelines/templates/steps/verify-changelog.yml
       parameters:
         PackagePath: ${{ parameters.PackagePath }}
-        VersionString: $(currentVersion)
+        VersionString: $(changelogVersion)
 
     - pwsh: |
         cd packages/${{ parameters.PackagePath }}
@@ -76,6 +90,8 @@ steps:
         New-Item -ItemType Directory -Force -Path "${{ parameters.PackRoot }}/${{ parameters.PackagePath }}" | Out-Null
         Copy-Item "./${{ parameters.PackageFileName }}-$(currentVersion).tgz" "${{ parameters.PackRoot }}/${{ parameters.PackagePath }}/"
       displayName: "Pack ${{ parameters.PackagePath }}"
+      env:
+        npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - ${{ if eq(parameters.Operation, 'publish') }}:
     - pwsh: |

--- a/eng/pipelines/templates/steps/set-env.yaml
+++ b/eng/pipelines/templates/steps/set-env.yaml
@@ -31,9 +31,7 @@ steps:
     displayName: Cache pnpm store
 
   - script: |
-      npm i -g corepack@latest
-      corepack enable
-      corepack prepare pnpm@latest-10 --activate
+      npm i -g pnpm@latest-10
     displayName: Install pnpm
     env:
       npm_config_userconfig: ${{ parameters.npmrcPath }}

--- a/eng/pipelines/templates/steps/set-env.yaml
+++ b/eng/pipelines/templates/steps/set-env.yaml
@@ -3,6 +3,7 @@ parameters:
   GoVersion: "$(GoVersion)"
   GoLintCLIVersion: "$(GoLintCLIVersion)"
   pnpmStorePath: $(Pipeline.Workspace)/.pnpm-store
+  npmrcPath: $(Agent.TempDirectory)/set-env/.npmrc
 
 steps:
   - task: NodeTool@0
@@ -19,6 +20,10 @@ steps:
       New-Item -ItemType Directory -Force -Path "${{ parameters.pnpmStorePath }}" | Out-Null
     displayName: Ensure pnpm store path exists
 
+  - template: /eng/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: ${{ parameters.npmrcPath }}
+
   - task: Cache@2
     inputs:
       key: 'pnpm | "$(Agent.OS)" | $(System.DefaultWorkingDirectory)/pnpm-lock.yaml'
@@ -30,9 +35,13 @@ steps:
       corepack enable
       corepack prepare pnpm@latest-10 --activate
     displayName: Install pnpm
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - script: pnpm config set store-dir ${{ parameters.pnpmStorePath }}
     displayName: Setup pnpm cache dir
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}
 
   - script: |
       echo "Node:"
@@ -44,3 +53,5 @@ steps:
   - script: |
       npm install -g autorest
     displayName: "Install Latest Autorest"
+    env:
+      npm_config_userconfig: ${{ parameters.npmrcPath }}

--- a/eng/pipelines/templates/steps/set-env.yaml
+++ b/eng/pipelines/templates/steps/set-env.yaml
@@ -15,6 +15,10 @@ steps:
       version: "${{ parameters.GoVersion }}"
     displayName: "Select Go Version"
 
+  - pwsh: |
+      New-Item -ItemType Directory -Force -Path "${{ parameters.pnpmStorePath }}" | Out-Null
+    displayName: Ensure pnpm store path exists
+
   - task: Cache@2
     inputs:
       key: 'pnpm | "$(Agent.OS)" | $(System.DefaultWorkingDirectory)/pnpm-lock.yaml'


### PR DESCRIPTION
This pull request makes significant improvements to the Azure DevOps pipeline for publishing releases, focusing on more robust and secure npm authentication, improved parameterization, and better separation of build and release stages. The changes enhance maintainability, security, and clarity of the build and release process for Go and TypeSpec packages.

Key changes include:

**Pipeline Structure and Stage Separation**
* Introduced a dedicated `Build` stage in `publish-release.yml` to handle building, testing, and artifact creation, followed by a `Release` stage that consumes build artifacts and performs publishing. This separation clarifies responsibilities and improves artifact management. [[1]](diffhunk://#diff-93b0894af66a6fadf99d43d0922454baae78ffcba1f7de167080cbd413f8796dR22-R105) [[2]](diffhunk://#diff-93b0894af66a6fadf99d43d0922454baae78ffcba1f7de167080cbd413f8796dR120-R170)

**npm Authentication and Environment Handling**
* Added a reusable `create-authenticated-npmrc.yml` template to securely generate and authenticate `.npmrc` files for both Azure DevOps and npmjs.org registries. This ensures all build and publish steps use the correct npm credentials.
* Updated all build and test templates (`build-test-go.yaml`, `build-test-gotest.yaml`, `build-test-typespec.yaml`) to accept an `npmrcPath` parameter and consistently set the `npm_config_userconfig` environment variable, ensuring npm authentication is respected throughout. [[1]](diffhunk://#diff-c1549f40e90268ecd9b35d7c19eb4c20cfdc2b21119c01da1a3b0cf453bef738R3-R28) [[2]](diffhunk://#diff-c1549f40e90268ecd9b35d7c19eb4c20cfdc2b21119c01da1a3b0cf453bef738R42-R43) [[3]](diffhunk://#diff-c1549f40e90268ecd9b35d7c19eb4c20cfdc2b21119c01da1a3b0cf453bef738R136-R143) [[4]](diffhunk://#diff-5570731554c08b7930d8228bc03de28195b0e54bb24661c860ccb892421aae62R1-R26) [[5]](diffhunk://#diff-86f4624b0cc35ed0f4bdc573e173c06f01f68bc2f3181fc3bbc47f172797544eR4) [[6]](diffhunk://#diff-86f4624b0cc35ed0f4bdc573e173c06f01f68bc2f3181fc3bbc47f172797544eR16-R31) [[7]](diffhunk://#diff-86f4624b0cc35ed0f4bdc573e173c06f01f68bc2f3181fc3bbc47f172797544eR43-R44) [[8]](diffhunk://#diff-86f4624b0cc35ed0f4bdc573e173c06f01f68bc2f3181fc3bbc47f172797544eR56-R57) [[9]](diffhunk://#diff-86f4624b0cc35ed0f4bdc573e173c06f01f68bc2f3181fc3bbc47f172797544eR101-R102)

**Parameterization and Flexibility**
* Refactored the `publish-release.yaml` template to add parameters for operation type (`pack` or `publish`), input type (`source` or `artifact`), and configurable paths for artifacts and `.npmrc`. This allows the same template to be reused for both packing and publishing, and for both source and artifact inputs.
* Updated `set-env.yaml` to create the `.npmrc` file and ensure all subsequent steps use the authenticated npm configuration. [[1]](diffhunk://#diff-e391ff90304cb40c65dc73f4fc370dd691611a0218d9638e98410ba8349ed152R6) [[2]](diffhunk://#diff-e391ff90304cb40c65dc73f4fc370dd691611a0218d9638e98410ba8349ed152R19-R42) [[3]](diffhunk://#diff-e391ff90304cb40c65dc73f4fc370dd691611a0218d9638e98410ba8349ed152R54-R55)

**Release and Publishing Logic**
* Improved logic for resolving package versions, handling dev/pre-release versions, and constructing release notes based on the type of release.
* Changed npm publishing to use the artifact tarball directly, ensuring that the published package matches the tested artifact.

**Other Improvements**
* Updated Node.js installation and pnpm setup to use the authenticated `.npmrc` and improved cache handling for dependencies.

These changes collectively make the pipeline more secure, modular, and easier to maintain, while reducing the risk of credential leakage and ensuring consistency between built and published artifacts.