### PR TITLE
Add @xirzec to CODEOWNERS alongside RickWinter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,11 @@
 # Default
-*                             @jhendrixMSFT @RickWinter @ArcturusZhang @lirenhe @tadelesh
+*                             @jhendrixMSFT @RickWinter @xirzec @ArcturusZhang @lirenhe @tadelesh
 
 # codegen (autorest and typespec)
-/packages/autorest.go         @jhendrixMSFT @RickWinter @lirenhe
-/packages/codegen.go          @jhendrixMSFT @RickWinter @lirenhe
-/packages/codemodel.go        @jhendrixMSFT @RickWinter @lirenhe
-/packages/typespec-go         @jhendrixMSFT @RickWinter @lirenhe
+/packages/autorest.go         @jhendrixMSFT @RickWinter @xirzec @lirenhe
+/packages/codegen.go          @jhendrixMSFT @RickWinter @xirzec @lirenhe
+/packages/codemodel.go        @jhendrixMSFT @RickWinter @xirzec @lirenhe
+/packages/typespec-go         @jhendrixMSFT @RickWinter @xirzec @lirenhe
 
 # autorest.gotest
 /packages/autorest.gotest     @ArcturusZhang @lirenhe @tadelesh
@@ -16,7 +16,7 @@
 ###########
 /eng/                         @benbp @weshaggard
 /eng/common/                  @Azure/azure-sdk-eng
-/eng/config.json              @jhendrixMSFT @RickWinter
+/eng/config.json              @jhendrixMSFT @RickWinter @xirzec
 /.config/1espt/               @benbp @weshaggard
 /.github/workflows/           @Azure/azure-sdk-eng
-/.github/CODEOWNERS           @rickwinter @sandeep-sen @Azure/azure-sdk-eng
+/.github/CODEOWNERS           @rickwinter @xirzec @sandeep-sen @Azure/azure-sdk-eng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,4 +19,4 @@
 /eng/config.json              @jhendrixMSFT @RickWinter @xirzec
 /.config/1espt/               @benbp @weshaggard
 /.github/workflows/           @Azure/azure-sdk-eng
-/.github/CODEOWNERS           @rickwinter @xirzec @sandeep-sen @Azure/azure-sdk-eng
+/.github/CODEOWNERS           @RickWinter @xirzec @sandeep-sen @Azure/azure-sdk-eng


### PR DESCRIPTION
Adds `@xirzec` as a code owner everywhere `@RickWinter` is already listed, so reviews and ownership are shared across both for the affected areas.

The additions cover every `RickWinter` entry:
- Default catch-all (`*`)
- codegen packages: `autorest.go`, `codegen.go`, `codemodel.go`, `typespec-go`
- `/eng/config.json`
- `/.github/CODEOWNERS`

No other owners or paths were changed.