### PR TITLE
Improved handling of Content-Type parameters part 2

### DIFF
--- a/packages/codegen.go/src/core/operations.ts
+++ b/packages/codegen.go/src/core/operations.ts
@@ -1267,9 +1267,11 @@ function createProtocolRequest(azureARM: boolean, method: go.MethodType | go.Nex
 
       // there's a corner case where we have a content-type param with no body
       // param. for this case we still need to set the header inline.
-      if (methodParamGroups.bodyParam) {
+      const bodyParam = methodParamGroups.bodyParam;
+      if (bodyParam?.bodyFormat === 'binary' || bodyParam?.bodyFormat === 'Text') {
         // if the content-type is from a param, then the param will be passed
-        // explicitly to runtime.SetBody() so don't emit code to set it inline
+        // explicitly to runtime.SetBody() so don't emit code to set it inline.
+        // NOTE: only binary/text payloads call runtime.SetBody().
         if (go.isClientSideDefault(param.style)) {
           text += emitClientSideDefault(param as go.HeaderScalarParameter, param.style, () => '', imports, indent);
           continue;

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 * Fixed an issue where two fake server types whose names differed only by a trailing duplicate word (e.g. `AuthorizationServer` and `AuthorizationServerServer`) generated the same `TransportInterceptor` variable name, producing a duplicate declaration in the `fake` package.
+* Fixed setting the `Content-Type` header from an explicit parameter for modeled body parameters.
 
 ### Other Changes
 

--- a/packages/typespec-go/test/local/azregressions/fake/zz_server.go
+++ b/packages/typespec-go/test/local/azregressions/fake/zz_server.go
@@ -84,6 +84,10 @@ type Server struct {
 	// HTTP status codes to indicate success: http.StatusNoContent
 	OptionalBodyPost func(ctx context.Context, options *azregressions.ClientOptionalBodyPostOptions) (resp azfake.Responder[azregressions.ClientOptionalBodyPostResponse], errResp azfake.ErrorResponder)
 
+	// PayloadWithExplicitContentType is the fake for method Client.PayloadWithExplicitContentType
+	// HTTP status codes to indicate success: http.StatusNoContent
+	PayloadWithExplicitContentType func(ctx context.Context, contentType azregressions.PayloadWithExplicitContentTypeRequestContentType, thing azregressions.SomeModel, options *azregressions.ClientPayloadWithExplicitContentTypeOptions) (resp azfake.Responder[azregressions.ClientPayloadWithExplicitContentTypeResponse], errResp azfake.ErrorResponder)
+
 	// SpreadWithModel is the fake for method Client.SpreadWithModel
 	// HTTP status codes to indicate success: http.StatusNoContent
 	SpreadWithModel func(ctx context.Context, name string, options *azregressions.ClientSpreadWithModelOptions) (resp azfake.Responder[azregressions.ClientSpreadWithModelResponse], errResp azfake.ErrorResponder)
@@ -165,6 +169,8 @@ func (s *ServerTransport) dispatchToMethodFake(req *http.Request, method string)
 				res.resp, res.err = s.dispatchOptionalBinaryBodyWithContentType(req)
 			case "Client.OptionalBodyPost":
 				res.resp, res.err = s.dispatchOptionalBodyPost(req)
+			case "Client.PayloadWithExplicitContentType":
+				res.resp, res.err = s.dispatchPayloadWithExplicitContentType(req)
 			case "Client.SpreadWithModel":
 				res.resp, res.err = s.dispatchSpreadWithModel(req)
 			case "Client.WithClientDefaultModelField":
@@ -521,6 +527,29 @@ func (s *ServerTransport) dispatchOptionalBodyPost(req *http.Request) (*http.Res
 		}
 	}
 	respr, errRespr := s.srv.OptionalBodyPost(req.Context(), options)
+	if respErr := server.GetError(errRespr, req); respErr != nil {
+		return nil, respErr
+	}
+	respContent := server.GetResponseContent(respr)
+	if !slices.Contains([]int{http.StatusNoContent}, respContent.HTTPStatus) {
+		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusNoContent", respContent.HTTPStatus)}
+	}
+	resp, err := server.NewResponse(respContent, req, nil)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (s *ServerTransport) dispatchPayloadWithExplicitContentType(req *http.Request) (*http.Response, error) {
+	if s.srv.PayloadWithExplicitContentType == nil {
+		return nil, &nonRetriableError{errors.New("fake for method PayloadWithExplicitContentType not implemented")}
+	}
+	body, err := server.UnmarshalRequestAsJSON[azregressions.SomeModel](req)
+	if err != nil {
+		return nil, err
+	}
+	respr, errRespr := s.srv.PayloadWithExplicitContentType(req.Context(), azregressions.PayloadWithExplicitContentTypeRequestContentType(getHeaderValue(req.Header, "Content-Type")), body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/typespec-go/test/local/azregressions/zz_client.go
+++ b/packages/typespec-go/test/local/azregressions/zz_client.go
@@ -712,6 +712,45 @@ func (client *Client) optionalBodyPostCreateRequest(ctx context.Context, options
 	return req, nil
 }
 
+// PayloadWithExplicitContentType - explicit content-type param is set when creating the request
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ClientPayloadWithExplicitContentTypeOptions contains the optional parameters for the Client.PayloadWithExplicitContentType
+//     method.
+func (client *Client) PayloadWithExplicitContentType(ctx context.Context, contentType PayloadWithExplicitContentTypeRequestContentType, thing SomeModel, options *ClientPayloadWithExplicitContentTypeOptions) (ClientPayloadWithExplicitContentTypeResponse, error) {
+	var err error
+	const operationName = "Client.PayloadWithExplicitContentType"
+	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
+	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
+	req, err := client.payloadWithExplicitContentTypeCreateRequest(ctx, contentType, thing, options)
+	if err != nil {
+		return ClientPayloadWithExplicitContentTypeResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return ClientPayloadWithExplicitContentTypeResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
+		err = runtime.NewResponseError(httpResp)
+		return ClientPayloadWithExplicitContentTypeResponse{}, err
+	}
+	return ClientPayloadWithExplicitContentTypeResponse{}, nil
+}
+
+// payloadWithExplicitContentTypeCreateRequest creates the PayloadWithExplicitContentType request.
+func (client *Client) payloadWithExplicitContentTypeCreateRequest(ctx context.Context, contentType PayloadWithExplicitContentTypeRequestContentType, thing SomeModel, _ *ClientPayloadWithExplicitContentTypeOptions) (*policy.Request, error) {
+	urlPath := "/payload-with-explicit-content-type"
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header["Content-Type"] = []string{string(contentType)}
+	if err := runtime.MarshalAsJSON(req, thing); err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
 // SpreadWithModel -
 // If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ClientSpreadWithModelOptions contains the optional parameters for the Client.SpreadWithModel method.

--- a/packages/typespec-go/test/local/azregressions/zz_constants.go
+++ b/packages/typespec-go/test/local/azregressions/zz_constants.go
@@ -39,3 +39,18 @@ func PossibleNetworkVersionValues() []NetworkVersion {
 		NetworkVersionV2,
 	}
 }
+
+type PayloadWithExplicitContentTypeRequestContentType string
+
+const (
+	PayloadWithExplicitContentTypeRequestContentTypeApplicationJSON         PayloadWithExplicitContentTypeRequestContentType = "application/json"
+	PayloadWithExplicitContentTypeRequestContentTypeApplicationSnapshotJSON PayloadWithExplicitContentTypeRequestContentType = "application/snapshot+json"
+)
+
+// PossiblePayloadWithExplicitContentTypeRequestContentTypeValues returns the possible values for the PayloadWithExplicitContentTypeRequestContentType const type.
+func PossiblePayloadWithExplicitContentTypeRequestContentTypeValues() []PayloadWithExplicitContentTypeRequestContentType {
+	return []PayloadWithExplicitContentTypeRequestContentType{
+		PayloadWithExplicitContentTypeRequestContentTypeApplicationJSON,
+		PayloadWithExplicitContentTypeRequestContentTypeApplicationSnapshotJSON,
+	}
+}

--- a/packages/typespec-go/test/local/azregressions/zz_options.go
+++ b/packages/typespec-go/test/local/azregressions/zz_options.go
@@ -84,6 +84,12 @@ type ClientOptionalBodyPostOptions struct {
 	Body *SomeModel
 }
 
+// ClientPayloadWithExplicitContentTypeOptions contains the optional parameters for the Client.PayloadWithExplicitContentType
+// method.
+type ClientPayloadWithExplicitContentTypeOptions struct {
+	// placeholder for future optional parameters
+}
+
 // ClientSpreadWithModelOptions contains the optional parameters for the Client.SpreadWithModel method.
 type ClientSpreadWithModelOptions struct {
 	Color *string

--- a/packages/typespec-go/test/local/azregressions/zz_responses.go
+++ b/packages/typespec-go/test/local/azregressions/zz_responses.go
@@ -84,6 +84,11 @@ type ClientOptionalBodyPostResponse struct {
 	// placeholder for future response values
 }
 
+// ClientPayloadWithExplicitContentTypeResponse contains the response from method Client.PayloadWithExplicitContentType.
+type ClientPayloadWithExplicitContentTypeResponse struct {
+	// placeholder for future response values
+}
+
 // ClientSpreadWithModelResponse contains the response from method Client.SpreadWithModel.
 type ClientSpreadWithModelResponse struct {
 	// placeholder for future response values

--- a/packages/typespec-go/test/tsp/Regressions/main.tsp
+++ b/packages/typespec-go/test/tsp/Regressions/main.tsp
@@ -229,3 +229,17 @@ op optionalBinaryBodyWithContentType(@body payload?: bytes, @header("content-typ
  */
 @route("/binary-payload-with-content-type")
 op binaryBodyWithContentType(@body payload: bytes, @header("content-type") contentType: string): void;
+
+/**
+ * explicit content-type param is set when creating the request
+ */
+@route("/payload-with-explicit-content-type")
+op payloadWithExplicitContentType(
+  @header("Content-Type")
+  contentType:
+    | "application/snapshot+json"
+    | "application/json";
+
+  @body
+  thing: SomeModel
+): void;


### PR DESCRIPTION
For modeled payloads, set Content-Type inline when it comes from an explicit parameter.
Addendum to db10ab8.