### PR TITLE
Use adapted type when adapting a literal enum value

### DIFF
--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.14.3 (unreleased)
 
+### Bugs Fixed
+
+* Fixed adapting `Access.internal` operations that return a polymorphic type.
+
 ### Other Changes
 
 * Updated to the latest tsp toolset.

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -797,13 +797,24 @@ export class TypeAdapter {
 
   private getLiteralValue(constType: tcgc.SdkConstantType | tcgc.SdkEnumValueType): go.Literal {
     if (constType.kind === 'enumvalue') {
-      const valueName = `${helpers.getEffectiveName(constType.enumType)}${helpers.getEffectiveName(constType)}`;
-      const keyName = `literal-${valueName}`;
+      const goConstType = this.getConstantType(constType.enumType);
+      // find the matching enum value
+      let goConstValue: go.ConstantValue | undefined;
+      for (const value of goConstType.values) {
+        if (value.value === constType.value) {
+          goConstValue = value;
+          break;
+        }
+      }
+      if (!goConstValue) {
+        throw new AdapterError('InternalError', `failed to find const value for ${constType.value} in const ${goConstType.name}`, constType.__raw?.node);
+      }
+      const keyName = `literal-${goConstValue.name}`;
       let literalConst = this.types.get(keyName);
       if (literalConst) {
         return <go.Literal>literalConst;
       }
-      const constValue = this.constValues.get(valueName);
+      const constValue = this.constValues.get(goConstValue.name);
       if (!constValue) {
         throw new AdapterError('InternalError', `failed to find const value for ${constType.name} in enum ${constType.enumType.name}`, constType.__raw?.node);
       }

--- a/packages/typespec-go/test/local/azregressions/zz_client.go
+++ b/packages/typespec-go/test/local/azregressions/zz_client.go
@@ -925,3 +925,48 @@ func (client *Client) withExpandParamCreateRequest(ctx context.Context, expand s
 	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
 	return req, nil
 }
+
+// getCallerIdentity - gets a polymorphic type when the operation is internal (makes the dependent type graph internal)
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - clientgetCallerIdentityOptions contains the optional parameters for the Client.getCallerIdentity method.
+func (client *Client) getCallerIdentity(ctx context.Context, options *clientgetCallerIdentityOptions) (clientgetCallerIdentityResponse, error) {
+	var err error
+	const operationName = "Client.getCallerIdentity"
+	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
+	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
+	req, err := client.getCallerIdentityCreateRequest(ctx, options)
+	if err != nil {
+		return clientgetCallerIdentityResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return clientgetCallerIdentityResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
+		err = runtime.NewResponseError(httpResp)
+		return clientgetCallerIdentityResponse{}, err
+	}
+	resp, err := client.getCallerIdentityHandleResponse(httpResp)
+	return resp, err
+}
+
+// getCallerIdentityCreateRequest creates the getCallerIdentity request.
+func (client *Client) getCallerIdentityCreateRequest(ctx context.Context, _ *clientgetCallerIdentityOptions) (*policy.Request, error) {
+	urlPath := "/get-caller-identity"
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
+}
+
+// getCallerIdentityHandleResponse handles the getCallerIdentity response.
+func (client *Client) getCallerIdentityHandleResponse(resp *http.Response) (clientgetCallerIdentityResponse, error) {
+	result := clientgetCallerIdentityResponse{}
+	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
+		return clientgetCallerIdentityResponse{}, err
+	}
+	return result, nil
+}

--- a/packages/typespec-go/test/local/azregressions/zz_constants.go
+++ b/packages/typespec-go/test/local/azregressions/zz_constants.go
@@ -54,3 +54,18 @@ func PossiblePayloadWithExplicitContentTypeRequestContentTypeValues() []PayloadW
 		PayloadWithExplicitContentTypeRequestContentTypeApplicationSnapshotJSON,
 	}
 }
+
+type inboundCallerIdentityType string
+
+const (
+	inboundCallerIdentityTypeSystemAssigned inboundCallerIdentityType = "SystemAssigned"
+	inboundCallerIdentityTypeUserAssigned   inboundCallerIdentityType = "UserAssigned"
+)
+
+// possibleinboundCallerIdentityTypeValues returns the possible values for the inboundCallerIdentityType const type.
+func possibleinboundCallerIdentityTypeValues() []inboundCallerIdentityType {
+	return []inboundCallerIdentityType{
+		inboundCallerIdentityTypeSystemAssigned,
+		inboundCallerIdentityTypeUserAssigned,
+	}
+}

--- a/packages/typespec-go/test/local/azregressions/zz_interfaces.go
+++ b/packages/typespec-go/test/local/azregressions/zz_interfaces.go
@@ -12,3 +12,12 @@ type DiscriminatedBaseNoSubTypesClassification interface {
 	// GetDiscriminatedBaseNoSubTypes returns the DiscriminatedBaseNoSubTypes content of the underlying type.
 	GetDiscriminatedBaseNoSubTypes() *DiscriminatedBaseNoSubTypes
 }
+
+// inboundCallerIdentityClassification provides polymorphic access to related types.
+// Call the interface's GetinboundCallerIdentity() method to access the common type.
+// Use a type switch to determine the concrete type.  The possible types are:
+// - *inboundCallerIdentity, *systemAssignedInboundCallerIdentity, *userAssignedInboundCallerIdentity
+type inboundCallerIdentityClassification interface {
+	// GetinboundCallerIdentity returns the inboundCallerIdentity content of the underlying type.
+	GetinboundCallerIdentity() *inboundCallerIdentity
+}

--- a/packages/typespec-go/test/local/azregressions/zz_models.go
+++ b/packages/typespec-go/test/local/azregressions/zz_models.go
@@ -59,3 +59,38 @@ type Widget struct {
 	// The default value is NetworkVersion("2026-04-15-preview").
 	NetworkVersion *NetworkVersion
 }
+
+type inboundCallerIdentity struct {
+	// REQUIRED
+	Type *inboundCallerIdentityType
+}
+
+// GetinboundCallerIdentity implements the inboundCallerIdentityClassification interface for type inboundCallerIdentity.
+func (i *inboundCallerIdentity) GetinboundCallerIdentity() *inboundCallerIdentity { return i }
+
+type systemAssignedInboundCallerIdentity struct {
+	// REQUIRED
+	Type *inboundCallerIdentityType
+}
+
+// GetinboundCallerIdentity implements the inboundCallerIdentityClassification interface for type systemAssignedInboundCallerIdentity.
+func (s *systemAssignedInboundCallerIdentity) GetinboundCallerIdentity() *inboundCallerIdentity {
+	return &inboundCallerIdentity{
+		Type: s.Type,
+	}
+}
+
+type userAssignedInboundCallerIdentity struct {
+	// REQUIRED
+	Type *inboundCallerIdentityType
+
+	// REQUIRED
+	UserAssignedIdentity *string
+}
+
+// GetinboundCallerIdentity implements the inboundCallerIdentityClassification interface for type userAssignedInboundCallerIdentity.
+func (u *userAssignedInboundCallerIdentity) GetinboundCallerIdentity() *inboundCallerIdentity {
+	return &inboundCallerIdentity{
+		Type: u.Type,
+	}
+}

--- a/packages/typespec-go/test/local/azregressions/zz_models_serde.go
+++ b/packages/typespec-go/test/local/azregressions/zz_models_serde.go
@@ -185,6 +185,91 @@ func (w *Widget) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type inboundCallerIdentity.
+func (i inboundCallerIdentity) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "type", i.Type)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type inboundCallerIdentity.
+func (i *inboundCallerIdentity) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", i, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "type":
+			err = unpopulate(val, "Type", &i.Type)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", i, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type systemAssignedInboundCallerIdentity.
+func (s systemAssignedInboundCallerIdentity) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	objectMap["type"] = inboundCallerIdentityTypeSystemAssigned
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type systemAssignedInboundCallerIdentity.
+func (s *systemAssignedInboundCallerIdentity) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", s, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "type":
+			err = unpopulate(val, "Type", &s.Type)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", s, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type userAssignedInboundCallerIdentity.
+func (u userAssignedInboundCallerIdentity) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	objectMap["type"] = inboundCallerIdentityTypeUserAssigned
+	populate(objectMap, "userAssignedIdentity", u.UserAssignedIdentity)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type userAssignedInboundCallerIdentity.
+func (u *userAssignedInboundCallerIdentity) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", u, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "type":
+			err = unpopulate(val, "Type", &u.Type)
+			delete(rawMsg, key)
+		case "userAssignedIdentity":
+			err = unpopulate(val, "UserAssignedIdentity", &u.UserAssignedIdentity)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", u, err)
+		}
+	}
+	return nil
+}
+
 func populate(m map[string]any, k string, v any) {
 	if v == nil {
 		return

--- a/packages/typespec-go/test/local/azregressions/zz_options.go
+++ b/packages/typespec-go/test/local/azregressions/zz_options.go
@@ -114,3 +114,8 @@ type ClientWithClientDefaultValuesOptions struct {
 type ClientWithExpandParamOptions struct {
 	Top *int32
 }
+
+// clientgetCallerIdentityOptions contains the optional parameters for the Client.getCallerIdentity method.
+type clientgetCallerIdentityOptions struct {
+	// placeholder for future optional parameters
+}

--- a/packages/typespec-go/test/local/azregressions/zz_polymorphic_helpers.go
+++ b/packages/typespec-go/test/local/azregressions/zz_polymorphic_helpers.go
@@ -24,3 +24,26 @@ func unmarshalDiscriminatedBaseNoSubTypesClassification(rawMsg json.RawMessage) 
 	}
 	return b, nil
 }
+
+func unmarshalinboundCallerIdentityClassification(rawMsg json.RawMessage) (inboundCallerIdentityClassification, error) {
+	if rawMsg == nil || string(rawMsg) == "null" {
+		return nil, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(rawMsg, &m); err != nil {
+		return nil, err
+	}
+	var b inboundCallerIdentityClassification
+	switch m["type"] {
+	case string(inboundCallerIdentityTypeSystemAssigned):
+		b = &systemAssignedInboundCallerIdentity{}
+	case string(inboundCallerIdentityTypeUserAssigned):
+		b = &userAssignedInboundCallerIdentity{}
+	default:
+		b = &inboundCallerIdentity{}
+	}
+	if err := json.Unmarshal(rawMsg, b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}

--- a/packages/typespec-go/test/local/azregressions/zz_responses.go
+++ b/packages/typespec-go/test/local/azregressions/zz_responses.go
@@ -108,3 +108,8 @@ type ClientWithClientDefaultValuesResponse struct {
 type ClientWithExpandParamResponse struct {
 	// placeholder for future response values
 }
+
+// clientgetCallerIdentityResponse contains the response from method Client.getCallerIdentity.
+type clientgetCallerIdentityResponse struct {
+	inboundCallerIdentityClassification
+}

--- a/packages/typespec-go/test/local/azregressions/zz_responses_serde.go
+++ b/packages/typespec-go/test/local/azregressions/zz_responses_serde.go
@@ -13,3 +13,13 @@ func (c *ClientGetDiscriminatedNoSubTypesResponse) UnmarshalJSON(data []byte) er
 	c.DiscriminatedBaseNoSubTypesClassification = res
 	return nil
 }
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type clientgetCallerIdentityResponse.
+func (c *clientgetCallerIdentityResponse) UnmarshalJSON(data []byte) error {
+	res, err := unmarshalinboundCallerIdentityClassification(data)
+	if err != nil {
+		return err
+	}
+	c.inboundCallerIdentityClassification = res
+	return nil
+}

--- a/packages/typespec-go/test/tsp/Regressions/main.tsp
+++ b/packages/typespec-go/test/tsp/Regressions/main.tsp
@@ -243,3 +243,30 @@ op payloadWithExplicitContentType(
   @body
   thing: SomeModel
 ): void;
+
+union InboundCallerIdentityType {
+  SystemAssigned: "SystemAssigned",
+  UserAssigned: "UserAssigned",
+  string,
+}
+
+@discriminator("type")
+model InboundCallerIdentity {
+  type: InboundCallerIdentityType;
+}
+
+model SystemAssignedInboundCallerIdentity extends InboundCallerIdentity {
+  type: InboundCallerIdentityType.SystemAssigned;
+}
+
+model UserAssignedInboundCallerIdentity extends InboundCallerIdentity {
+  type: InboundCallerIdentityType.UserAssigned;
+  userAssignedIdentity: string;
+}
+
+/**
+ * gets a polymorphic type when the operation is internal (makes the dependent type graph internal)
+ */
+@access(Access.internal)
+@route("/get-caller-identity")
+op getCallerIdentity(): InboundCallerIdentity;


### PR DESCRIPTION
The adapted type contains the proper name and correctly handles internal types.

Fixes https://github.com/Azure/autorest.go/issues/1994